### PR TITLE
feat(setup): batch apply with single consolidated restart

### DIFF
--- a/.specify/features/004-setup-zero-friction/tasks.md
+++ b/.specify/features/004-setup-zero-friction/tasks.md
@@ -5,7 +5,7 @@
 - [x] Integrate supported-agent auto-detection into setup.
 - [x] Add multi-select connect UX (`1,3,all`) for detected agents.
 - [x] Add one-confirm connect path when only one agent is detected.
-- [ ] Refactor apply phase to batch writes and perform one restart.
+- [x] Refactor apply phase to batch writes and perform one restart.
 - [x] Add final readiness evaluator and verdict output.
 - [x] Add single-command remediation for critical gaps.
 - [x] Add/adjust tests for setup flow invariants and readiness output.

--- a/crates/ctl/src/capabilities/ai.rs
+++ b/crates/ctl/src/capabilities/ai.rs
@@ -149,7 +149,11 @@ impl Capability for AiCapability {
                 "Patch {agent}: [ai] base_url = \"{url}\""
             )));
         }
-        effects.push(CapabilityEffect::new("Restart innerwarden-agent"));
+        effects.push(CapabilityEffect::new(if opts.defer_restarts {
+            "Restart innerwarden-agent (deferred)"
+        } else {
+            "Restart innerwarden-agent"
+        }));
         effects
     }
 
@@ -187,9 +191,13 @@ impl Capability for AiCapability {
             effects.push(CapabilityEffect::new(format!("[ai] base_url = \"{url}\"")));
         }
 
-        // 5. Restart agent
-        systemd::restart_service("innerwarden-agent", opts.dry_run)?;
-        effects.push(CapabilityEffect::new("Restarted innerwarden-agent"));
+        // 5. Restart agent (or defer for batched setup apply)
+        if opts.defer_restarts {
+            effects.push(CapabilityEffect::new("Deferred innerwarden-agent restart"));
+        } else {
+            systemd::restart_service("innerwarden-agent", opts.dry_run)?;
+            effects.push(CapabilityEffect::new("Restarted innerwarden-agent"));
+        }
 
         Ok(ActivationReport {
             effects_applied: effects,
@@ -209,7 +217,11 @@ impl Capability for AiCapability {
             CapabilityEffect::new(format!(
                 "Patch {agent}: [ai] enabled = false{provider_note}"
             )),
-            CapabilityEffect::new("Restart innerwarden-agent"),
+            CapabilityEffect::new(if opts.defer_restarts {
+                "Restart innerwarden-agent (deferred)"
+            } else {
+                "Restart innerwarden-agent"
+            }),
         ]
     }
 
@@ -220,9 +232,13 @@ impl Capability for AiCapability {
         config_editor::write_bool(&opts.agent_config, "ai", "enabled", false)?;
         effects.push(CapabilityEffect::new("[ai] enabled = false"));
 
-        // 2. Restart agent
-        systemd::restart_service("innerwarden-agent", opts.dry_run)?;
-        effects.push(CapabilityEffect::new("Restarted innerwarden-agent"));
+        // 2. Restart agent (or defer for batched setup apply)
+        if opts.defer_restarts {
+            effects.push(CapabilityEffect::new("Deferred innerwarden-agent restart"));
+        } else {
+            systemd::restart_service("innerwarden-agent", opts.dry_run)?;
+            effects.push(CapabilityEffect::new("Restarted innerwarden-agent"));
+        }
 
         Ok(ActivationReport {
             effects_applied: effects,
@@ -257,6 +273,7 @@ mod tests {
             dry_run: true,
             params,
             yes: true,
+            defer_restarts: false,
         }
     }
 
@@ -394,5 +411,23 @@ mod tests {
         );
         let opts = make_opts(&sensor, &agent, params);
         assert!(AiCapability.activate(&opts).is_err());
+    }
+
+    #[test]
+    fn activate_can_defer_restart() {
+        let sensor = NamedTempFile::new().unwrap();
+        let mut agent = NamedTempFile::new().unwrap();
+        writeln!(agent, "[ai]\nenabled = false\n").unwrap();
+
+        let mut params = HashMap::new();
+        params.insert("provider".to_string(), "ollama".to_string());
+        let mut opts = make_opts(&sensor, &agent, params);
+        opts.defer_restarts = true;
+
+        let report = AiCapability.activate(&opts).unwrap();
+        assert!(report
+            .effects_applied
+            .iter()
+            .any(|effect| effect.description == "Deferred innerwarden-agent restart"));
     }
 }

--- a/crates/ctl/src/capabilities/block_ip.rs
+++ b/crates/ctl/src/capabilities/block_ip.rs
@@ -82,7 +82,11 @@ impl Capability for BlockIpCapability {
                 "Write /etc/sudoers.d/{} (validated with visudo)",
                 Self::sudoers_name()
             )),
