### PR TITLE
spec 015: knowledge graph signal quality (3,954 false positives removed)

### DIFF
--- a/.specify/features/015-graph-signal-quality/spec.md
+++ b/.specify/features/015-graph-signal-quality/spec.md
@@ -1,0 +1,369 @@
+# Feature Specification: Knowledge Graph Signal Quality
+
+**Feature Branch**: `015-graph-signal-quality`
+**Created**: 2026-04-11
+**Status**: Draft — execution scheduled for a follow-up session
+**Priority**: P0 (blocks operator UX quality AND AI research data quality)
+**Depends on**: nothing (independent from spec 017 Phase 1 work)
+
+## Origin
+
+While validating spec 017 Phase 1 (01-home) on production on 2026-04-11, the new calm Home layout landed correctly — but Recent Activity was dominated by 13+ "Graph User Creation" items, all labeled ACTIVE, all at high severity. The operator UX was broken by noise, not by the UX design.
+
+Investigation into that noise revealed a systemic data-quality problem in the knowledge graph that is far more consequential than a single noisy detector. This spec captures the finding and defines the scope of the cleanup.
+
+## Product principle
+
+**Every node in the knowledge graph must earn its place by being useful for operator experience OR AI research and training. Noise that is useful for neither is waste — it inflates memory, dilutes training data, and destroys the dashboard experience.**
+
+This is a hard rule, not a style preference. A detector that produces high-volume false positives is worse than a detector that produces nothing: the false positives pollute correlation chains, feed wrong signals to the neural model, consume memory, and erode trust in the UI.
+
+## Investigation findings (2026-04-11, prod snapshot)
+
+Data from `/var/lib/innerwarden/graph-snapshot-2026-04-11.json` on the production server:
+
+### Incident node distribution
+
+| Slug | Count | Share | Assessment |
+|---|---|---|---|
+| `kill_chain` (forming, medium) | 21,814 | 77.8% | Noise for operator; **useful for research** — near-miss LSM patterns feed AI training. Keep, already hidden in Home by spec 017 rules. |
+| **`graph_user_creation`** | **3,954** | **14.1%** | **LIXO** — 100% false positives (see Bug 1 below). Delete detector, delete existing nodes, restructure ingestion. |
+| `cross_layer_chain` | 760 | 2.7% | Legitimate correlation. Keep. |
+| `proto_anomaly` | 591 | 2.1% | Legitimate. Keep. |
+| `host_drift` | 316 | 1.1% | Legitimate (some FPs from agent's own binaries — acceptable). Keep. |
+| `rootkit`, `dns_c2`, `kernel_module`, `sandbox_evasion`, `discovery_burst`, `graph_network_sniffing`, `graph_host_drift`, `graph_correlation`, `graph_discovery_burst` | <150 each | <3% total | Mostly legitimate. Subject to audit in this spec. |
+
+**Total Incident nodes**: 28,050. **Node types total in graph**: ~29,566.
+
+### The `graph_user_creation` victims (top 20 "users" triggering the detector)
+
+| User | Count | What it actually is |
+|---|---|---|
+| `uid` | 156 | **Parser bug** — an ingestion path creates a User node with literal name `"uid"` (probably parsing strings like `uid:1001` wrong) |
+| `admin`, `admin2`, `admian`, `AdminGPON`, `adminuser` | 23 each | SSH brute-force login attempt usernames |
+| `ali`, `amir`, `ansible`, `anton`, `aidan`, `analisa` | 23 each | SSH brute-force attempts |
+| `azureuser`, `bakuser`, `banxgg`, `belkinstyle`, `blockchain`, `bmuuser`, `bot` | 23 each | SSH brute-force attempts |
+
+**Zero legitimate user creations**. 100% of the 3,954 incidents are false positives.
+
+## Root causes
+
+Three compounding bugs produce the 3,954 false-positive graph_user_creation incidents:
+
+### Bug 1 — `detect_user_creation` detects presence, not creation
+
+Location: `crates/agent/src/knowledge_graph/detectors.rs:2282` (function `detect_user_creation`).
+
+Logic: on every detector tick (30s), iterate all `User` nodes in the graph, skip a hardcoded list of system users (`root`, `daemon`, ..., ~30 entries), and emit an incident for each remaining user. Per-user cooldown is 30 minutes.
+
+Result: every non-system User node in the graph fires a `graph_user_creation` incident every 30 minutes forever. On a server with 175 User nodes (current prod), that is approximately 175 × 48 = 8,400 emissions per day in steady state, with 14-day retention producing the ~3,954 currently persisted.
+
+The function's test comment says "user_index growth" but the actual code never implemented baseline-diff. It has always been a presence detector mislabeled as a creation detector.
+
+### Bug 2 — Ingestion creates User nodes from SSH brute-force failures
+
+Location: wherever `auth_log` events are ingested into the graph (likely `crates/agent/src/knowledge_graph/ingestion.rs` or the auth_log event handler).
+
+Logic: every failed SSH login is ingested as an event that mentions a username. The ingestion path calls `ensure_user(username)` for each one, creating a User node for the attempted username. Once the node exists, it is indistinguishable from a real local user.
+
+Result: the attacker's dictionary of usernames (admin, ansible, blockchain, ali, amir, bot, ...) is persisted as User nodes in the graph. This pollutes:
+- The User namespace (cannot tell real users from attempted usernames)
+- Detectors that iterate User nodes (Bug 1)
+- Correlation rules referencing `user_creation`
+- Neural model training features
+- Attacker fingerprinting (the attacker's usernames leak into user-facing graph queries)
+
+### Bug 3 — Parser bug creating a User node named `uid`
+
+Location: unknown until investigated. Symptom: a User node with `name == "uid"` exists in the graph and fires `graph_user_creation` 156 times.
+
+Hypothesis: some event parser reads a string like `"uid:1001 (user)"` or `"user=uid:1001"` and extracts `uid` as the username instead of `1001` or the resolved name. This is a single parser bug that should be easy to locate once `ensure_user` call sites are audited.
+
+## Scope
+
+**In scope**:
+- Audit all 27 graph detectors listed in `crates/agent/src/knowledge_graph/detectors.rs` for the "presence-as-event" anti-pattern. Any detector that emits one incident per existing graph element per tick is in scope.
+- Fix `detect_user_creation` to detect genuine creation via baseline diff, OR remove it entirely if creation can be detected from an ingestion event more cheaply.
+- Fix auth_log ingestion so SSH brute-force failures do NOT create User nodes. Attempted usernames are tracked as a different, attacker-scoped field.
+- Fix the `uid` parser bug (locate the offending event parser, correct the extraction).
+- Garbage-collect existing polluted nodes in the production graph: delete all `graph_user_creation` incident nodes; delete User nodes that originated from auth failures only; delete the `uid` User node.
+- Audit `CL-012 Multi-Persistence` and any other correlation rule referencing `user_creation` to confirm they still function after the fix.
+- Document the "signal quality" principle in `CLAUDE.md` so future detectors are evaluated against it.
+
+**In scope for the broader audit (lower priority but same spec)**:
+- `graph_network_sniffing`, `graph_host_drift`, `graph_discovery_burst`, `graph_correlation`: inspect volumes and logic for similar smells. Not all of these are guilty, but the naming pattern `graph_*` suggests they may share the same presence-scan anti-pattern.
+- `kill_chain forming` (medium, 21,814 nodes): not a bug — these are legitimate near-miss LSM patterns. Not in scope for deletion. **In scope for a decision**: should they be stored as Incident nodes at all, or as a lightweight counter/histogram on the related Process node? This is a design question for research value vs. memory cost.
+
+**Out of scope**:
+- Any spec 017 Phase 1 work (Home, Threats, Health, Intel UX). That work pauses until this spec is executed.
+- Backend schema migration (e.g., spec 016 SQLite work). Independent.
+- Adding new detectors. This spec is purely about cleaning up and fixing existing detectors.
+- Tuning severity thresholds of detectors that are working correctly.
+
+## Principles applied
+
+1. **Every node must be useful for ops OR research.** If a detector produces data that fails both tests, the detector is wrong.
+2. **Parser robustness at ingestion boundary.** Bad data at ingestion pollutes everything downstream. Fix it at the source, not at the display layer.
+3. **Detectors should prefer baseline diff over presence scan** when the semantic is "something new happened". A presence scan is cheap but produces cumulative noise indistinguishable from static state.
+4. **Research data and operator data can coexist in the graph** — but research-only data should be structurally distinct (different node type, or a tag/flag), so the operator view can filter it out without losing training signal.
+5. **Cleanup of existing pollution is part of the fix.** Restoring signal quality requires both stopping new pollution AND removing accumulated garbage from the current graph snapshot.
+
+## Proposed changes
+
+### Change 1 — Audit all 27 graph detectors for the presence-as-event anti-pattern
+
+**Where**: `crates/agent/src/knowledge_graph/detectors.rs`.
+
+**Method**: for each `detect_*` function, answer these questions:
+- Does it iterate `graph.nodes_of_type(...)` and emit per-node unconditionally? (smell)
+- Does it maintain a baseline or seen-set to distinguish "new" from "existing"? (good)
+- Does it have a cooldown AND a meaningful fire condition? (cooldown alone is not enough — it just slows the noise)
+- Is the severity proportional to the detection confidence?
+
+**Output**: a table in this spec's implementation commit listing all 27 detectors with a pass/fail verdict and the fix required for each failing one.
+
+**Current known failures**: `detect_user_creation` (Bug 1). Others to be audited.
+
+**Risk**: medium. Audit is code review, low risk. Fixes vary by detector and carry their own risk.
+
+### Change 2 — Fix `detect_user_creation`
+
+**Where**: `crates/agent/src/knowledge_graph/detectors.rs:2282`.
+
+**Two options, pick during implementation**:
+
+**Option A — Baseline diff (preserves existing function signature)**
+
+- At agent startup, capture the set of User names present in the graph as a `baseline: HashSet<String>` in `GraphDetectorState`.
+- On each tick, compute `current_users - baseline - system_users`. Emit for items in the difference.
+- After emitting, add them to the baseline so they don't re-fire.
+- Severity stays medium/high based on existing logic (has_privilege edge).
+
+**Option B — Remove the detector, replace with ingestion-side event emission**
+
+- Delete `detect_user_creation` entirely.
+- In the ingestion path that calls `ensure_user(name)`, check if the user is new (not in graph yet). If new AND the event source is a legitimate creation event (e.g., `useradd`, `/etc/passwd` change, or a successful login from an external IP), emit a `graph_user_creation` incident inline.
+- Auth failures do NOT count as creation events (covers Bug 2 by design).
+
+**Recommendation**: Option B. It is architecturally cleaner (creation is an event, not a scan) and naturally fixes Bug 2. Option A is a mechanical fix that leaves the architecture smell in place.
+
+**Risk**: medium. Requires touching ingestion paths and possibly correlation rules.
+
+### Change 3 — Fix auth_log ingestion (no User node for brute-force attempts)
+
+**Where**: whichever file handles auth_log events — likely `crates/agent/src/knowledge_graph/ingestion.rs` or an event-specific handler. Exact location determined in implementation.
+
+**Fix**:
+
+1. Distinguish successful vs failed authentication events at the ingestion layer.
+2. **Failed auth**: do NOT call `ensure_user`. Instead, append the attempted username to a list/set on the source Ip node (new field: `attempted_usernames: Vec<String>`, deduplicated, bounded).
+3. **Successful auth**: call `ensure_user` as today.
+4. Add a query helper to `KnowledgeGraph` to retrieve attempted usernames for attacker fingerprinting (this replaces any code that currently reads User nodes expecting to find attacker-provided usernames).
+
+**Result**: the User namespace contains only real local users. Attacker usernames are isolated on Ip nodes where they semantically belong.
+
+**Risk**: medium-high. Schema change on Ip node. Requires migration for existing graph snapshots. Any code that currently reads User nodes expecting to find brute-force usernames (e.g., threat-dna behavioral fingerprinting) must be updated.
+
+### Change 4 — Fix the `uid` parser bug
+
+**Where**: unknown until investigated. Plan:
+
+1. Grep for all call sites of `ensure_user` in `crates/agent/src/`.
+2. For each call site, check the source string being passed.
+3. Find the one that produces `name == "uid"` from input like `"uid:1001"` or similar.
+4. Fix the parser to extract the numeric uid or resolve to the actual username.
+
+**Risk**: low once located. The fix is a one-line parser correction.
+
+### Change 5 — Garbage-collect existing pollution
+
+**Where**: `/var/lib/innerwarden/graph-snapshot-YYYY-MM-DD.json` files on production and any other host. Executed via:
+
+1. Stop the agent (so it does not overwrite the edited snapshot).
+2. Back up the current snapshot.
+3. Run a one-shot cleanup script (Rust or jq) to:
+   - Delete all Incident nodes where `incident_id` starts with `graph_user_creation:`.
+   - Delete all User nodes that originated from auth failures only (determined by: no SuccessfulLoginFrom or similar legitimate edge).
+   - Delete the specific User node named `"uid"`.
+   - Optionally: delete any Incident node that references a deleted User node (to avoid dangling edges).
+   - Preserve all other nodes and edges.
+4. Write the cleaned snapshot back.
+5. Restart the agent (which loads the cleaned snapshot).
+
+**Alternative**: implement the cleanup as a one-time migration in the agent itself, triggered by a CLI flag (`innerwarden-agent --cleanup-015-graph-signal-quality`). This is safer than editing the JSON file directly.
+
+**Recommendation**: implement as an agent CLI migration. Keeps the cleanup code reviewable and runnable on any host, not just production.
+
+**Risk**: medium. Destructive. Requires backup + verification. Must be reversible.
+
+### Change 6 — Audit correlation rules referencing `user_creation`
+
+**Where**: `crates/agent/src/knowledge_graph/detectors.rs` correlation rule definitions (around lines 1500+).
+
+**Known reference**: `CL-012 Multi-Persistence` (line 1505) includes `user_creation` as a stage:
+```rust
+stages: &[
+    &["crontab_persistence", "systemd_persistence"],
+    &["ssh_key_injection", "user_creation"],
+],
+```
+
+**Task**: after Change 2 lands, verify CL-012 still fires correctly for its intended pattern (real persistence via user account creation). If Change 2 makes `graph_user_creation` rarer (which it should), CL-012 will fire less — but the firings should be higher-signal. Validate this empirically after cleanup.
+
+**Risk**: low. Read-only audit.
+
+### Change 7 — Document the signal-quality principle in CLAUDE.md
+
+**Where**: `CLAUDE.md` (root or nearest relevant).
+
+**Addition**: new section `## Signal quality principle (spec 015)` that states the hard rule — every node in the graph must be useful for ops OR research — and links to this spec for the rationale.
+
+**Goal**: prevent future detectors from regressing the principle.
+
+**Risk**: none.
+
+### Change 8 — Broader audit of other `graph_*` detectors
+
+**Where**: `crates/agent/src/knowledge_graph/detectors.rs`. Functions starting with `detect_graph_*` or contributing to incidents with `graph_*` slugs.
+
+**Suspects** (from prod snapshot volume analysis):
+- `graph_network_sniffing` — 65 nodes
+- `graph_host_drift` — 43 nodes
+- `graph_correlation` — 36 nodes
+- `graph_discovery_burst` — 30 nodes
+
+**Task**: for each, apply the Change 1 audit checklist. Fix or document any that fail.
+
+**Risk**: low audit, medium fixes depending on findings.
+
+## Execution plan (for the follow-up session)
+
+This spec is deliberately deferred to a fresh session. The execution order is:
+
+1. **Re-read this spec**. Understand the philosophy and the 3 known bugs.
+2. **Investigation phase** (read-only, ~1 hour on prod/local):
+   - Grep all `ensure_user` call sites in `crates/agent/src/`
+   - Read each `detect_*` function in `detectors.rs` and score against the Change 1 checklist
+   - Pull a fresh graph snapshot from prod to reconfirm distributions
+   - Locate Bug 3 (`uid` parser)
+3. **Audit report**. Produce the per-detector verdict table. Commit as an intermediate artifact.
+4. **Code changes** in this order (each its own commit on branch `015-graph-signal-quality`):
+   - Change 4 (parser fix for `uid`) — smallest, builds confidence
+   - Change 2 (fix `detect_user_creation` — probably option B)
+   - Change 3 (auth_log ingestion split) — biggest change, most test coverage needed
+   - Change 8 (other `graph_*` audits and fixes)
+   - Change 6 (correlation rule validation)
+   - Change 7 (CLAUDE.md signal-quality section)
+5. **Build local, `make test`** — all tests must pass. Add new tests for the ingestion split and the fixed `detect_user_creation`.
+6. **Cleanup migration (Change 5)**:
+   - Implement as `innerwarden-agent --cleanup-015-graph-signal-quality` CLI flag
+   - Test on VM with a copy of the prod snapshot
+   - Verify the cleanup removes only the targeted nodes
+7. **Deploy to VM first**, observe for 24 hours.
+8. **Deploy to prod**:
+   - Stop agent, back up snapshot, run cleanup, verify snapshot delta, restart agent
+   - Confirm Recent Activity is clean (the 14% noise should be gone)
+9. **Validation with spec 017 Phase 1 01-home**: reload Home on prod. The Recent Activity feed should now be dominated by legitimate high/critical events, not `graph_user_creation`. This is the downstream acceptance test for both 015 and 017.
+10. **Resume spec 017 Phase 1** (02-threats, 03-health, 04-intel) in a subsequent session.
+
+## Acceptance criteria
+
+### Investigation
+
+- [ ] Per-detector audit table produced and committed, covering all 27 `detect_*` functions in `detectors.rs`
+- [ ] Bug 3 (`uid` parser) located and fixed
+- [ ] All `ensure_user` call sites mapped and classified as "real user" or "parsed from untrusted event"
+
+### Detector fix
+
+- [ ] `detect_user_creation` no longer fires on existing graph users — only on genuinely new creations (baseline-diff or ingestion-event, whichever option is chosen)
+- [ ] After deploy, `graph_user_creation` incident count over 24 hours drops from ~8,400/day to a handful (expected: 0–5/day on a stable server)
+- [ ] `CL-012 Multi-Persistence` correlation rule still fires on genuine multi-persistence patterns (validated via a synthetic test or historical data)
+
+### Ingestion fix
+
+- [ ] Failed SSH logins no longer create User nodes (validated via live auth_log ingestion test)
+- [ ] Successful SSH logins still create User nodes
+- [ ] Attempted usernames from brute force are available via a new query (on Ip node or equivalent) for attacker fingerprinting
+- [ ] `threat-dna` behavioral fingerprinting still has access to attempted usernames (via the new field) and produces the same or better fingerprints
+
+### Cleanup
+
+- [ ] The cleanup migration is implemented as a CLI flag, not a manual JSON edit
+- [ ] Running the migration on a backed-up prod snapshot copy produces a verifiable delta (X nodes removed, Y edges removed, Z nodes preserved)
+- [ ] After deploy + cleanup, the production graph has **zero** `graph_user_creation` Incident nodes
+- [ ] After deploy + cleanup, the production graph has **zero** User nodes that were created purely from auth failures
+- [ ] After deploy + cleanup, the User node named `"uid"` does not exist
+- [ ] Memory usage of the agent process (RSS) drops measurably after cleanup (rough expectation: 5–15% reduction, depending on how much of the 14% bloat was in-memory)
+
+### Downstream validation
+
+- [ ] Spec 017 Phase 1 01-home Recent Activity feed, viewed on prod after cleanup, does NOT contain any `graph_user_creation` entry
+- [ ] The Home hero, in normal operation without sensor stall, does NOT show `System Health Alert` just because of `graph_user_creation` noise (this is already the case because 017 doesn't use graph_user_creation as a trigger — but confirm)
+- [ ] AI training pipeline, when next run, no longer includes `graph_user_creation` false-positive features (if any feature extractor references that detector)
+
+### Documentation
+
+- [ ] Signal quality principle section added to `CLAUDE.md`
+- [ ] This spec updated with the audit table and final implementation notes
+- [ ] Commit messages reference `spec 015` for traceability
+
+## Risks and mitigations
+
+### Risk — Cleanup destroys research-useful data
+
+**Mitigation**: the cleanup targets only nodes that were verified false positives (`graph_user_creation` derived from brute-force usernames). Legitimate data is not touched. Backup the snapshot before running the migration. Keep the backup for at least 30 days post-deploy.
+
+### Risk — `CL-012 Multi-Persistence` correlation rule breaks
+
+**Mitigation**: validate the rule still fires on a synthetic multi-persistence scenario before/after the fix. If it breaks, either adjust the rule to use a different marker or restore `user_creation` in a cleaner form.
+
+### Risk — `threat-dna` loses its attacker-username features
+
+**Mitigation**: Change 3 preserves the data by moving it to a different location (`attempted_usernames` on Ip nodes). `threat-dna` code must be updated to read from the new location. This is part of the spec's scope, not a risk to defer.
+
+### Risk — Migration corrupts the production graph
+
+**Mitigation**: always run the migration on a copy first. Keep the agent stopped during migration so no concurrent writes happen. Verify node counts before and after. Have a documented rollback path (restore the backup snapshot).
+
+### Risk — Other `graph_*` detectors have similar bugs
+
+**Mitigation**: Change 8 audits them as part of this spec. Any additional fixes discovered during the audit are folded into this spec's scope. The spec is done when all 27 detectors pass the audit.
+
+## Open questions
+
+1. **Should `kill_chain forming` medium incidents (21,814 nodes, 77% of the graph) be restructured?** They are legitimate research data but consume 4x the space of everything else combined. Options:
+   - Leave as-is (simplicity)
+   - Compact into a histogram/counter on the related Process node (memory efficient)
+   - Decided in implementation based on memory pressure measurements
+
+2. **Should the cleanup migration be a one-shot (run once and remove the flag) or a permanent feature?** One-shot is safer. Permanent is useful if future false-positive waves surface — but that would mean the new wave is itself a bug needing a proper fix, not a sweep.
+
+3. **Should detectors with `graph_*` prefix be removed entirely and re-implemented as ingestion-time emissions?** This is the architectural question underlying Change 2 Option B. Answering it may require a prototype.
+
+## Related work
+
+- **Spec 010 — Detector Migration (Phase 3)** introduced the 27 graph detectors. Spec 015 fixes the quality of that migration's output.
+- **Spec 012 — Eliminate JSONL Dependency (Phase 6)** made the graph the single source of truth for dashboard queries. The Recent Activity flood on Home surfaced graph noise that was previously hidden when JSONL was the primary read path.
+- **Spec 013 — Graph Single Source of Truth (Phase 7)** completed the transition. Any signal quality problem in the graph is now directly visible on the dashboard.
+- **Spec 014 — Graph Full Connectivity** added new relation types and ingestion paths. The ingestion changes in Change 3 build on this work.
+- **Spec 017 — Dashboard Operator UX** Phase 1 (00-shared + 01-home) is **paused** until 015 is executed. 017 cannot deliver its operator experience promises while the graph is producing 14% false-positive noise. The downstream validation of 015 (Home feed clean) is effectively the acceptance test for 017 Phase 1 to resume.
+
+## Out of scope (explicit)
+
+- **Other spec 017 pages** (02-threats, 03-health, 04-intel). 017 Phase 1 resumes after 015 lands.
+- **Spec 016 SQLite unified store**. Independent. 015 operates on the current JSON snapshot format; 016 operates on the future SQLite format. Both are valid.
+- **Adding new detectors or new correlation rules**. 015 is cleanup, not expansion.
+- **Neural model retraining**. If the training pipeline used the polluted data, it may need a retrain — but that is a follow-up spec.
+- **Sensor-side detector changes**. 015 is agent-side only. Any sensor detector behavior that contributes to User node pollution should be addressed here via the ingestion layer (Change 3), not by changing the sensor.
+
+---
+
+## Implementation notes for the follow-up session
+
+- This spec was written in a session that was executing spec 017 Phase 1. The 017 work is committed on branch `017-dashboard-operator-ux` at commit `b35b72c` (01-home implementation deployed to prod 2026-04-11). That branch is paused, not abandoned.
+- The graph snapshot referenced in this spec lives at `/var/lib/innerwarden/graph-snapshot-2026-04-11.json` on the production server (`ubuntu@130.162.171.105`, port 49222). Size: ~39 MB.
+- The investigation that produced this spec is reconstructible from:
+  - `git log` on branch `017-dashboard-operator-ux` (shows the 017 work that surfaced the noise)
+  - `jq` queries on the graph snapshot for distribution analysis (examples in the Investigation section above)
+- The user is aware of the detector bug and explicitly authorized: (a) stopping 017 Phase 1 work, (b) cleaning the 3,954 false-positive incidents, (c) executing the full 015 scope in a fresh session.

--- a/.specify/features/015-graph-signal-quality/spec.md
+++ b/.specify/features/015-graph-signal-quality/spec.md
@@ -2,7 +2,7 @@
 
 **Feature Branch**: `015-graph-signal-quality`
 **Created**: 2026-04-11
-**Status**: Draft — execution scheduled for a follow-up session
+**Status**: In execution (investigation phase complete, audit table below)
 **Priority**: P0 (blocks operator UX quality AND AI research data quality)
 **Depends on**: nothing (independent from spec 017 Phase 1 work)
 
@@ -73,11 +73,26 @@ Result: the attacker's dictionary of usernames (admin, ansible, blockchain, ali,
 - Neural model training features
 - Attacker fingerprinting (the attacker's usernames leak into user-facing graph queries)
 
-### Bug 3 — Parser bug creating a User node named `uid`
+### Bug 3 — **Not a bug (investigation artifact, reclassified 2026-04-11)**
 
-Location: unknown until investigated. Symptom: a User node with `name == "uid"` exists in the graph and fires `graph_user_creation` 156 times.
+Original hypothesis: a User node with literal name `"uid"` existed in the graph and fired `graph_user_creation` 156 times, suggesting a parser bug.
 
-Hypothesis: some event parser reads a string like `"uid:1001 (user)"` or `"user=uid:1001"` and extracts `uid` as the username instead of `1001` or the resolved name. This is a single parser bug that should be easy to locate once `ensure_user` call sites are audited.
+Investigation result: **No such User node exists.** The `"uid"` string in the original top-20 table was produced by `jq '... | split(":")[1]'` on incident_ids of the form `graph_user_creation:uid:1001:<timestamp>`, which splits on `:` and returns the first segment `"uid"`. The actual User nodes involved are `uid:0, uid:1001, uid:105, uid:33, uid:584788, uid:6, uid:998` — 7 distinct fallback names created legitimately by `ingest_privilege_escalation` (`crates/agent/src/knowledge_graph/ingestion.rs:511`) via `format!("uid:{}", new_uid)` when an event has no resolved username.
+
+These `uid:N` User nodes are not a parser bug:
+- They come from `privilege.escalation` / `privilege.setuid` events that carry a numeric `new_uid` but no symbolic username.
+- Once Bug 1 is fixed (no presence scan) they stop firing `graph_user_creation` regardless.
+- A future enhancement could resolve them against `/etc/passwd` or drop them entirely, but that is not in scope for spec 015.
+
+Verification queries (run against `/var/lib/innerwarden/graph-snapshot-2026-04-11.json` on prod):
+```
+jq '[.nodes[] | select(.User != null)] | length'  # 175
+jq '.nodes[] | select(.User != null and .User.name == "uid")'  # empty
+jq '[.nodes[] | select(.User != null) | .User.name] | map(select(startswith("uid")))'
+# → ["uid:0","uid:1001","uid:105","uid:33","uid:584788","uid:6","uid:998"]
+```
+
+**Conclusion**: Change 4 (below) is dropped from this spec. Bug 1 + Bug 2 fixes + cleanup migration cover the observed 3,954 false positives without any parser work.
 
 ## Scope
 
@@ -126,6 +141,44 @@ Hypothesis: some event parser reads a string like `"uid:1001 (user)"` or `"user=
 
 **Risk**: medium. Audit is code review, low risk. Fixes vary by detector and carry their own risk.
 
+#### Audit table (executed 2026-04-11)
+
+All 27 `detect_*` functions in `crates/agent/src/knowledge_graph/detectors.rs` were scored against the checklist. Heuristic: iterates `nodes_of_type` with no timestamp filter (`edges_in_window` / `active_nodes_since` / `start_ts` check) → presence-scan smell. Prod snapshot counts as of 2026-04-11.
+
+| # | Detector | Line | Presence scan | Prod count | Verdict |
+|---|---|---|---|---|---|
+| 1 | `detect_threat_intel` | 161 | no (query helper) | (merged) | PASS |
+| 2 | `detect_lateral_movement` | 221 | no (`active_nodes_since`) | (rare) | PASS |
+| 3 | `detect_process_tree_anomaly` | 311 | **yes** (shell comm scan) | 0 | SMELL — bounded by Process 24h TTL |
+| 4 | `detect_reverse_shell` | 395 | no (`active_nodes_since`, edge ts) | 2 | PASS |
+| 5 | `detect_fileless` | 487 | no | 0 | PASS |
+| 6 | `detect_discovery_burst` | 568 | no (filters RunAs edges by `ts >= cutoff`) | 30 (legit) | PASS |
+| 7 | `detect_persistence` | 661 | no (`active_nodes_since`) | 0 | PASS |
+| 8 | `detect_data_exfil` | 743 | no | 13 | PASS |
+| 9 | `detect_network_sniffing` | 843 | **yes** (comm whitelist, no edge ts filter) | **67** (likely agent tcpdump self-detect) | **FIX** — Change 8 |
+| 10 | `detect_dns_tunnel` | 903 | no (`edges_in_window`) | 0 | PASS |
+| 11 | `detect_kernel_module` | 983 | **yes** | 0 | SMELL — bounded |
+| 12 | `detect_service_stop` | 1041 | **yes** | 0 | SMELL — bounded |
+| 13 | `detect_container_escape` | 1121 | **yes** | 0 | SMELL — bounded |
+| 14 | `detect_log_tampering` | 1189 | **yes** | 0 | SMELL — bounded |
+| 15 | `detect_crypto_miner` | 1267 | **yes** | 0 | SMELL — bounded |
+| 16 | `detect_sensitive_write` | 1351 | **yes** | 0 | SMELL — bounded |
+| 17 | `detect_correlation_chains` | 1571 | no (windowed per rule) | 36 (legit) | PASS |
+| 18 | `detect_host_drift_aggregated` | 1790 | no (`now - start_ts > window` skip) | 43 | PASS |
+| 19 | `detect_proto_anomaly_aggregated` | 2009 | no (`edges_in_window`) | 597 (legit) | PASS |
+| 20 | `detect_port_scan` | 2090 | no (window) | 0 | PASS |
+| 21 | `detect_credential_stuffing` | 2147 | no (window) | 0 | PASS |
+| 22 | `detect_sudo_abuse` | 2219 | no (window on SudoAs edge) | 0 | PASS |
+| 23 | **`detect_user_creation`** | **2282** | **yes** | **3,954** | **FAIL — Change 2 (delete detector)** |
+| 24 | `detect_docker_anomaly` | 2392 | no (`edges_in_window`) | 0 | PASS |
+| 25 | `detect_scanner_ua` | 2491 | **yes** (iterates Ip, no edge ts filter) | 0 | SMELL — bounded |
+| 26 | `detect_c2_beacon` | 2575 | no (`now - edge.ts > window`) | 3 | PASS |
+| 27 | `detect_cgroup_abuse` | 2687 | no (window) | 0 | PASS |
+
+**Key insight**: Only `detect_user_creation` produces *unbounded* noise. `User` nodes are permanent by schema (`graph.rs:1327` — `Node::User { .. } => false // Permanent`), so every new User name the graph ever sees fires forever under the presence-scan loop. All other smells iterate `Process` or `Ip` nodes, which have a 24h TTL (`graph.rs:1292-1305`), so accumulated noise is naturally capped. The prod snapshot confirms this: only `detect_user_creation` (3,954) and `detect_network_sniffing` (67 — the agent's own tcpdump) produce measurable false-positive volume; the other 8 SMELL detectors sit at 0.
+
+**Scope decision**: fix the two with measurable prod noise (#23 + #9). Document the 8 bounded smells here; leave them untouched this cycle. If they start showing up in snapshots, file follow-up specs.
+
 ### Change 2 — Fix `detect_user_creation`
 
 **Where**: `crates/agent/src/knowledge_graph/detectors.rs:2282`.
@@ -164,16 +217,9 @@ Hypothesis: some event parser reads a string like `"uid:1001 (user)"` or `"user=
 
 **Risk**: medium-high. Schema change on Ip node. Requires migration for existing graph snapshots. Any code that currently reads User nodes expecting to find brute-force usernames (e.g., threat-dna behavioral fingerprinting) must be updated.
 
-### Change 4 — Fix the `uid` parser bug
+### Change 4 — DROPPED (see Bug 3 reclassification above)
 
-**Where**: unknown until investigated. Plan:
-
-1. Grep for all call sites of `ensure_user` in `crates/agent/src/`.
-2. For each call site, check the source string being passed.
-3. Find the one that produces `name == "uid"` from input like `"uid:1001"` or similar.
-4. Fix the parser to extract the numeric uid or resolve to the actual username.
-
-**Risk**: low once located. The fix is a one-line parser correction.
+No parser bug exists. The `uid:N` User nodes are a legitimate fallback in `ingest_privilege_escalation` and disappear from the `graph_user_creation` feed once Bug 1 is fixed. No code change required for this item.
 
 ### Change 5 — Garbage-collect existing pollution
 
@@ -211,6 +257,28 @@ stages: &[
 **Task**: after Change 2 lands, verify CL-012 still fires correctly for its intended pattern (real persistence via user account creation). If Change 2 makes `graph_user_creation` rarer (which it should), CL-012 will fire less — but the firings should be higher-signal. Validate this empirically after cleanup.
 
 **Risk**: low. Read-only audit.
+
+#### CL-012 audit (executed 2026-04-11)
+
+`detect_correlation_chains` (`crates/agent/src/knowledge_graph/detectors.rs:1571`) walks `Incident` nodes in the graph via `TriggeredBy` edges and groups them by entity. For each rule, every stage matches an incident whose `detector` field `starts_with(pattern) || contains(pattern)` (`check_rule_stages` at line 1716).
+
+`CL-012 Multi-Persistence` has two stages:
+
+```
+&["crontab_persistence", "systemd_persistence"]
+&["ssh_key_injection", "user_creation"]
+```
+
+After Change 2 deletes `detect_user_creation`, the `graph_user_creation:*` incident slug stops being emitted. **However, CL-012 still fires correctly** because:
+
+1. The sensor-side `user_creation` detector (`crates/sensor/src/detectors/user_creation.rs`) continues to emit incidents whose `incident_id` is `user_creation:<comm>:<alert_key>:<ts>`.
+2. These incidents land in the graph via `ingest_incident` (`ingestion.rs:182`) which sets `detector = "user_creation"` from the `incident_id` prefix.
+3. `check_rule_stages` matches `"user_creation"` against the stage pattern `["ssh_key_injection", "user_creation"]` via exact `starts_with`, so the stage still resolves.
+4. The same path previously also accepted `graph_user_creation:*` via `contains("user_creation")`, which is now dead but harmless.
+
+Net effect on CL-012: **signal preserved, false-positive floor removed**. Before spec 015, any User node lingering in the graph caused CL-012 to *almost* match when combined with a real `crontab_persistence` incident on the same entity — which would have occasionally fired the rule for no real reason. After spec 015, only a legitimate sensor-side `user_creation` incident can satisfy stage 2, and the rule's signal-to-noise improves.
+
+No code change required in CL-012. No synthetic multi-persistence test added in this spec — the existing detector-level tests for `user_creation` and `crontab_persistence` already cover the upstream signals, and the correlation rule's matcher (`check_rule_stages`) has its own unit tests via `test_correlation_multi_low_elevation` and friends.
 
 ### Change 7 — Document the signal-quality principle in CLAUDE.md
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,21 @@ make replay-qa    # validacao E2E
 - I/O errors em sinks: `warn!`, nao `?`
 - `spawn_blocking` pra I/O sincrono em tasks Tokio
 
+## Signal quality principle (spec 015)
+
+**Every node in the knowledge graph must earn its place by being useful for operator experience OR AI research and training. Noise that is useful for neither is waste.**
+
+This is a hard rule. A detector that produces high-volume false positives is worse than a detector that produces nothing: the false positives pollute correlation chains, feed wrong signals to the neural model, consume memory, and erode trust in the dashboard.
+
+Concrete checks when adding or reviewing a `detect_*` function in `crates/agent/src/knowledge_graph/detectors.rs`:
+
+- **Prefer baseline diff or event-driven emission over presence scans.** If the semantic is "something new happened", do not iterate `nodes_of_type` unconditionally — filter by a time window (`edges_in_window`, `active_nodes_since`, `now - start_ts < W`) or move the emission into the ingestion path where the event first arrives.
+- **A cooldown is not a fix for a presence scan.** It just slows the noise down. A stale node matching a static predicate will still keep firing once per cooldown window forever.
+- **Parser robustness at the ingestion boundary.** Bad data at ingestion pollutes everything downstream. Fix it at the source, not at the display layer. `ensure_user`, `ensure_ip`, `ensure_file` call sites must be reviewed any time they touch attacker-controlled input.
+- **Research data and operator data can coexist, but should be structurally distinct.** Different node types, or a tag/flag, so the operator view can filter noise out without losing training signal.
+
+Spec 015 (`/.specify/features/015-graph-signal-quality/spec.md`) caught 3,954 false-positive `graph_user_creation` incidents from a single presence-scan detector on permanent (non-expiring) User nodes. The spec contains the full audit table of all 27 graph detectors and the rationale for each pass/fail verdict.
+
 ## Fonte De Verdade
 
 - `CLAUDE.md` e o unico arquivo de navegacao e governanca do repo

--- a/crates/agent/src/cloud_safelist.rs
+++ b/crates/agent/src/cloud_safelist.rs
@@ -65,6 +65,40 @@ const CLOUDFLARE_RANGES: &[&str] = &[
     "172.64.0.0/13",
 ];
 
+/// Agent-owned service endpoints — IPs the agent itself talks to for its
+/// notification, enrichment, and threat-intel pipelines. Traffic to these
+/// destinations is *self-traffic* and MUST NOT fire data-exfil / C2-beacon
+/// style detectors in the operator view. Added after spec 015 surfaced the
+/// self-detection pattern (see the dashboard flood on 2026-04-11 where the
+/// agent was flagging its own Telegram calls as "Data Exfil → CRITICAL").
+const AGENT_SERVICE_RANGES: &[&str] = &[
+    // Telegram (Bot API + MTProto) — AS62041
+    "149.154.160.0/20",
+    "91.108.0.0/16",
+    "91.108.4.0/22",
+    "91.108.56.0/22",
+    "95.161.64.0/20",
+    // ip-api.com (GeoIP enrichment used by crate::geoip)
+    "208.95.112.0/24",
+    // Canonical / Ubuntu archive + snapcraft + livepatch
+    "185.125.188.0/23",
+    "91.189.88.0/21",
+    "162.213.32.0/22",
+];
+
+/// Oracle Cloud peer ranges not already covered by CLOUD_PROVIDER_RANGES.
+/// These are the infrastructure peers of OCI instances (metadata, NTP,
+/// internal DNS, OKE control plane, etc.) that an OCI-hosted agent will
+/// regularly connect to. Keeping them separate from the main cloud list
+/// makes it obvious *why* they're in the safelist — they're the agent's
+/// own home provider, not some random customer workload.
+const ORACLE_PEER_RANGES: &[&str] = &[
+    "138.1.16.0/22",    // OCI peer range
+    "140.91.0.0/16",    // OCI London peers
+    "147.154.224.0/20", // OCI customer /20 that the server peers with
+    "193.122.0.0/15",   // OCI EU-London
+];
+
 /// Major cloud provider CIDR ranges that should not be auto-blocked.
 /// These are broad ranges — individual IPs may still be malicious,
 /// but auto-blocking risks collateral damage.
@@ -157,7 +191,12 @@ const CLOUD_PROVIDER_RANGES: &[&str] = &[
 pub fn init() {
     let mut ranges = Vec::new();
 
-    for cidr in CLOUDFLARE_RANGES.iter().chain(CLOUD_PROVIDER_RANGES.iter()) {
+    for cidr in CLOUDFLARE_RANGES
+        .iter()
+        .chain(CLOUD_PROVIDER_RANGES.iter())
+        .chain(AGENT_SERVICE_RANGES.iter())
+        .chain(ORACLE_PEER_RANGES.iter())
+    {
         if let Some(r) = CidrRange::from_str(cidr) {
             ranges.push(r);
         }
@@ -167,6 +206,33 @@ pub fn init() {
     let _ = CLOUD_RANGES.set(ranges);
     let _ = CLOUD_PROVIDER_COUNT.set(count);
     info!(ranges = count, "Cloud provider safelist loaded");
+}
+
+/// Returns true if the IP should be treated as *self-traffic* — either a
+/// known cloud provider, the agent's own notification / enrichment
+/// endpoints (Telegram, GeoIP), or the OCI peer ranges of the host the
+/// agent runs on.
+///
+/// Callers that generate operator-facing incidents should use this to
+/// flag the incident as `research_only` instead of surfacing it in the
+/// threats feed.
+pub fn is_self_traffic_ip(ip_str: &str) -> bool {
+    is_cloud_provider_ip(ip_str)
+}
+
+/// Returns true if `comm` is the agent itself or one of its spawned
+/// workers. Matches the graph detector convention (`detect_network_sniffing`)
+/// used in spec 015.
+#[allow(dead_code)] // reserved for future process-side self-filter unification
+pub fn is_agent_process(comm: &str) -> bool {
+    matches!(
+        comm,
+        "innerwarden-agent"
+            | "innerwarden-sensor"
+            | "innerwarden-watchdog"
+            | "tokio-rt-worker"
+            | "openclaw-gatewa"
+    )
 }
 
 /// Check if an IP belongs to a known cloud provider.
@@ -251,5 +317,63 @@ mod tests {
         assert_eq!(identify_provider("34.95.197.36"), Some("Google Cloud"));
         assert_eq!(identify_provider("52.1.1.1"), Some("AWS"));
         assert_eq!(identify_provider("20.12.41.6"), Some("Azure"));
+    }
+
+    #[test]
+    fn telegram_detected() {
+        // Spec 015 follow-up: Telegram Bot API must be recognized as
+        // self-traffic. Without this, 222+ false positives per day from
+        // the agent's own notification channel (149.154.166.110:443).
+        init();
+        assert!(is_self_traffic_ip("149.154.160.1"));
+        assert!(is_self_traffic_ip("149.154.166.110"));
+        assert!(is_self_traffic_ip("149.154.175.255"));
+        assert!(is_self_traffic_ip("91.108.4.200"));
+    }
+
+    #[test]
+    fn ip_api_com_detected() {
+        // GeoIP enrichment endpoint used by crate::geoip.
+        init();
+        assert!(is_self_traffic_ip("208.95.112.1"));
+    }
+
+    #[test]
+    fn canonical_detected() {
+        // Ubuntu apt archive + snapcraft + livepatch.
+        init();
+        assert!(is_self_traffic_ip("185.125.188.58"));
+        assert!(is_self_traffic_ip("91.189.88.1"));
+    }
+
+    #[test]
+    fn oracle_peer_range_detected() {
+        // OCI London peer ranges outside the main CLOUD_PROVIDER_RANGES
+        // list. These are the /20 the server peers with on its internal
+        // network, not random Oracle customer IPs.
+        init();
+        assert!(is_self_traffic_ip("147.154.225.94"));
+        assert!(is_self_traffic_ip("138.1.16.172"));
+        assert!(is_self_traffic_ip("140.91.26.100"));
+    }
+
+    #[test]
+    fn real_attacker_still_detected() {
+        // Safety net: random external IPs that are NOT cloud providers or
+        // agent services must still be reported to the operator.
+        init();
+        assert!(!is_self_traffic_ip("147.185.132.13")); // dashboard shows this as an attacker
+        assert!(!is_self_traffic_ip("198.235.24.154"));
+        assert!(!is_self_traffic_ip("185.113.139.51"));
+    }
+
+    #[test]
+    fn agent_process_recognition() {
+        assert!(is_agent_process("innerwarden-agent"));
+        assert!(is_agent_process("innerwarden-sensor"));
+        assert!(is_agent_process("tokio-rt-worker"));
+        assert!(is_agent_process("openclaw-gatewa"));
+        assert!(!is_agent_process("sshd"));
+        assert!(!is_agent_process("bash"));
     }
 }

--- a/crates/agent/src/dashboard/data_api.rs
+++ b/crates/agent/src/dashboard/data_api.rs
@@ -64,9 +64,15 @@ pub(super) async fn api_overview(
             decision,
             severity,
             is_allowlisted,
+            research_only,
             ..
         }) = graph.get_node(id)
         {
+            // Spec 015 follow-up: skip research-only incidents so overview
+            // counts reflect actual operator workload, not self-traffic.
+            if *research_only {
+                continue;
+            }
             if *is_allowlisted {
                 allowlisted_count += 1;
             }
@@ -148,9 +154,16 @@ pub(super) async fn api_incidents(
                 decision,
                 confidence,
                 is_allowlisted,
+                research_only,
                 ..
             }) = graph.get_node(id)
             {
+                // Spec 015 follow-up: research-only incidents belong to
+                // the neural training / investigation views, not the
+                // operator incident list.
+                if *research_only {
+                    return None;
+                }
                 // Collect entities from TriggeredBy edges
                 let entities: Vec<String> = graph
                     .outgoing_edges(id)
@@ -407,9 +420,15 @@ pub(super) fn compute_overview_from_graph(
             decision,
             severity,
             is_allowlisted,
+            research_only,
             ..
         }) = graph.get_node(id)
         {
+            // Spec 015 follow-up: skip research-only incidents so overview
+            // counts reflect actual operator workload, not self-traffic.
+            if *research_only {
+                continue;
+            }
             if *is_allowlisted {
                 allowlisted_count += 1;
             }

--- a/crates/agent/src/dashboard/live_feed.rs
+++ b/crates/agent/src/dashboard/live_feed.rs
@@ -116,9 +116,18 @@ pub(super) async fn api_live_feed(State(state): State<DashboardState>) -> Json<L
             decision_target,
             auto_executed,
             detector: _,
+            research_only,
             ..
         }) = graph.get_node(id)
         {
+            // Spec 015 follow-up: hide research_only incidents from the
+            // operator live feed. They still live in the graph (neural
+            // training + investigation views still see them) but don't
+            // pollute the Threats tab with self-traffic to Telegram,
+            // Cloudflare, AWS, Oracle peers, etc.
+            if *research_only {
+                continue;
+            }
             // Collect entities from TriggeredBy edges
             let entities: Vec<innerwarden_core::entities::EntityRef> = graph
                 .outgoing_edges(id)

--- a/crates/agent/src/knowledge_graph/detectors.rs
+++ b/crates/agent/src/knowledge_graph/detectors.rs
@@ -3265,6 +3265,7 @@ mod tests {
                 false_positive: false,
                 fp_reporter: None,
                 fp_reported_at: None,
+                research_only: false,
             });
             g.add_edge(Edge::new(
                 inc_id,

--- a/crates/agent/src/knowledge_graph/detectors.rs
+++ b/crates/agent/src/knowledge_graph/detectors.rs
@@ -120,7 +120,17 @@ pub fn run_all(
     incidents.extend(detect_log_tampering(graph, state, host, now));
     incidents.extend(detect_crypto_miner(graph, state, host, now));
     incidents.extend(detect_sensitive_write(graph, state, host, now));
-    incidents.extend(detect_user_creation(graph, state, host, now));
+    // Spec 015: detect_user_creation was removed. It was a pure presence
+    // scan over `nodes_of_type(User)` that fired every 30min for every
+    // non-system User node in the graph. Because User nodes are permanent
+    // (graph.rs is_expired → `Node::User => false`), each attacker-supplied
+    // username from SSH brute-force stayed in the graph forever and fired
+    // the detector indefinitely — 3,954 false positives on prod snapshot
+    // 2026-04-11. Real user creation continues to be detected by the
+    // sensor-side `user_creation` detector (crates/sensor/src/detectors/
+    // user_creation.rs), whose incidents are ingested via ingest_incident()
+    // and still match the CL-012 "Multi-Persistence" correlation rule via
+    // the stage pattern contains("user_creation").
     incidents.extend(detect_docker_anomaly(graph, state, host, now));
     incidents.extend(detect_scanner_ua(graph, state, host, now));
     incidents.extend(detect_c2_beacon(graph, state, host, now));
@@ -858,17 +868,50 @@ fn detect_network_sniffing(
         "arpspoof",
         "mitmproxy",
     ];
+    // Spec 015: processes spawned by the agent itself must not trigger this
+    // detector. The dashboard pcap_capture module spawns tcpdump for ~60s
+    // bursts whenever a High/Critical incident fires, and the old presence
+    // scan was counting each of those bursts as a new sniffing event —
+    // contributing 67 graph_network_sniffing false positives on the prod
+    // snapshot from 2026-04-11.
+    let agent_ancestors = ["innerwarden-agent", "innerwarden-sensor"];
+
+    // Only consider processes that actually started recently. This matches
+    // the signal we care about ("someone just launched tcpdump") and stops
+    // the presence-scan behavior where a stale Process node kept firing the
+    // detector once per cooldown window forever.
+    let window = Duration::seconds(300);
 
     for &pid_id in graph.nodes_of_type(NodeType::Process).iter() {
-        let comm = match graph.get_node(pid_id) {
-            Some(Node::Process { comm, .. }) => comm.clone(),
+        let (pid, comm, start_ts) = match graph.get_node(pid_id) {
+            Some(Node::Process {
+                pid,
+                comm,
+                start_ts,
+                ..
+            }) => (*pid, comm.clone(), *start_ts),
             _ => continue,
         };
         if !sniffer_tools.iter().any(|t| comm == *t) {
             continue;
         }
+        if now - start_ts > window {
+            continue; // stale node — not a fresh launch
+        }
 
-        let key = format!("graph_sniff:{}", comm);
+        // Walk ancestors; if any is the agent/sensor itself, this sniffer
+        // was spawned by InnerWarden's own pcap_capture and is not an alert.
+        let spawned_by_agent = graph.ancestors(pid).iter().any(|&anc| {
+            matches!(
+                graph.get_node(anc),
+                Some(Node::Process { comm: ac, .. }) if agent_ancestors.iter().any(|a| ac == a)
+            )
+        });
+        if spawned_by_agent {
+            continue;
+        }
+
+        let key = format!("graph_sniff:{}:{}", comm, pid_id);
         if !state.check_and_set(&key, now, 600) {
             continue;
         }
@@ -2279,114 +2322,11 @@ fn detect_sudo_abuse(
 }
 
 // 15. User creation — new user accounts appearing (privilege escalation vector)
-fn detect_user_creation(
-    graph: &KnowledgeGraph,
-    state: &mut GraphDetectorState,
-    host: &str,
-    now: DateTime<Utc>,
-) -> Vec<Incident> {
-    let mut incidents = Vec::new();
-    let system_users = [
-        "root",
-        "daemon",
-        "bin",
-        "sys",
-        "sync",
-        "games",
-        "man",
-        "lp",
-        "mail",
-        "news",
-        "uucp",
-        "proxy",
-        "www-data",
-        "backup",
-        "list",
-        "irc",
-        "gnats",
-        "nobody",
-        "syslog",
-        "messagebus",
-        "sshd",
-        "ubuntu",
-        "systemd-resolve",
-        "systemd-timesync",
-        "ntp",
-        "_apt",
-        "pollinate",
-        "landscape",
-        "lxd",
-    ];
-
-    // Check all User nodes — alert on non-system users that appeared recently
-    for &uid in graph.nodes_of_type(NodeType::User).iter() {
-        let name = match graph.get_node(uid) {
-            Some(Node::User { name, .. }) => name.clone(),
-            _ => continue,
-        };
-        if system_users.iter().any(|s| name == *s) {
-            continue;
-        }
-
-        // Check if this user has an EscalatedTo or SudoAs edge (privilege)
-        let has_privilege = graph
-            .outgoing_edges(uid)
-            .iter()
-            .any(|e| matches!(e.relation, Relation::EscalatedTo | Relation::SudoAs))
-            || graph
-                .incoming_edges(uid)
-                .iter()
-                .any(|e| matches!(e.relation, Relation::EscalatedTo | Relation::SudoAs));
-
-        let key = format!("graph_user_create:{}", name);
-        if !state.check_and_set(&key, now, 1800) {
-            continue;
-        }
-
-        let severity = if has_privilege {
-            Severity::High
-        } else {
-            Severity::Medium
-        };
-        incidents.push(Incident {
-            ts: now,
-            host: host.to_string(),
-            incident_id: format!("graph_user_creation:{}:{}", name, now.timestamp()),
-            severity,
-            title: format!(
-                "New user account: {}{}",
-                name,
-                if has_privilege {
-                    " (with privileges)"
-                } else {
-                    ""
-                }
-            ),
-            summary: format!(
-                "User account '{}' detected in system.{}",
-                name,
-                if has_privilege {
-                    " User has elevated privileges (sudo/escalation)."
-                } else {
-                    ""
-                }
-            ),
-            evidence: serde_json::json!({
-                "source": "knowledge_graph",
-                "detector": "graph_user_creation",
-                "user": name,
-                "has_privilege": has_privilege,
-            }),
-            recommended_checks: vec![
-                format!("Verify user: id {}", name),
-                format!("Check sudo: sudo -l -U {}", name),
-            ],
-            tags: vec!["T1136.001".to_string()],
-            entities: vec![EntityRef::user(&name)],
-        });
-    }
-    incidents
-}
+// Spec 015: `detect_user_creation` was removed as a presence-scan
+// anti-pattern. See the comment in `run_all` above for the rationale.
+// Real user-creation signal is preserved via the sensor-side
+// `user_creation` detector, whose incidents reach the graph via
+// `ingest_incident` and continue to feed correlation rules.
 
 // 16. Docker anomaly — container rapid restarts or OOM kills
 fn detect_docker_anomaly(
@@ -2985,6 +2925,42 @@ mod tests {
     }
 
     #[test]
+    fn test_network_sniffing_skips_agent_spawned_tcpdump() {
+        // Spec 015: pcap_capture spawns tcpdump via the agent. Those
+        // invocations must not fire graph_network_sniffing.
+        let mut g = KnowledgeGraph::new();
+        let now = ts(100);
+        // agent → tcpdump chain
+        let agent = g.ensure_process(42, 1, "innerwarden-agent", 0, now);
+        let tcpdump = g.ensure_process(1234, 42, "tcpdump", 0, now);
+        g.add_edge(Edge::new(tcpdump, agent, Relation::SpawnedBy, now));
+
+        let mut state = GraphDetectorState::new();
+        let incidents = detect_network_sniffing(&g, &mut state, "test", now);
+        assert!(
+            incidents.is_empty(),
+            "tcpdump spawned by the agent itself must not alert"
+        );
+    }
+
+    #[test]
+    fn test_network_sniffing_skips_stale_processes() {
+        // Spec 015: the pre-fix detector re-fired every 10 minutes for the
+        // lifetime of any Process node with comm=tcpdump, even after the
+        // process exited, because it was a pure presence scan. The fixed
+        // version only considers Process nodes started in the last 5min.
+        let mut g = KnowledgeGraph::new();
+        g.ensure_process(1234, 0, "tcpdump", 0, ts(0));
+
+        let mut state = GraphDetectorState::new();
+        let incidents = detect_network_sniffing(&g, &mut state, "test", ts(1_000));
+        assert!(
+            incidents.is_empty(),
+            "stale tcpdump node (>5min old) must not fire the detector"
+        );
+    }
+
+    #[test]
     fn test_sensitive_write_detection() {
         let mut g = KnowledgeGraph::new();
         let now = ts(100);
@@ -3104,21 +3080,11 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_user_creation_detection() {
-        let mut g = KnowledgeGraph::new();
-        // Simulate a new user appearing in graph
-        g.ensure_user("hackerman");
-
-        let mut state = GraphDetectorState::new();
-        // user_creation checks user_index growth — on first run it learns baseline
-        let _ = detect_user_creation(&g, &mut state, "test", ts(10));
-        // Add another user and run again
-        g.ensure_user("backdoor_user");
-        let result = detect_user_creation(&g, &mut state, "test", ts(20));
-        // Should detect the new user
-        assert!(!result.is_empty(), "new user creation should trigger");
-    }
+    // Spec 015: test_user_creation_detection was removed alongside the
+    // detector. The anti-pattern it verified (emit per non-system User
+    // node) is precisely the behavior we deleted. Real user-creation
+    // coverage stays on the sensor side (crates/sensor/src/detectors/
+    // user_creation.rs tests) and the CL-012 correlation-rule path.
 
     #[test]
     fn test_scanner_ua_detection() {

--- a/crates/agent/src/knowledge_graph/detectors.rs
+++ b/crates/agent/src/knowledge_graph/detectors.rs
@@ -2771,6 +2771,7 @@ mod tests {
             is_tor: false,
             first_seen: ts(0),
             last_seen: ts(0),
+            attempted_usernames: Vec::new(),
         });
         g.add_edge(Edge::new(proc_id, ip_id, Relation::ConnectedTo, ts(1)));
 
@@ -3089,6 +3090,7 @@ mod tests {
             is_tor: false,
             first_seen: ts(0),
             last_seen: ts(0),
+            attempted_usernames: Vec::new(),
         });
         g.add_edge(
             Edge::new(proc_id, ip_id, Relation::ConnectedTo, ts(10)).with_prop("port", 3333u16),
@@ -3129,6 +3131,7 @@ mod tests {
             is_tor: false,
             first_seen: ts(0),
             last_seen: ts(0),
+            attempted_usernames: Vec::new(),
         });
         let sys_id = g.ensure_system("test-host");
         g.add_edge(
@@ -3197,6 +3200,7 @@ mod tests {
             is_tor: false,
             first_seen: ts(0),
             last_seen: ts(0),
+            attempted_usernames: Vec::new(),
         });
         // 5 distinct users with failed auth from same IP
         for i in 0..5 {
@@ -3271,6 +3275,7 @@ mod tests {
             is_tor: false,
             first_seen: ts(0),
             last_seen: ts(0),
+            attempted_usernames: Vec::new(),
         });
         // Create 3 incidents from different detectors all connected to same IP
         for (i, det) in ["port_scan", "user_agent_scanner", "discovery_burst"]
@@ -3324,6 +3329,7 @@ mod tests {
             is_tor: false,
             first_seen: ts(0),
             last_seen: ts(0),
+            attempted_usernames: Vec::new(),
         });
         // 6 connections at regular 30s intervals (within 15% jitter)
         for i in 0..6 {

--- a/crates/agent/src/knowledge_graph/graph.rs
+++ b/crates/agent/src/knowledge_graph/graph.rs
@@ -463,7 +463,48 @@ impl KnowledgeGraph {
             is_tor: false,
             first_seen: ts,
             last_seen: ts,
+            attempted_usernames: Vec::new(),
         })
+    }
+
+    /// Spec 015: record an attacker-supplied username from a failed SSH auth.
+    /// Appends to the Ip node's `attempted_usernames` list, deduplicating and
+    /// capping at 50 most-recent entries (LIFO). Silently no-ops if the node
+    /// is not an Ip.
+    pub fn record_attempted_username(&mut self, ip_id: NodeId, username: &str) {
+        const MAX_ATTEMPTED: usize = 50;
+        if username.is_empty() {
+            return;
+        }
+        if let Some(Node::Ip {
+            attempted_usernames,
+            ..
+        }) = self.nodes.get_mut(&ip_id)
+        {
+            // Move to the back if already present; otherwise push.
+            if let Some(pos) = attempted_usernames.iter().position(|u| u == username) {
+                attempted_usernames.remove(pos);
+            }
+            attempted_usernames.push(username.to_string());
+            // Cap (LIFO): drop the oldest entries when exceeding the max.
+            if attempted_usernames.len() > MAX_ATTEMPTED {
+                let drop = attempted_usernames.len() - MAX_ATTEMPTED;
+                attempted_usernames.drain(0..drop);
+            }
+        }
+    }
+
+    /// Spec 015: retrieve attacker-supplied usernames from a given Ip node,
+    /// for attacker fingerprinting / threat-dna features.
+    #[allow(dead_code)] // API surface for future attacker-intel consumers
+    pub fn attempted_usernames_for_ip(&self, ip_id: NodeId) -> Vec<String> {
+        match self.nodes.get(&ip_id) {
+            Some(Node::Ip {
+                attempted_usernames,
+                ..
+            }) => attempted_usernames.clone(),
+            _ => Vec::new(),
+        }
     }
 
     pub fn ensure_file(&mut self, path: &str) -> NodeId {
@@ -1587,6 +1628,7 @@ mod tests {
             is_tor: false,
             first_seen: ts(0),
             last_seen: ts(0),
+            attempted_usernames: Vec::new(),
         });
         g.add_edge(Edge::new(proc1, ip, Relation::ConnectedTo, ts(1)));
 

--- a/crates/agent/src/knowledge_graph/ingestion.rs
+++ b/crates/agent/src/knowledge_graph/ingestion.rs
@@ -29,17 +29,33 @@ fn detail_u16(event: &Event, key: &str) -> Option<u16> {
         .map(|v| v as u16)
 }
 
-/// Spec 015 follow-up: decide whether an incoming incident is self-traffic
-/// (research-only) vs a real external threat (user-facing).
+/// Spec 015 follow-up: decide whether an incoming incident is research-only
+/// (hidden from the operator dashboard, still kept for neural training).
 ///
-/// An incident is research_only when it has at least one Ip entity AND
-/// EVERY Ip entity is in the cloud/agent-service safelist. The conservative
-/// "all IPs match" rule means that if a chain has one attacker IP and one
-/// Cloudflare IP, we still show it to the operator — only pure self-traffic
-/// is hidden. Incidents with zero Ip entities are treated as "not specifically
-/// about an external IP" and keep their default operator-visible status.
+/// Two orthogonal rules:
+///
+/// 1. **Kill chain forming** (severity Medium with "Kill chain forming"
+///    title) — near-miss LSM patterns (2/3 bits set) that fire hundreds
+///    of times per hour. Valuable training signal, but the operator
+///    cannot act on them. Fully formed kill chains (severity Critical)
+///    stay user-visible.
+///
+/// 2. **Self-traffic** — the incident has ≥1 `Ip` entity AND every `Ip`
+///    entity is in the cloud/agent-service safelist. Mixed chains (one
+///    attacker IP + one Cloudflare IP) stay operator-visible.
 fn is_self_traffic_incident(incident: &Incident) -> bool {
     use innerwarden_core::entities::EntityType;
+    use innerwarden_core::event::Severity;
+
+    // Rule 1: kill chain forming
+    if matches!(incident.severity, Severity::Medium)
+        && incident.incident_id.starts_with("kill_chain")
+        && incident.title.starts_with("Kill chain forming")
+    {
+        return true;
+    }
+
+    // Rule 2: self-traffic IPs
     let ips: Vec<&str> = incident
         .entities
         .iter()

--- a/crates/agent/src/knowledge_graph/ingestion.rs
+++ b/crates/agent/src/knowledge_graph/ingestion.rs
@@ -554,18 +554,26 @@ impl KnowledgeGraph {
             return;
         }
 
-        let user_id = self.ensure_user(&user_str);
         let ip_id = self.ensure_ip(&ip_str, event.ts);
 
+        if !success {
+            // Spec 015: failed SSH auth must NOT create User nodes, because
+            // attacker brute-force dictionaries (admin, ansible, blockchain,
+            // bot, ...) would otherwise pollute the User namespace forever
+            // and feed the removed detect_user_creation false-positive loop.
+            // Record the attempted username on the Ip node instead, where it
+            // belongs semantically (attacker fingerprinting data).
+            self.record_attempted_username(ip_id, &user_str);
+            return;
+        }
+
+        // Successful login: the user is a real local account. Create/fetch
+        // the User node and record the LoggedInFrom edge as before.
+        let user_id = self.ensure_user(&user_str);
         let mut edge = Edge::new(user_id, ip_id, Relation::LoggedInFrom, event.ts);
-        edge = edge.with_prop("success", serde_json::Value::from(success));
+        edge = edge.with_prop("success", serde_json::Value::from(true));
         if let Some(method) = detail_str(event, "method") {
             edge = edge.with_prop("method", serde_json::Value::from(method));
-        }
-        if !success {
-            if let Some(reason) = detail_str(event, "reason") {
-                edge = edge.with_prop("reason", serde_json::Value::from(reason));
-            }
         }
         self.add_edge(edge);
     }
@@ -1636,17 +1644,89 @@ mod tests {
     }
 
     #[test]
-    fn test_ingest_ssh_login() {
+    fn test_ingest_ssh_login_success_creates_user() {
+        // Successful login: User node created, LoggedInFrom edge added.
         let mut g = KnowledgeGraph::new();
         let event = make_event(
-            "ssh.login_failed",
-            serde_json::json!({"ip": "185.1.1.1", "user": "root", "reason": "invalid password", "method": "password"}),
+            "ssh.login_success",
+            serde_json::json!({"ip": "185.1.1.1", "user": "root", "method": "password"}),
         );
         g.ingest(&event);
 
         assert!(g.find_by_ip("185.1.1.1").is_some());
-        assert!(g.find_by_user("root").is_some());
-        assert_eq!(g.edge_count(), 1); // LoggedInFrom
+        assert!(
+            g.find_by_user("root").is_some(),
+            "successful login should create User node"
+        );
+        assert_eq!(g.edge_count(), 1, "LoggedInFrom edge expected");
+    }
+
+    #[test]
+    fn test_ingest_ssh_login_failed_does_not_create_user() {
+        // Spec 015 Bug 2: failed SSH auth must NOT create User nodes.
+        // The attempted username lands in Ip.attempted_usernames instead.
+        let mut g = KnowledgeGraph::new();
+        let event = make_event(
+            "ssh.login_failed",
+            serde_json::json!({
+                "ip": "185.1.1.1",
+                "user": "admin",
+                "reason": "invalid password",
+                "method": "password"
+            }),
+        );
+        g.ingest(&event);
+
+        let ip_id = g.find_by_ip("185.1.1.1").expect("Ip node expected");
+        assert!(
+            g.find_by_user("admin").is_none(),
+            "failed login must NOT create a User node for the attempted username"
+        );
+        assert_eq!(
+            g.edge_count(),
+            0,
+            "no LoggedInFrom edge is created for failed auth"
+        );
+        let attempted = g.attempted_usernames_for_ip(ip_id);
+        assert_eq!(attempted, vec!["admin".to_string()]);
+    }
+
+    #[test]
+    fn test_ingest_ssh_login_failed_dedups_and_caps_attempts() {
+        // Multiple failed auths from the same IP accumulate usernames,
+        // deduplicated and LIFO-capped.
+        let mut g = KnowledgeGraph::new();
+        let usernames = [
+            "admin", "ansible", "root", "admin", "bot", "ansible", "oracle",
+        ];
+        for u in usernames {
+            let e = make_event(
+                "ssh.login_failed",
+                serde_json::json!({
+                    "ip": "185.1.1.1",
+                    "user": u,
+                    "reason": "invalid_user",
+                }),
+            );
+            g.ingest(&e);
+        }
+
+        let ip_id = g.find_by_ip("185.1.1.1").unwrap();
+        let attempted = g.attempted_usernames_for_ip(ip_id);
+        // No User nodes, no LoggedInFrom edges.
+        assert_eq!(g.nodes_of_type(NodeType::User).len(), 0);
+        assert_eq!(g.edge_count(), 0);
+        // Dedup: unique set preserved, last-write-wins order.
+        assert_eq!(
+            attempted,
+            vec![
+                "root".to_string(),
+                "admin".to_string(),
+                "bot".to_string(),
+                "ansible".to_string(),
+                "oracle".to_string(),
+            ]
+        );
     }
 
     #[test]

--- a/crates/agent/src/knowledge_graph/ingestion.rs
+++ b/crates/agent/src/knowledge_graph/ingestion.rs
@@ -29,6 +29,30 @@ fn detail_u16(event: &Event, key: &str) -> Option<u16> {
         .map(|v| v as u16)
 }
 
+/// Spec 015 follow-up: decide whether an incoming incident is self-traffic
+/// (research-only) vs a real external threat (user-facing).
+///
+/// An incident is research_only when it has at least one Ip entity AND
+/// EVERY Ip entity is in the cloud/agent-service safelist. The conservative
+/// "all IPs match" rule means that if a chain has one attacker IP and one
+/// Cloudflare IP, we still show it to the operator — only pure self-traffic
+/// is hidden. Incidents with zero Ip entities are treated as "not specifically
+/// about an external IP" and keep their default operator-visible status.
+fn is_self_traffic_incident(incident: &Incident) -> bool {
+    use innerwarden_core::entities::EntityType;
+    let ips: Vec<&str> = incident
+        .entities
+        .iter()
+        .filter(|e| e.r#type == EntityType::Ip)
+        .map(|e| e.value.as_str())
+        .collect();
+    if ips.is_empty() {
+        return false;
+    }
+    ips.iter()
+        .all(|ip| crate::cloud_safelist::is_self_traffic_ip(ip))
+}
+
 fn detail_u64(event: &Event, key: &str) -> Option<u64> {
     event.details.get(key).and_then(|v| v.as_u64())
 }
@@ -194,6 +218,13 @@ impl KnowledgeGraph {
             .unwrap_or("unknown")
             .to_string();
 
+        // Spec 015 follow-up: flag incidents whose only external entity is
+        // self-traffic (Telegram, Cloudflare, Oracle peers, GeoIP, AWS
+        // eu-west-1, Canonical) as research_only. They still land in the
+        // graph for neural training and investigation, but the operator
+        // dashboard filters them out so real threats are visible.
+        let research_only = is_self_traffic_incident(incident);
+
         let inc_id = self.upsert_node(Node::Incident {
             incident_id: incident.incident_id.clone(),
             detector,
@@ -211,6 +242,7 @@ impl KnowledgeGraph {
             false_positive: false,
             fp_reporter: None,
             fp_reported_at: None,
+            research_only,
         });
 
         // Create TriggeredBy edges from Incident to each entity
@@ -1832,6 +1864,103 @@ mod tests {
 
         assert!(g.system_node().is_some());
         assert_eq!(g.edge_count(), 1); // InsertedOn
+    }
+
+    #[test]
+    fn test_ingest_incident_flags_self_traffic_as_research_only() {
+        // Spec 015 follow-up: an incident whose only external IP is
+        // Telegram / Cloudflare / OCI peers must land in the graph with
+        // research_only=true so the operator dashboard hides it.
+        crate::cloud_safelist::init();
+        let mut g = KnowledgeGraph::new();
+
+        let telegram_inc = Incident {
+            ts: Utc::now(),
+            host: "prod-01".to_string(),
+            incident_id: "graph_data_exfil:tokio-rt-worker:12345".to_string(),
+            severity: Severity::Critical,
+            title: "Data exfil → 149.154.166.110".to_string(),
+            summary: String::new(),
+            evidence: serde_json::json!({}),
+            recommended_checks: Vec::new(),
+            tags: vec!["T1041".to_string()],
+            entities: vec![EntityRef::ip("149.154.166.110")], // Telegram
+        };
+        g.ingest_incident(&telegram_inc);
+        let id = g
+            .find_by_incident("graph_data_exfil:tokio-rt-worker:12345")
+            .expect("incident node");
+        match g.get_node(id) {
+            Some(Node::Incident { research_only, .. }) => {
+                assert!(
+                    *research_only,
+                    "Telegram self-traffic must be flagged as research_only"
+                );
+            }
+            _ => panic!("expected Incident node"),
+        }
+    }
+
+    #[test]
+    fn test_ingest_incident_real_attacker_stays_operator_visible() {
+        // Opposite case: a real external IP must stay operator-visible.
+        crate::cloud_safelist::init();
+        let mut g = KnowledgeGraph::new();
+
+        let attacker_inc = Incident {
+            ts: Utc::now(),
+            host: "prod-01".to_string(),
+            incident_id: "ssh_bruteforce:185.113.139.51:999".to_string(),
+            severity: Severity::High,
+            title: "SSH brute force".to_string(),
+            summary: String::new(),
+            evidence: serde_json::json!({}),
+            recommended_checks: Vec::new(),
+            tags: vec!["T1110.001".to_string()],
+            entities: vec![EntityRef::ip("185.113.139.51")],
+        };
+        g.ingest_incident(&attacker_inc);
+        let id = g
+            .find_by_incident("ssh_bruteforce:185.113.139.51:999")
+            .unwrap();
+        match g.get_node(id) {
+            Some(Node::Incident { research_only, .. }) => {
+                assert!(!*research_only, "real attacker must stay visible");
+            }
+            _ => panic!("expected Incident node"),
+        }
+    }
+
+    #[test]
+    fn test_ingest_incident_mixed_entities_stays_visible() {
+        // Conservative rule: if an incident touches ANY non-self IP, show it.
+        // We only hide incidents where *every* external IP is self-traffic.
+        crate::cloud_safelist::init();
+        let mut g = KnowledgeGraph::new();
+
+        let mixed = Incident {
+            ts: Utc::now(),
+            host: "prod-01".to_string(),
+            incident_id: "cross_layer_chain:mixed:1".to_string(),
+            severity: Severity::High,
+            title: "Mixed chain".to_string(),
+            summary: String::new(),
+            evidence: serde_json::json!({}),
+            recommended_checks: Vec::new(),
+            tags: vec![],
+            entities: vec![
+                EntityRef::ip("149.154.166.110"), // Telegram self-traffic
+                EntityRef::ip("185.113.139.51"),  // real attacker
+            ],
+        };
+        g.ingest_incident(&mixed);
+        let id = g.find_by_incident("cross_layer_chain:mixed:1").unwrap();
+        match g.get_node(id) {
+            Some(Node::Incident { research_only, .. }) => {
+                assert!(!*research_only, "mixed chain must stay visible");
+            }
+            _ => panic!("expected Incident node"),
+        }
     }
 
     #[test]

--- a/crates/agent/src/knowledge_graph/migrations.rs
+++ b/crates/agent/src/knowledge_graph/migrations.rs
@@ -1,0 +1,262 @@
+//! One-shot migrations for the knowledge graph.
+//!
+//! Each migration is implemented as a standalone function that takes a
+//! mutable [`KnowledgeGraph`] reference and returns a report describing
+//! what was removed. Migrations are triggered by CLI flags on the agent
+//! binary (see `main.rs`) — never run automatically — so operators have
+//! full control of destructive cleanups.
+//!
+//! When a migration has been deployed everywhere, its module here and the
+//! corresponding CLI flag can be deleted together.
+
+use super::graph::KnowledgeGraph;
+use super::types::{Node, NodeId, NodeType, Relation};
+
+/// Report returned by [`cleanup_015_graph_signal_quality`].
+#[derive(Debug, Default, Clone, PartialEq, Eq, serde::Serialize)]
+pub struct Cleanup015Report {
+    /// Incident nodes deleted because their `incident_id` or `detector`
+    /// belongs to the removed `graph_user_creation` detector.
+    pub graph_user_creation_incidents_removed: usize,
+    /// User nodes deleted because every `LoggedInFrom` edge they had was a
+    /// failed auth (SSH brute-force pollution). Real users — those with at
+    /// least one successful login, a `RunAs`/`SudoAs`/`EscalatedTo` edge,
+    /// or any other structural reference — are preserved.
+    pub brute_force_user_nodes_removed: usize,
+    /// Names of the deleted User nodes (for audit in the migration output).
+    pub removed_user_names: Vec<String>,
+    /// Total nodes in the graph before cleanup.
+    pub nodes_before: usize,
+    /// Total nodes in the graph after cleanup.
+    pub nodes_after: usize,
+}
+
+/// Spec 015: remove the 3,954 `graph_user_creation` false-positive
+/// incidents and the brute-force User nodes that accumulated while the
+/// buggy `detect_user_creation` presence scan was running.
+///
+/// Safe to run multiple times — if the graph has already been cleaned,
+/// the report will show zero removals.
+///
+/// The cleanup is conservative: a User node is only deleted when **all**
+/// of its `LoggedInFrom` edges carry `success == false` (or it has no
+/// `LoggedInFrom` edge but is otherwise isolated). Any User that has a
+/// successful login, `RunAs` edge, `SudoAs` edge, or `EscalatedTo` edge
+/// is preserved. Real local users, `uid:N` fallback nodes created by
+/// privilege-escalation ingestion, and `root` are never removed.
+pub fn cleanup_015_graph_signal_quality(graph: &mut KnowledgeGraph) -> Cleanup015Report {
+    let mut report = Cleanup015Report {
+        nodes_before: graph.node_count(),
+        ..Default::default()
+    };
+
+    // ── 1. Remove graph_user_creation Incident nodes ────────────────────
+    //
+    // Any Incident whose `incident_id` starts with `graph_user_creation:`
+    // is false-positive noise. The `detector` field is redundant (set from
+    // the incident_id prefix in `ingest_incident`) but we check both for
+    // robustness against older snapshots that may have mismatched values.
+    let incident_victims: Vec<NodeId> = graph
+        .nodes_of_type(NodeType::Incident)
+        .into_iter()
+        .filter(|&id| {
+            matches!(
+                graph.get_node(id),
+                Some(Node::Incident {
+                    incident_id,
+                    detector,
+                    ..
+                }) if incident_id.starts_with("graph_user_creation:")
+                    || detector == "graph_user_creation"
+            )
+        })
+        .collect();
+
+    for id in &incident_victims {
+        graph.remove_node(*id);
+    }
+    report.graph_user_creation_incidents_removed = incident_victims.len();
+
+    // ── 2. Remove brute-force User nodes ─────────────────────────────────
+    //
+    // A User node is a brute-force artifact iff it has at least one
+    // `LoggedInFrom` edge AND every such edge has `success == false`
+    // (attacker username that never successfully logged in), AND it has no
+    // `RunAs`, `SudoAs`, or `EscalatedTo` edge (otherwise it's a real
+    // local user or a uid:N fallback we want to keep).
+    let mut user_victims: Vec<(NodeId, String)> = Vec::new();
+    for &user_id in graph.nodes_of_type(NodeType::User).iter() {
+        let name = match graph.get_node(user_id) {
+            Some(Node::User { name, .. }) => name.clone(),
+            _ => continue,
+        };
+
+        // Preserve system singletons and uid:N fallbacks unconditionally.
+        if name == "root" || name.starts_with("uid:") {
+            continue;
+        }
+
+        // Look at every edge touching this user.
+        let mut has_logged_in = false;
+        let mut all_failed = true;
+        let mut has_privilege_edge = false;
+        for edge in graph
+            .outgoing_edges(user_id)
+            .iter()
+            .chain(graph.incoming_edges(user_id).iter())
+        {
+            match edge.relation {
+                Relation::LoggedInFrom => {
+                    has_logged_in = true;
+                    let success = edge
+                        .properties
+                        .get("success")
+                        .and_then(|v| v.as_bool())
+                        .unwrap_or(false);
+                    if success {
+                        all_failed = false;
+                    }
+                }
+                Relation::RunAs | Relation::SudoAs | Relation::EscalatedTo => {
+                    has_privilege_edge = true;
+                }
+                _ => {}
+            }
+        }
+
+        if has_privilege_edge {
+            continue; // real user
+        }
+        if !has_logged_in {
+            continue; // not SSH-sourced pollution — leave alone
+        }
+        if !all_failed {
+            continue; // at least one successful login → real user
+        }
+
+        user_victims.push((user_id, name));
+    }
+
+    for (id, name) in &user_victims {
+        graph.remove_node(*id);
+        report.removed_user_names.push(name.clone());
+    }
+    report.brute_force_user_nodes_removed = user_victims.len();
+
+    report.nodes_after = graph.node_count();
+    report
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::knowledge_graph::types::Edge;
+    use chrono::{TimeZone, Utc};
+
+    fn ts(s: i64) -> chrono::DateTime<Utc> {
+        Utc.with_ymd_and_hms(2026, 4, 11, 0, 0, s as u32).unwrap()
+    }
+
+    #[test]
+    fn cleanup_removes_graph_user_creation_incidents() {
+        let mut g = KnowledgeGraph::new();
+        let user = g.ensure_user("admin");
+        let inc = g.add_node(Node::Incident {
+            incident_id: "graph_user_creation:admin:12345".to_string(),
+            detector: "graph_user_creation".to_string(),
+            severity: "medium".to_string(),
+            title: "New user account: admin".to_string(),
+            summary: String::new(),
+            ts: ts(0),
+            mitre_ids: vec![],
+            decision: None,
+            confidence: None,
+            decision_reason: None,
+            decision_target: None,
+            auto_executed: false,
+            is_allowlisted: false,
+            false_positive: false,
+            fp_reporter: None,
+            fp_reported_at: None,
+        });
+        g.add_edge(Edge::new(inc, user, Relation::TriggeredBy, ts(0)));
+
+        let report = cleanup_015_graph_signal_quality(&mut g);
+        assert_eq!(report.graph_user_creation_incidents_removed, 1);
+        assert!(g.get_node(inc).is_none(), "incident should be deleted");
+    }
+
+    #[test]
+    fn cleanup_removes_brute_force_user_only_failed_logins() {
+        let mut g = KnowledgeGraph::new();
+        let ip = g.ensure_ip("185.1.1.1", ts(0));
+        let admin = g.ensure_user("admin"); // attacker username
+        let root = g.ensure_user("root"); // real user — preserved
+        let alice = g.ensure_user("alice"); // real user with success
+
+        // admin: 3 failed logins, zero success → delete
+        for i in 0..3 {
+            let edge =
+                Edge::new(admin, ip, Relation::LoggedInFrom, ts(i)).with_prop("success", false);
+            g.add_edge(edge);
+        }
+        // alice: 1 failed + 1 success → preserve
+        g.add_edge(Edge::new(alice, ip, Relation::LoggedInFrom, ts(5)).with_prop("success", false));
+        g.add_edge(Edge::new(alice, ip, Relation::LoggedInFrom, ts(6)).with_prop("success", true));
+        // root: only failed but the migration preserves root unconditionally.
+        g.add_edge(Edge::new(root, ip, Relation::LoggedInFrom, ts(10)).with_prop("success", false));
+
+        let report = cleanup_015_graph_signal_quality(&mut g);
+        assert_eq!(report.brute_force_user_nodes_removed, 1);
+        assert_eq!(report.removed_user_names, vec!["admin".to_string()]);
+        assert!(g.find_by_user("admin").is_none());
+        assert!(g.find_by_user("alice").is_some());
+        assert!(g.find_by_user("root").is_some());
+    }
+
+    #[test]
+    fn cleanup_preserves_uid_fallback_users() {
+        let mut g = KnowledgeGraph::new();
+        let ip = g.ensure_ip("185.1.1.1", ts(0));
+        let uid_user = g.ensure_user("uid:1001");
+        // Even if the only edges are failed LoggedInFrom, the uid:N prefix
+        // is always preserved.
+        g.add_edge(
+            Edge::new(uid_user, ip, Relation::LoggedInFrom, ts(0)).with_prop("success", false),
+        );
+
+        let report = cleanup_015_graph_signal_quality(&mut g);
+        assert_eq!(report.brute_force_user_nodes_removed, 0);
+        assert!(g.find_by_user("uid:1001").is_some());
+    }
+
+    #[test]
+    fn cleanup_preserves_user_with_privilege_edge() {
+        let mut g = KnowledgeGraph::new();
+        let user = g.ensure_user("deploy");
+        let proc_id = g.ensure_process(1234, 0, "sudo", 0, ts(0));
+        let ip = g.ensure_ip("185.1.1.1", ts(0));
+
+        // Only failed logins via SSH, but a SudoAs edge exists →
+        // user is real, preserve.
+        g.add_edge(Edge::new(user, ip, Relation::LoggedInFrom, ts(0)).with_prop("success", false));
+        g.add_edge(Edge::new(proc_id, user, Relation::SudoAs, ts(1)));
+
+        let report = cleanup_015_graph_signal_quality(&mut g);
+        assert_eq!(report.brute_force_user_nodes_removed, 0);
+        assert!(g.find_by_user("deploy").is_some());
+    }
+
+    #[test]
+    fn cleanup_is_idempotent() {
+        let mut g = KnowledgeGraph::new();
+        let ip = g.ensure_ip("185.1.1.1", ts(0));
+        let admin = g.ensure_user("admin");
+        g.add_edge(Edge::new(admin, ip, Relation::LoggedInFrom, ts(0)).with_prop("success", false));
+
+        let first = cleanup_015_graph_signal_quality(&mut g);
+        let second = cleanup_015_graph_signal_quality(&mut g);
+        assert_eq!(first.brute_force_user_nodes_removed, 1);
+        assert_eq!(second.brute_force_user_nodes_removed, 0);
+    }
+}

--- a/crates/agent/src/knowledge_graph/migrations.rs
+++ b/crates/agent/src/knowledge_graph/migrations.rs
@@ -180,19 +180,41 @@ pub fn backfill_research_only_flag(graph: &mut KnowledgeGraph) -> BackfillResear
     report.incidents_scanned = incident_nodes.len();
 
     for inc_id in incident_nodes {
-        let (already_flagged, detector) = match graph.get_node(inc_id) {
+        let (already_flagged, detector, severity, title) = match graph.get_node(inc_id) {
             Some(Node::Incident {
                 research_only,
                 detector,
+                severity,
+                title,
                 ..
-            }) => (*research_only, detector.clone()),
+            }) => (
+                *research_only,
+                detector.clone(),
+                severity.clone(),
+                title.clone(),
+            ),
             _ => continue,
         };
         if already_flagged {
             continue;
         }
 
-        // Gather the Ip nodes this incident is TriggeredBy.
+        // Rule 1: kill_chain "forming" (incomplete bit pattern, severity
+        // Medium) is research/training data, never user-facing. The fully
+        // formed kill chains (severity Critical) stay visible.
+        //
+        // On the 2026-04-11 prod snapshot this alone moves 21,783 incidents
+        // out of the operator view while preserving the 31 critical ones.
+        if detector == "kill_chain"
+            && severity.eq_ignore_ascii_case("medium")
+            && title.starts_with("Kill chain forming")
+        {
+            updates.push((inc_id, detector));
+            continue;
+        }
+
+        // Rule 2: self-traffic rule — the incident is anchored on IPs and
+        // every anchor IP is a cloud provider / agent service endpoint.
         let mut ip_addrs: Vec<String> = Vec::new();
         for edge in graph.outgoing_edges(inc_id) {
             if edge.relation != super::types::Relation::TriggeredBy {
@@ -203,7 +225,7 @@ pub fn backfill_research_only_flag(graph: &mut KnowledgeGraph) -> BackfillResear
             }
         }
         if ip_addrs.is_empty() {
-            continue; // not a specifically IP-anchored incident
+            continue;
         }
         let all_self = ip_addrs
             .iter()

--- a/crates/agent/src/knowledge_graph/migrations.rs
+++ b/crates/agent/src/knowledge_graph/migrations.rs
@@ -147,6 +147,84 @@ pub fn cleanup_015_graph_signal_quality(graph: &mut KnowledgeGraph) -> Cleanup01
     report
 }
 
+/// Report returned by [`backfill_research_only_flag`].
+#[derive(Debug, Default, Clone, PartialEq, Eq, serde::Serialize)]
+pub struct BackfillResearchOnlyReport {
+    /// Total Incident nodes scanned.
+    pub incidents_scanned: usize,
+    /// Incidents that had their `research_only` flag flipped from false → true.
+    pub incidents_flagged: usize,
+    /// Breakdown by detector slug (top contributors).
+    pub by_detector: std::collections::BTreeMap<String, usize>,
+}
+
+/// Spec 015 follow-up: walk the graph and backfill the `research_only`
+/// flag on every Incident node whose connected `Ip` nodes are all
+/// self-traffic (cloud providers, Telegram, GeoIP, Canonical, OCI peers).
+///
+/// Safe to run multiple times — idempotent. The migration never *unflags*
+/// an incident; it only promotes false → true when the data matches.
+///
+/// The rule is the same as `ingest_incident`'s: an incident is research_only
+/// iff it has at least one connected Ip node AND every connected Ip node is
+/// a safelist match. Incidents with a single attacker IP and a self-traffic
+/// IP stay visible.
+pub fn backfill_research_only_flag(graph: &mut KnowledgeGraph) -> BackfillResearchOnlyReport {
+    let mut report = BackfillResearchOnlyReport::default();
+
+    // Collect (incident_id, should_flag) in a first pass so we don't hold a
+    // mutable borrow while iterating.
+    let mut updates: Vec<(NodeId, String)> = Vec::new();
+
+    let incident_nodes = graph.nodes_of_type(NodeType::Incident);
+    report.incidents_scanned = incident_nodes.len();
+
+    for inc_id in incident_nodes {
+        let (already_flagged, detector) = match graph.get_node(inc_id) {
+            Some(Node::Incident {
+                research_only,
+                detector,
+                ..
+            }) => (*research_only, detector.clone()),
+            _ => continue,
+        };
+        if already_flagged {
+            continue;
+        }
+
+        // Gather the Ip nodes this incident is TriggeredBy.
+        let mut ip_addrs: Vec<String> = Vec::new();
+        for edge in graph.outgoing_edges(inc_id) {
+            if edge.relation != super::types::Relation::TriggeredBy {
+                continue;
+            }
+            if let Some(Node::Ip { addr, .. }) = graph.get_node(edge.to) {
+                ip_addrs.push(addr.clone());
+            }
+        }
+        if ip_addrs.is_empty() {
+            continue; // not a specifically IP-anchored incident
+        }
+        let all_self = ip_addrs
+            .iter()
+            .all(|ip| crate::cloud_safelist::is_self_traffic_ip(ip));
+        if all_self {
+            updates.push((inc_id, detector));
+        }
+    }
+
+    // Apply.
+    for (inc_id, detector) in updates {
+        if let Some(Node::Incident { research_only, .. }) = graph.nodes.get_mut(&inc_id) {
+            *research_only = true;
+            report.incidents_flagged += 1;
+            *report.by_detector.entry(detector).or_insert(0) += 1;
+        }
+    }
+
+    report
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -178,6 +256,7 @@ mod tests {
             false_positive: false,
             fp_reporter: None,
             fp_reported_at: None,
+            research_only: false,
         });
         g.add_edge(Edge::new(inc, user, Relation::TriggeredBy, ts(0)));
 
@@ -245,6 +324,144 @@ mod tests {
         let report = cleanup_015_graph_signal_quality(&mut g);
         assert_eq!(report.brute_force_user_nodes_removed, 0);
         assert!(g.find_by_user("deploy").is_some());
+    }
+
+    #[test]
+    fn backfill_research_only_flags_telegram_chain() {
+        crate::cloud_safelist::init();
+        let mut g = KnowledgeGraph::new();
+
+        // Telegram IP (Bot API) → incident
+        let telegram = g.ensure_ip("149.154.166.110", ts(0));
+        let inc = g.add_node(Node::Incident {
+            incident_id: "graph_data_exfil:tokio-rt-worker:1".to_string(),
+            detector: "graph_data_exfil".to_string(),
+            severity: "critical".to_string(),
+            title: "exfil → telegram".to_string(),
+            summary: String::new(),
+            ts: ts(0),
+            mitre_ids: vec![],
+            decision: None,
+            confidence: None,
+            decision_reason: None,
+            decision_target: None,
+            auto_executed: false,
+            is_allowlisted: false,
+            false_positive: false,
+            fp_reporter: None,
+            fp_reported_at: None,
+            research_only: false,
+        });
+        g.add_edge(Edge::new(inc, telegram, Relation::TriggeredBy, ts(0)));
+
+        let report = backfill_research_only_flag(&mut g);
+        assert_eq!(report.incidents_flagged, 1);
+        assert_eq!(report.by_detector.get("graph_data_exfil"), Some(&1));
+        match g.get_node(inc) {
+            Some(Node::Incident { research_only, .. }) => assert!(*research_only),
+            _ => panic!("incident lost"),
+        }
+    }
+
+    #[test]
+    fn backfill_preserves_real_attacker_incidents() {
+        crate::cloud_safelist::init();
+        let mut g = KnowledgeGraph::new();
+
+        let attacker = g.ensure_ip("185.113.139.51", ts(0));
+        let inc = g.add_node(Node::Incident {
+            incident_id: "ssh_bruteforce:1".to_string(),
+            detector: "ssh_bruteforce".to_string(),
+            severity: "high".to_string(),
+            title: "brute force".to_string(),
+            summary: String::new(),
+            ts: ts(0),
+            mitre_ids: vec![],
+            decision: None,
+            confidence: None,
+            decision_reason: None,
+            decision_target: None,
+            auto_executed: false,
+            is_allowlisted: false,
+            false_positive: false,
+            fp_reporter: None,
+            fp_reported_at: None,
+            research_only: false,
+        });
+        g.add_edge(Edge::new(inc, attacker, Relation::TriggeredBy, ts(0)));
+
+        let report = backfill_research_only_flag(&mut g);
+        assert_eq!(report.incidents_flagged, 0);
+        match g.get_node(inc) {
+            Some(Node::Incident { research_only, .. }) => assert!(!*research_only),
+            _ => panic!("incident lost"),
+        }
+    }
+
+    #[test]
+    fn backfill_mixed_chain_stays_visible() {
+        crate::cloud_safelist::init();
+        let mut g = KnowledgeGraph::new();
+
+        let telegram = g.ensure_ip("149.154.166.110", ts(0));
+        let attacker = g.ensure_ip("185.113.139.51", ts(0));
+        let inc = g.add_node(Node::Incident {
+            incident_id: "cross_layer_chain:mixed:1".to_string(),
+            detector: "cross_layer_chain".to_string(),
+            severity: "high".to_string(),
+            title: "mixed".to_string(),
+            summary: String::new(),
+            ts: ts(0),
+            mitre_ids: vec![],
+            decision: None,
+            confidence: None,
+            decision_reason: None,
+            decision_target: None,
+            auto_executed: false,
+            is_allowlisted: false,
+            false_positive: false,
+            fp_reporter: None,
+            fp_reported_at: None,
+            research_only: false,
+        });
+        g.add_edge(Edge::new(inc, telegram, Relation::TriggeredBy, ts(0)));
+        g.add_edge(Edge::new(inc, attacker, Relation::TriggeredBy, ts(0)));
+
+        let report = backfill_research_only_flag(&mut g);
+        assert_eq!(report.incidents_flagged, 0, "mixed chain must stay visible");
+    }
+
+    #[test]
+    fn backfill_is_idempotent() {
+        crate::cloud_safelist::init();
+        let mut g = KnowledgeGraph::new();
+
+        let telegram = g.ensure_ip("149.154.166.110", ts(0));
+        let inc = g.add_node(Node::Incident {
+            incident_id: "graph_data_exfil:1".to_string(),
+            detector: "graph_data_exfil".to_string(),
+            severity: "critical".to_string(),
+            title: "t".to_string(),
+            summary: String::new(),
+            ts: ts(0),
+            mitre_ids: vec![],
+            decision: None,
+            confidence: None,
+            decision_reason: None,
+            decision_target: None,
+            auto_executed: false,
+            is_allowlisted: false,
+            false_positive: false,
+            fp_reporter: None,
+            fp_reported_at: None,
+            research_only: false,
+        });
+        g.add_edge(Edge::new(inc, telegram, Relation::TriggeredBy, ts(0)));
+
+        let first = backfill_research_only_flag(&mut g);
+        let second = backfill_research_only_flag(&mut g);
+        assert_eq!(first.incidents_flagged, 1);
+        assert_eq!(second.incidents_flagged, 0);
     }
 
     #[test]

--- a/crates/agent/src/knowledge_graph/mod.rs
+++ b/crates/agent/src/knowledge_graph/mod.rs
@@ -25,6 +25,7 @@
 pub mod detectors;
 pub mod graph;
 pub mod ingestion;
+pub mod migrations;
 pub mod narrative;
 pub mod persistence;
 pub mod triggers;

--- a/crates/agent/src/knowledge_graph/types.rs
+++ b/crates/agent/src/knowledge_graph/types.rs
@@ -111,6 +111,13 @@ pub enum Node {
         /// When the FP was reported.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         fp_reported_at: Option<DateTime<Utc>>,
+        /// Spec 015 follow-up: incident is useful for AI research/training
+        /// but NOT for the operator (e.g. self-traffic to cloud providers,
+        /// the agent's own Telegram/GeoIP/Cloudflare calls, near-miss LSM
+        /// patterns). Dashboard operator views filter these out; neural
+        /// training and investigation views still see them.
+        #[serde(default)]
+        research_only: bool,
     },
     Campaign {
         campaign_id: String,

--- a/crates/agent/src/knowledge_graph/types.rs
+++ b/crates/agent/src/knowledge_graph/types.rs
@@ -41,6 +41,11 @@ pub enum Node {
         is_tor: bool,
         first_seen: DateTime<Utc>,
         last_seen: DateTime<Utc>,
+        /// Spec 015: attacker-supplied usernames from failed SSH auth.
+        /// Stored here (not as User nodes) so the User namespace only
+        /// contains real local users. Dedup + LIFO cap of 50.
+        #[serde(default)]
+        attempted_usernames: Vec<String>,
     },
     File {
         path: String,

--- a/crates/agent/src/main.rs
+++ b/crates/agent/src/main.rs
@@ -174,6 +174,14 @@ struct Cli {
     /// Internal: path to honeypot sandbox runner result JSON.
     #[arg(long, hide = true)]
     honeypot_sandbox_result: Option<PathBuf>,
+
+    /// Spec 015 one-shot migration: load today's dated graph snapshot,
+    /// delete `graph_user_creation` false-positive incidents and
+    /// brute-force User nodes, then save and exit. Never runs unless this
+    /// flag is passed explicitly. Creates a backup of the snapshot as
+    /// `<name>.bak-015` before writing.
+    #[arg(long)]
+    cleanup_015_graph_signal_quality: bool,
 }
 
 // ---------------------------------------------------------------------------
@@ -517,6 +525,79 @@ pub(crate) use trust_rules::{
 // Trust rules and LSM enforcement moved to trust_rules.rs
 
 // ---------------------------------------------------------------------------
+// Spec 015: one-shot cleanup of graph_user_creation false positives and
+// brute-force User node pollution. Invoked via
+// `innerwarden-agent --cleanup-015-graph-signal-quality`. Non-destructive
+// outside that flag: the function below loads today's dated snapshot,
+// writes a timestamped backup, applies the migration, and saves the result.
+// ---------------------------------------------------------------------------
+
+fn run_cleanup_015(data_dir: &std::path::Path) -> Result<()> {
+    use chrono::Local;
+    use std::fs;
+
+    let snapshot_path = knowledge_graph::KnowledgeGraph::dated_snapshot_path(data_dir);
+    if !snapshot_path.exists() {
+        anyhow::bail!(
+            "No dated snapshot found at {} — run the agent at least once first",
+            snapshot_path.display()
+        );
+    }
+
+    // Backup the raw snapshot bytes before touching anything, so the
+    // operator can always roll back if the migration does something
+    // unexpected. Name it with a timestamp so repeated runs don't clobber.
+    let stamp = Local::now().format("%Y%m%dT%H%M%S");
+    let backup_path = snapshot_path.with_extension(format!("json.bak-015-{stamp}"));
+    fs::copy(&snapshot_path, &backup_path)
+        .with_context(|| format!("failed to back up snapshot to {}", backup_path.display()))?;
+    println!(
+        "spec 015 cleanup: backed up snapshot to {}",
+        backup_path.display()
+    );
+
+    // Load, mutate, save.
+    let mut graph = knowledge_graph::KnowledgeGraph::load_snapshot(&snapshot_path);
+    let report = knowledge_graph::migrations::cleanup_015_graph_signal_quality(&mut graph);
+    graph.save_snapshot(&snapshot_path).with_context(|| {
+        format!(
+            "failed to save cleaned snapshot to {}",
+            snapshot_path.display()
+        )
+    })?;
+
+    println!("spec 015 cleanup complete:");
+    println!("  snapshot             : {}", snapshot_path.display());
+    println!("  backup               : {}", backup_path.display());
+    println!("  nodes before         : {}", report.nodes_before);
+    println!("  nodes after          : {}", report.nodes_after);
+    println!(
+        "  graph_user_creation  : {} incident node(s) removed",
+        report.graph_user_creation_incidents_removed
+    );
+    println!(
+        "  brute-force users    : {} User node(s) removed",
+        report.brute_force_user_nodes_removed
+    );
+    if !report.removed_user_names.is_empty() {
+        let sample: Vec<&str> = report
+            .removed_user_names
+            .iter()
+            .take(10)
+            .map(|s| s.as_str())
+            .collect();
+        println!("  removed sample       : {}", sample.join(", "));
+        if report.removed_user_names.len() > 10 {
+            println!(
+                "  …                    : +{} more",
+                report.removed_user_names.len() - 10
+            );
+        }
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
 // Main
 // ---------------------------------------------------------------------------
 
@@ -554,6 +635,10 @@ async fn main() -> Result<()> {
             .ok_or_else(|| anyhow::anyhow!("missing --honeypot-sandbox-result"))?;
         skills::builtin::run_honeypot_sandbox_worker(spec, result).await?;
         return Ok(());
+    }
+
+    if cli.cleanup_015_graph_signal_quality {
+        return run_cleanup_015(&cli.data_dir);
     }
 
     if cli.report {

--- a/crates/agent/src/main.rs
+++ b/crates/agent/src/main.rs
@@ -182,6 +182,15 @@ struct Cli {
     /// `<name>.bak-015` before writing.
     #[arg(long)]
     cleanup_015_graph_signal_quality: bool,
+
+    /// Spec 015 follow-up: load today's dated graph snapshot and set the
+    /// `research_only` flag on every Incident whose connected IPs are
+    /// 100% self-traffic (cloud providers, Telegram, GeoIP, Canonical,
+    /// OCI peers). Incidents are preserved for neural training — only
+    /// the operator dashboard filter changes. Creates a backup as
+    /// `<name>.bak-015-researchonly-<stamp>` before writing.
+    #[arg(long)]
+    backfill_015_research_only: bool,
 }
 
 // ---------------------------------------------------------------------------
@@ -597,6 +606,54 @@ fn run_cleanup_015(data_dir: &std::path::Path) -> Result<()> {
     Ok(())
 }
 
+fn run_backfill_015_research_only(data_dir: &std::path::Path) -> Result<()> {
+    use chrono::Local;
+    use std::fs;
+
+    cloud_safelist::init();
+
+    let snapshot_path = knowledge_graph::KnowledgeGraph::dated_snapshot_path(data_dir);
+    if !snapshot_path.exists() {
+        anyhow::bail!(
+            "No dated snapshot found at {} — run the agent at least once first",
+            snapshot_path.display()
+        );
+    }
+
+    let stamp = Local::now().format("%Y%m%dT%H%M%S");
+    let backup_path = snapshot_path.with_extension(format!("json.bak-015-researchonly-{stamp}"));
+    fs::copy(&snapshot_path, &backup_path)
+        .with_context(|| format!("failed to back up snapshot to {}", backup_path.display()))?;
+    println!(
+        "spec 015 research-only backfill: backed up snapshot to {}",
+        backup_path.display()
+    );
+
+    let mut graph = knowledge_graph::KnowledgeGraph::load_snapshot(&snapshot_path);
+    let report = knowledge_graph::migrations::backfill_research_only_flag(&mut graph);
+    graph.save_snapshot(&snapshot_path).with_context(|| {
+        format!(
+            "failed to save cleaned snapshot to {}",
+            snapshot_path.display()
+        )
+    })?;
+
+    println!("spec 015 research-only backfill complete:");
+    println!("  snapshot       : {}", snapshot_path.display());
+    println!("  backup         : {}", backup_path.display());
+    println!("  scanned        : {}", report.incidents_scanned);
+    println!("  flagged        : {}", report.incidents_flagged);
+    if !report.by_detector.is_empty() {
+        println!("  by detector    :");
+        let mut top: Vec<(&String, &usize)> = report.by_detector.iter().collect();
+        top.sort_by(|a, b| b.1.cmp(a.1));
+        for (det, n) in top.iter().take(15) {
+            println!("    {det:<28} {n}");
+        }
+    }
+    Ok(())
+}
+
 // ---------------------------------------------------------------------------
 // Main
 // ---------------------------------------------------------------------------
@@ -639,6 +696,10 @@ async fn main() -> Result<()> {
 
     if cli.cleanup_015_graph_signal_quality {
         return run_cleanup_015(&cli.data_dir);
+    }
+
+    if cli.backfill_015_research_only {
+        return run_backfill_015_research_only(&cli.data_dir);
     }
 
     if cli.report {


### PR DESCRIPTION
## Summary

Executes spec 015 end-to-end: eliminates the `graph_user_creation` false-positive loop (3,954 incidents on prod 2026-04-11), hardens SSH auth ingestion so brute-force usernames stop polluting the User namespace, fixes the `detect_network_sniffing` self-detection bug, and introduces a `research_only` flag on Incident nodes so the operator dashboard hides self-traffic and near-miss kill-chain signals without losing them for neural training.

## What changed

### Bug fixes
- **`detect_user_creation` removed** — was a pure presence scan over permanent User nodes, firing every 30min per user forever. Real user-creation signal preserved via the existing sensor-side `user_creation` detector + CL-012 Multi-Persistence correlation rule.
- **`ingest_ssh_login` split by success/failure** — failed SSH auth no longer creates User nodes. Attacker usernames now land on `Node::Ip.attempted_usernames` (dedup + LIFO cap 50) where they belong semantically.
- **`detect_network_sniffing` hardened** — skips stale Process nodes (>5min old) and excludes sniffer tools spawned by `innerwarden-agent` / `innerwarden-sensor` ancestors. Fixes self-detection on the agent's own `pcap_capture` tcpdump bursts.

### New: research_only flag
- `Node::Incident` gains `research_only: bool` (with `#[serde(default)]`).
- Computed at ingestion time. Two rules:
  1. **Self-traffic**: incident has ≥1 `Ip` entity AND every `Ip` is in the cloud/agent-service safelist.
  2. **Kill chain forming**: detector=`kill_chain`, severity=Medium, title starts with "Kill chain forming" (near-miss 2/3 bit LSM patterns).
- Operator views (`api_live_feed`, `api_incidents`, `api_overview`, `compute_overview_from_graph`) filter `research_only=true` out. Research views (investigation, compliance, sensors tab, neural training) see everything.

### Safelist extension (`cloud_safelist.rs`)
- Added `AGENT_SERVICE_RANGES` (Telegram 149.154.160.0/20 + 91.108.0.0/16, ip-api.com 208.95.112.0/24, Canonical 185.125.188.0/23 + 91.189.88.0/21).
- Added `ORACLE_PEER_RANGES` (138.1.16.0/22, 140.91.0.0/16, 147.154.224.0/20, 193.122.0.0/15).
- New helpers: `is_self_traffic_ip`, `is_agent_process`.
- Total safelist ranges: 103 (was ~80).

### One-shot migration CLIs
- `--cleanup-015-graph-signal-quality` — deletes `graph_user_creation:*` incident nodes and brute-force User nodes with only failed LoggedInFrom edges. Preserves `root`, `uid:N` fallbacks, and users with privilege edges. Idempotent.
- `--backfill-015-research-only` — walks existing incidents, flips `research_only=true` where the rules apply. Also idempotent.
- Both back up the snapshot to a timestamped `.bak-015-*` file before writing.

### Docs
- New "Signal quality principle" section in `CLAUDE.md` with the per-detector review checklist.
- Full 27-detector audit table in `.specify/features/015-graph-signal-quality/spec.md` with pass/fail verdicts and prod-snapshot counts.
- Bug 3 reclassification: the original "uid parser bug" was a jq artifact, not real; Change 4 dropped from scope.
- CL-012 Multi-Persistence audit: rule still fires correctly via the sensor-side `user_creation` slug path.

## Prod deploy results (2026-04-11)

Ran both migrations on `ubuntu@130.162.171.105:/var/lib/innerwarden`:

| Metric | Before | After |
|---|---|---|
| `graph_user_creation` incidents | 4,300 | **0** |
| User nodes | 175 | 148 (−27 brute-force) |
| `research_only=true` incidents | 0 | 22,688 (21,782 kill-chain forming + 906 self-traffic) |
| Operator-visible incidents | 24,260 | **1,572** (93.5% reduction) |
| Total graph nodes | 30,068 | 25,808 |

Top user-visible slugs after cleanup: `host_drift` (373), `cross_layer_chain` (344), `proto_anomaly` (162), `rootkit` (128), `dns_c2` (116) — all legitimate detections or chains with non-self IPs.

## Test plan

- [x] `make check` passes (clippy + fmt)
- [x] `make test` passes — 598 agent tests (+18 new), 746 sensor tests, zero regressions
- [x] Deployed to prod VM, agent healthy, `systemctl is-active innerwarden-agent` → active
- [x] Fresh snapshot post-cleanup has 0 `graph_user_creation` incidents
- [x] Fresh snapshot post-backfill has 22,688 `research_only=true` incidents
- [x] Operator Threats tab loads without the Telegram/Cloudflare/Oracle self-traffic flood
- [ ] 24h observation window (post-merge, non-blocking)

🤖 Generated with [Claude Code](https://claude.com/claude-code)