### PR TITLE
fix: security hardening — bind localhost, insecure_http guard, URL redaction

### DIFF
--- a/crates/agent/src/dashboard.rs
+++ b/crates/agent/src/dashboard.rs
@@ -3659,6 +3659,17 @@ async fn api_action_suspend_user(
 ) -> Json<ActionResponse> {
     let skill_id = "suspend-user-sudo".to_string();
 
+    if state.insecure_http {
+        return Json(ActionResponse {
+            success: false,
+            dry_run: state.action_cfg.dry_run,
+            message: "actions disabled - dashboard is exposed over HTTP without TLS. \
+                      Use a reverse proxy with TLS or bind to 127.0.0.1."
+                .to_string(),
+            skill_id,
+        });
+    }
+
     if !state.action_cfg.enabled {
         return Json(ActionResponse {
             success: false,
@@ -3732,6 +3743,17 @@ async fn api_action_honeypot(
     Json(body): Json<HoneypotTestRequest>,
 ) -> Json<ActionResponse> {
     let skill_id = "honeypot".to_string();
+
+    if state.insecure_http {
+        return Json(ActionResponse {
+            success: false,
+            dry_run: state.action_cfg.dry_run,
+            message: "actions disabled - dashboard is exposed over HTTP without TLS. \
+                      Use a reverse proxy with TLS or bind to 127.0.0.1."
+                .to_string(),
+            skill_id,
+        });
+    }
 
     if !state.action_cfg.enabled {
         return Json(ActionResponse {

--- a/crates/agent/src/main.rs
+++ b/crates/agent/src/main.rs
@@ -84,8 +84,8 @@ struct Cli {
     #[arg(long)]
     dashboard: bool,
 
-    /// Bind address for dashboard mode (default: all interfaces - use with reverse proxy + auth)
-    #[arg(long, default_value = "0.0.0.0:8787")]
+    /// Bind address for dashboard mode (default: localhost only — use 0.0.0.0:8787 to expose)
+    #[arg(long, default_value = "127.0.0.1:8787")]
     dashboard_bind: String,
 
     /// Utility: generate Argon2 password hash for dashboard auth and exit.

--- a/crates/agent/src/webhook.rs
+++ b/crates/agent/src/webhook.rs
@@ -135,13 +135,13 @@ pub async fn send_incident(
             client.post(url).json(&payload).send().await
         }
     }
-    .with_context(|| format!("webhook POST to {url} failed"))?;
+    .with_context(|| format!("webhook POST to {} failed", redact_url(url)))?;
 
     if !resp.status().is_success() {
         let status = resp.status();
         let body = resp.text().await.unwrap_or_default();
         warn!(
-            url,
+            url = redact_url(url),
             status = status.as_u16(),
             body = body.chars().take(200).collect::<String>(),
             "webhook returned non-2xx"
@@ -151,7 +151,15 @@ pub async fn send_incident(
     Ok(())
 }
 
-// ---------------------------------------------------------------------------
+/// Redact query string from URL to prevent leaking tokens/keys in logs.
+/// "https://hooks.slack.com/T123/B456?token=secret" → "https://hooks.slack.com/T123/B456?[REDACTED]"
+fn redact_url(url: &str) -> String {
+    match url.find('?') {
+        Some(pos) => format!("{}?[REDACTED]", &url[..pos]),
+        None => url.to_string(),
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Agent Guard alert webhook
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Addresses findings from external security audit.

## Changes

1. **[Critical] Dashboard default bind**: `0.0.0.0:8787` → `127.0.0.1:8787`. Remote access requires explicit `--dashboard-bind 0.0.0.0:8787` with reverse proxy + TLS.

2. **[High] insecure_http guard**: Applied consistently to all mutable action endpoints (suspend-user and honeypot were missing it, block-ip already had it).

3. **[Medium] Webhook URL redaction**: Query strings stripped from log output to prevent token/API key leakage.

## Not changed (by design)

- Agent API routes (`/api/agent/*`) remain without auth — they are designed for localhost-only access by AI agents (OpenClaw). With the new default bind to 127.0.0.1, these are not remotely accessible.
- Live feed CORS `*` remains — intentionally public for live.innerwarden.com. Data is aggregated, attacker IPs are not sensitive (already public on AbuseIPDB).
- RUSTSEC-2023-0071 — no upstream fix available, tracked in deny.toml.

## Test plan

- [x] `cargo test --package innerwarden-agent` — 364 tests passing
- [x] `cargo build` — clean
- [ ] Verify dashboard only accessible on localhost after deploy
- [ ] Verify suspend-user and honeypot reject actions over insecure HTTP

🤖 Generated with [Claude Code](https://claude.com/claude-code)