-            CapabilityEffect::new("Restart innerwarden-agent"),
+            CapabilityEffect::new(if opts.defer_restarts {
+                "Restart innerwarden-agent (deferred)"
+            } else {
+                "Restart innerwarden-agent"
+            }),
         ]
     }
 
@@ -132,9 +136,13 @@ impl Capability for BlockIpCapability {
             Self::sudoers_name()
         )));
 
-        // 5. Restart agent
-        systemd::restart_service("innerwarden-agent", opts.dry_run)?;
-        effects.push(CapabilityEffect::new("Restarted innerwarden-agent"));
+        // 5. Restart agent (or defer for batched setup apply)
+        if opts.defer_restarts {
+            effects.push(CapabilityEffect::new("Deferred innerwarden-agent restart"));
+        } else {
+            systemd::restart_service("innerwarden-agent", opts.dry_run)?;
+            effects.push(CapabilityEffect::new("Restarted innerwarden-agent"));
+        }
 
         Ok(ActivationReport {
             effects_applied: effects,
@@ -149,7 +157,11 @@ impl Capability for BlockIpCapability {
                 "Remove block-ip-* skills from [responder] allowed_skills in {agent}"
             )),
             CapabilityEffect::new(format!("Remove /etc/sudoers.d/{}", Self::sudoers_name())),
-            CapabilityEffect::new("Restart innerwarden-agent"),
+            CapabilityEffect::new(if opts.defer_restarts {
+                "Restart innerwarden-agent (deferred)"
+            } else {
+                "Restart innerwarden-agent"
+            }),
         ]
     }
 
@@ -180,9 +192,13 @@ impl Capability for BlockIpCapability {
             Self::sudoers_name()
         )));
 
-        // 3. Restart agent
-        systemd::restart_service("innerwarden-agent", opts.dry_run)?;
-        effects.push(CapabilityEffect::new("Restarted innerwarden-agent"));
+        // 3. Restart agent (or defer for batched setup apply)
+        if opts.defer_restarts {
+            effects.push(CapabilityEffect::new("Deferred innerwarden-agent restart"));
+        } else {
+            systemd::restart_service("innerwarden-agent", opts.dry_run)?;
+            effects.push(CapabilityEffect::new("Restarted innerwarden-agent"));
+        }
 
         Ok(ActivationReport {
             effects_applied: effects,
@@ -221,6 +237,7 @@ mod tests {
             dry_run: true,
             params: HashMap::new(),
             yes: true,
+            defer_restarts: false,
         }
     }
 
@@ -330,5 +347,20 @@ mod tests {
         let opts = make_opts(&sensor, &agent);
         let effects = BlockIpCapability.planned_disable_effects(&opts);
         assert_eq!(effects.len(), 3);
+    }
+
+    #[test]
+    fn activate_can_defer_restart() {
+        let sensor = NamedTempFile::new().unwrap();
+        let mut agent = NamedTempFile::new().unwrap();
+        writeln!(agent, "[responder]\nenabled = false\ndry_run = true\n").unwrap();
+        let mut opts = make_opts(&sensor, &agent);
+        opts.defer_restarts = true;
+
+        let report = BlockIpCapability.activate(&opts).unwrap();
+        assert!(report
+            .effects_applied
+            .iter()
+            .any(|effect| effect.description == "Deferred innerwarden-agent restart"));
     }
 }

--- a/crates/ctl/src/capabilities/search_protection.rs
+++ b/crates/ctl/src/capabilities/search_protection.rs
@@ -67,8 +67,16 @@ impl Capability for SearchProtectionCapability {
                 Self::sudoers_name()
             )),
             CapabilityEffect::new("Create /etc/nginx/innerwarden-blocklist.conf placeholder"),
-            CapabilityEffect::new("Restart innerwarden-sensor"),
-            CapabilityEffect::new("Restart innerwarden-agent"),
+            CapabilityEffect::new(if opts.defer_restarts {
+                "Restart innerwarden-sensor (deferred)"
+            } else {
+                "Restart innerwarden-sensor"
+            }),
+            CapabilityEffect::new(if opts.defer_restarts {
+                "Restart innerwarden-agent (deferred)"
+            } else {
+                "Restart innerwarden-agent"
+            }),
         ]
     }
 
@@ -145,13 +153,19 @@ impl Capability for SearchProtectionCapability {
                 .to_string(),
         );
 
-        // 8. Restart sensor (nginx_access collector must pick up new config)
-        systemd::restart_service("innerwarden-sensor", opts.dry_run)?;
-        effects.push(CapabilityEffect::new("Restarted innerwarden-sensor"));
+        // 8 & 9. Restart services (or defer for batched setup apply)
+        if opts.defer_restarts {
+            effects.push(CapabilityEffect::new("Deferred innerwarden-sensor restart"));
+            effects.push(CapabilityEffect::new("Deferred innerwarden-agent restart"));
+        } else {
+            // nginx_access collector must pick up new config
+            systemd::restart_service("innerwarden-sensor", opts.dry_run)?;
+            effects.push(CapabilityEffect::new("Restarted innerwarden-sensor"));
 
-        // 9. Restart agent (rate-limit-nginx skill is now in allowed_skills)
-        systemd::restart_service("innerwarden-agent", opts.dry_run)?;
-        effects.push(CapabilityEffect::new("Restarted innerwarden-agent"));
+            // rate-limit-nginx skill is now in allowed_skills
+            systemd::restart_service("innerwarden-agent", opts.dry_run)?;
+            effects.push(CapabilityEffect::new("Restarted innerwarden-agent"));
+        }
 
         Ok(ActivationReport {
             effects_applied: effects,
@@ -173,8 +187,16 @@ impl Capability for SearchProtectionCapability {
                 "Remove \"rate-limit-nginx\" from [responder] allowed_skills in {agent}"
             )),
             CapabilityEffect::new(format!("Remove /etc/sudoers.d/{}", Self::sudoers_name())),
-            CapabilityEffect::new("Restart innerwarden-sensor"),
-            CapabilityEffect::new("Restart innerwarden-agent"),
+            CapabilityEffect::new(if opts.defer_restarts {
+                "Restart innerwarden-sensor (deferred)"
+            } else {
+                "Restart innerwarden-sensor"
+            }),
+            CapabilityEffect::new(if opts.defer_restarts {
+                "Restart innerwarden-agent (deferred)"
+            } else {
+                "Restart innerwarden-agent"
+            }),
         ]
     }
 
@@ -230,12 +252,17 @@ impl Capability for SearchProtectionCapability {
             Self::sudoers_name()
         )));
 
-        // 5 & 6. Restart both services
-        systemd::restart_service("innerwarden-sensor", opts.dry_run)?;
-        effects.push(CapabilityEffect::new("Restarted innerwarden-sensor"));
+        // 5 & 6. Restart services (or defer for batched setup apply)
+        if opts.defer_restarts {
+            effects.push(CapabilityEffect::new("Deferred innerwarden-sensor restart"));
+            effects.push(CapabilityEffect::new("Deferred innerwarden-agent restart"));
+        } else {
+            systemd::restart_service("innerwarden-sensor", opts.dry_run)?;
+            effects.push(CapabilityEffect::new("Restarted innerwarden-sensor"));
 
-        systemd::restart_service("innerwarden-agent", opts.dry_run)?;
-        effects.push(CapabilityEffect::new("Restarted innerwarden-agent"));
+            systemd::restart_service("innerwarden-agent", opts.dry_run)?;
+            effects.push(CapabilityEffect::new("Restarted innerwarden-agent"));
+        }
 
         Ok(ActivationReport {
             effects_applied: effects,
@@ -306,6 +333,7 @@ mod tests {
             dry_run: true,
             params: HashMap::new(),
             yes: true,
+            defer_restarts: false,
         }
     }
 
@@ -492,5 +520,24 @@ mod tests {
         assert!(rule.contains("nginx -s reload"));
         assert!(rule.contains("innerwarden-blocklist.conf"));
         assert!(rule.contains("NOPASSWD"));
+    }
+
+    #[test]
+    fn activate_can_defer_restarts() {
+        let sensor = NamedTempFile::new().unwrap();
+        let mut agent = NamedTempFile::new().unwrap();
+        writeln!(agent, "[responder]\nenabled = false\n").unwrap();
+        let mut opts = make_opts(&sensor, &agent);
+        opts.defer_restarts = true;
+
+        let report = SearchProtectionCapability.activate(&opts).unwrap();
+        assert!(report
+            .effects_applied
+            .iter()
+            .any(|effect| effect.description == "Deferred innerwarden-sensor restart"));
+        assert!(report
+            .effects_applied
+            .iter()
+            .any(|effect| effect.description == "Deferred innerwarden-agent restart"));
     }
 }

--- a/crates/ctl/src/capabilities/shell_audit.rs
+++ b/crates/ctl/src/capabilities/shell_audit.rs
@@ -96,7 +96,11 @@ impl Capability for ShellAuditCapability {
             )),
             CapabilityEffect::new(format!("Write {AUDITD_RULE_FILE}")),
             CapabilityEffect::new("Load audit rules (augenrules --load)"),
-            CapabilityEffect::new("Restart innerwarden-sensor"),
+            CapabilityEffect::new(if opts.defer_restarts {
+                "Restart innerwarden-sensor (deferred)"
+            } else {
+                "Restart innerwarden-sensor"
+            }),
         ]
     }
 
@@ -133,9 +137,13 @@ impl Capability for ShellAuditCapability {
         }
         effects.push(CapabilityEffect::new("Loaded audit rules"));
 
-        // 4. Restart sensor
-        systemd::restart_service("innerwarden-sensor", opts.dry_run)?;
-        effects.push(CapabilityEffect::new("Restarted innerwarden-sensor"));
+        // 4. Restart sensor (or defer for batched setup apply)
+        if opts.defer_restarts {
+            effects.push(CapabilityEffect::new("Deferred innerwarden-sensor restart"));
+        } else {
+            systemd::restart_service("innerwarden-sensor", opts.dry_run)?;
+            effects.push(CapabilityEffect::new("Restarted innerwarden-sensor"));
+        }
 
         Ok(ActivationReport {
             effects_applied: effects,
@@ -151,7 +159,11 @@ impl Capability for ShellAuditCapability {
             )),
             CapabilityEffect::new(format!("Remove {AUDITD_RULE_FILE}")),
             CapabilityEffect::new("Reload audit rules (augenrules --load)"),
-            CapabilityEffect::new("Restart innerwarden-sensor"),
+            CapabilityEffect::new(if opts.defer_restarts {
+                "Restart innerwarden-sensor (deferred)"
+            } else {
+                "Restart innerwarden-sensor"
+            }),
         ]
     }
 
@@ -185,9 +197,13 @@ impl Capability for ShellAuditCapability {
         }
         effects.push(CapabilityEffect::new("Reloaded audit rules"));
 
-        // 4. Restart sensor
-        systemd::restart_service("innerwarden-sensor", opts.dry_run)?;
-        effects.push(CapabilityEffect::new("Restarted innerwarden-sensor"));
+        // 4. Restart sensor (or defer for batched setup apply)
+        if opts.defer_restarts {
+            effects.push(CapabilityEffect::new("Deferred innerwarden-sensor restart"));
+        } else {
+            systemd::restart_service("innerwarden-sensor", opts.dry_run)?;
+            effects.push(CapabilityEffect::new("Restarted innerwarden-sensor"));
+        }
 
         Ok(ActivationReport {
             effects_applied: effects,
@@ -259,6 +275,7 @@ mod tests {
             dry_run: true,
             params: HashMap::new(),
             yes: true, // skip privacy gate in tests
+            defer_restarts: false,
         }
     }
 
@@ -326,5 +343,19 @@ mod tests {
         let opts = make_opts(&sensor, &agent);
         let effects = ShellAuditCapability.planned_effects(&opts);
         assert!(effects[0].description.contains("Privacy"));
+    }
+
+    #[test]
+    fn activate_can_defer_restart() {
+        let sensor = NamedTempFile::new().unwrap();
+        let agent = NamedTempFile::new().unwrap();
+        let mut opts = make_opts(&sensor, &agent);
+        opts.defer_restarts = true;
+
+        let report = ShellAuditCapability.activate(&opts).unwrap();
+        assert!(report
+            .effects_applied
+            .iter()
+            .any(|effect| effect.description == "Deferred innerwarden-sensor restart"));
     }
 }

--- a/crates/ctl/src/capabilities/sudo_protection.rs
+++ b/crates/ctl/src/capabilities/sudo_protection.rs
@@ -58,8 +58,16 @@ impl Capability for SudoProtectionCapability {
                 "Write /etc/sudoers.d/{} (validated with visudo)",
                 Self::sudoers_name()
             )),
-            CapabilityEffect::new("Restart innerwarden-sensor"),
-            CapabilityEffect::new("Restart innerwarden-agent"),
+            CapabilityEffect::new(if opts.defer_restarts {
+                "Restart innerwarden-sensor (deferred)"
+            } else {
+                "Restart innerwarden-sensor"
+            }),
+            CapabilityEffect::new(if opts.defer_restarts {
+                "Restart innerwarden-agent (deferred)"
+            } else {
+                "Restart innerwarden-agent"
+            }),
         ]
     }
 
@@ -97,12 +105,17 @@ impl Capability for SudoProtectionCapability {
             Self::sudoers_name()
         )));
 
-        // 5 & 6. Restart both services
-        systemd::restart_service("innerwarden-sensor", opts.dry_run)?;
-        effects.push(CapabilityEffect::new("Restarted innerwarden-sensor"));
+        // 5 & 6. Restart services (or defer for batched setup apply)
+        if opts.defer_restarts {
+            effects.push(CapabilityEffect::new("Deferred innerwarden-sensor restart"));
+            effects.push(CapabilityEffect::new("Deferred innerwarden-agent restart"));
+        } else {
+            systemd::restart_service("innerwarden-sensor", opts.dry_run)?;
+            effects.push(CapabilityEffect::new("Restarted innerwarden-sensor"));
 
-        systemd::restart_service("innerwarden-agent", opts.dry_run)?;
-        effects.push(CapabilityEffect::new("Restarted innerwarden-agent"));
+            systemd::restart_service("innerwarden-agent", opts.dry_run)?;
+            effects.push(CapabilityEffect::new("Restarted innerwarden-agent"));
+        }
 
         Ok(ActivationReport {
             effects_applied: effects,
@@ -121,8 +134,16 @@ impl Capability for SudoProtectionCapability {
                 "Remove \"suspend-user-sudo\" from [responder] allowed_skills in {agent}"
             )),
             CapabilityEffect::new(format!("Remove /etc/sudoers.d/{}", Self::sudoers_name())),
-            CapabilityEffect::new("Restart innerwarden-sensor"),
-            CapabilityEffect::new("Restart innerwarden-agent"),
+            CapabilityEffect::new(if opts.defer_restarts {
+                "Restart innerwarden-sensor (deferred)"
+            } else {
+                "Restart innerwarden-sensor"
+            }),
+            CapabilityEffect::new(if opts.defer_restarts {
+                "Restart innerwarden-agent (deferred)"
+            } else {
+                "Restart innerwarden-agent"
+            }),
         ]
     }
 
@@ -161,12 +182,17 @@ impl Capability for SudoProtectionCapability {
             Self::sudoers_name()
         )));
 
-        // 4 & 5. Restart both services
-        systemd::restart_service("innerwarden-sensor", opts.dry_run)?;
-        effects.push(CapabilityEffect::new("Restarted innerwarden-sensor"));
+        // 4 & 5. Restart services (or defer for batched setup apply)
+        if opts.defer_restarts {
+            effects.push(CapabilityEffect::new("Deferred innerwarden-sensor restart"));
+            effects.push(CapabilityEffect::new("Deferred innerwarden-agent restart"));
+        } else {
+            systemd::restart_service("innerwarden-sensor", opts.dry_run)?;
+            effects.push(CapabilityEffect::new("Restarted innerwarden-sensor"));
 
-        systemd::restart_service("innerwarden-agent", opts.dry_run)?;
-        effects.push(CapabilityEffect::new("Restarted innerwarden-agent"));
+            systemd::restart_service("innerwarden-agent", opts.dry_run)?;
+            effects.push(CapabilityEffect::new("Restarted innerwarden-agent"));
+        }
 
         Ok(ActivationReport {
             effects_applied: effects,
@@ -202,6 +228,7 @@ mod tests {
             dry_run: true,
             params: HashMap::new(),
             yes: true,
+            defer_restarts: false,
         }
     }
 
@@ -293,5 +320,23 @@ mod tests {
         ));
         let skills = config_editor::read_str_array(agent.path(), "responder", "allowed_skills");
         assert!(skills.contains(&"suspend-user-sudo".to_string()));
+    }
+
+    #[test]
+    fn activate_can_defer_restarts() {
+        let sensor = NamedTempFile::new().unwrap();
+        let agent = NamedTempFile::new().unwrap();
+        let mut opts = make_opts(&sensor, &agent);
+        opts.defer_restarts = true;
+
+        let report = SudoProtectionCapability.activate(&opts).unwrap();
+        assert!(report
+            .effects_applied
+            .iter()
+            .any(|effect| effect.description == "Deferred innerwarden-sensor restart"));
+        assert!(report
+            .effects_applied
+            .iter()
+            .any(|effect| effect.description == "Deferred innerwarden-agent restart"));
     }
 }

--- a/crates/ctl/src/capability.rs
+++ b/crates/ctl/src/capability.rs
@@ -15,6 +15,9 @@ pub struct ActivationOptions {
     pub params: HashMap<String, String>,
     /// Skip interactive confirmation prompts (e.g. privacy gate for shell-audit)
     pub yes: bool,
+    /// When true, capability code should avoid restarting services.
+    /// Caller is responsible for consolidated restart orchestration.
+    pub defer_restarts: bool,
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/ctl/src/commands/capability.rs
+++ b/crates/ctl/src/commands/capability.rs
@@ -24,11 +24,23 @@ pub(crate) fn cmd_enable(
     params: HashMap<String, String>,
     yes: bool,
 ) -> Result<()> {
+    cmd_enable_with_deferred_restart(cli, registry, id, params, yes, false)
+}
+
+pub(crate) fn cmd_enable_with_deferred_restart(
+    cli: &Cli,
+    registry: &CapabilityRegistry,
+    id: &str,
+    params: HashMap<String, String>,
+    yes: bool,
+    defer_restarts: bool,
+) -> Result<()> {
     if !cli.dry_run {
         require_sudo(cli);
     }
     let cap = registry.get(id).ok_or_else(|| unknown_cap_error(id))?;
-    let opts = make_opts(cli, params, yes);
+    let mut opts = make_opts(cli, params, yes);
+    opts.defer_restarts = defer_restarts;
 
     if cap.is_enabled(&opts) {
         println!(

--- a/crates/ctl/src/commands/setup.rs
+++ b/crates/ctl/src/commands/setup.rs
@@ -6,7 +6,7 @@ use anyhow::Result;
 
 use crate::commands::agent::{cmd_agent, parse_selection_indices, resolve_dashboard_url};
 use crate::commands::ai::{fetch_models, prompt_ollama_api_key, WIZARD_PROVIDERS};
-use crate::commands::capability::cmd_enable;
+use crate::commands::capability::cmd_enable_with_deferred_restart;
 use crate::commands::notify::cmd_configure_telegram;
 use crate::{
     am_root, config_editor, load_env_file, prompt, reexec_with_sudo, restart_agent, scan, systemd,
@@ -230,6 +230,18 @@ fn parse_setup_capability_hint(hint: &str) -> Option<SetupCapabilityPlan> {
         id: parts[2].to_string(),
         params,
     })
+}
+
+fn setup_capability_restart_needs(capability_id: &str) -> (bool, bool) {
+    match capability_id {
+        // (sensor, agent)
+        "ai" => (false, true),
+        "block-ip" => (false, true),
+        "sudo-protection" => (true, true),
+        "shell-audit" => (true, false),
+        "search-protection" => (true, true),
+        _ => (false, false),
+    }
 }
 
 fn collect_setup_preconfig_plan(agent_doc: Option<&toml_edit::DocumentMut>) -> SetupPreconfigPlan {
@@ -895,16 +907,21 @@ pub(crate) fn cmd_setup(cli: &Cli, mode: &str) -> Result<()> {
     println!();
 
     let registry = CapabilityRegistry::default_all();
+    let mut restart_sensor_needed = false;
     if apply_preconfig {
         for capability in &preconfig_plan.essential_capabilities {
-            if let Err(err) = cmd_enable(
+            if let Err(err) = cmd_enable_with_deferred_restart(
                 cli,
                 &registry,
                 &capability.id,
                 capability.params.clone(),
                 true,
+                true,
             ) {
                 println!("  [warn] Could not enable {}: {err:#}", capability.id);
+            } else {
+                let (sensor_needed, _agent_needed) = setup_capability_restart_needs(&capability.id);
+                restart_sensor_needed |= sensor_needed;
             }
         }
         if preconfig_plan.set_telegram_min_severity {
@@ -930,7 +947,7 @@ pub(crate) fn cmd_setup(cli: &Cli, mode: &str) -> Result<()> {
         "dry_run",
         responder_plan.dry_run,
     )?;
-    let mut restart_needed = true;
+    let restart_agent_needed = true;
 
     if enable_mesh && !mesh_ok {
         config_editor::write_bool(&cli.agent_config, "mesh", "enabled", true)?;
@@ -942,16 +959,29 @@ pub(crate) fn cmd_setup(cli: &Cli, mode: &str) -> Result<()> {
     }
 
     let needs_telegram_setup = !telegram_ok && notification_plan.needs_telegram();
+    let mut telegram_restarted_agent = false;
     if needs_telegram_setup {
         println!("  Telegram\n");
         if let Err(err) = cmd_configure_telegram(cli, None, None, false) {
             println!("  [warn] Telegram setup did not finish: {err:#}");
         } else {
-            restart_needed = false;
+            telegram_restarted_agent = true;
         }
     }
 
-    if restart_needed {
+    if restart_sensor_needed {
+        if std::env::consts::OS == "macos" {
+            println!("  [warn] innerwarden-sensor restart skipped on macOS.");
+        } else if cli.dry_run {
+            println!("  [dry-run] would restart innerwarden-sensor");
+        } else if let Err(err) = systemd::restart_service("innerwarden-sensor", false) {
+            println!("  [warn] Could not restart innerwarden-sensor: {err:#}");
+        } else {
+            println!("  [ok] innerwarden-sensor restarted");
+        }
+    }
+
+    if restart_agent_needed && !telegram_restarted_agent {
         restart_agent(cli);
     }
 

--- a/crates/ctl/src/main.rs
+++ b/crates/ctl/src/main.rs
@@ -1757,6 +1757,7 @@ pub(crate) fn make_opts(
         dry_run: cli.dry_run,
         params,
         yes,
+        defer_restarts: false,
     }
 }
 


### PR DESCRIPTION
## Summary\n- add deferred restart support to capability activation options\n- make setup apply preconfig capabilities with deferred restarts\n- consolidate setup restarts so services restart once at the end\n- keep Telegram setup flow unchanged while avoiding duplicate agent restart\n- add tests for deferred restart behavior in capabilities\n\n## Validation\n- cargo fmt --all\n- cargo check -p innerwarden-ctl\n- cargo test -p innerwarden-ctl --quiet\n