### PR TITLE
spec 017: Dashboard AI-first operator UX (Phase 1 — Home + Threats)

### DIFF
--- a/.specify/features/017-dashboard-operator-ux/checklists/requirements.md
+++ b/.specify/features/017-dashboard-operator-ux/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Dashboard Operator UX and QA Reliability
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning  
+**Created**: 2026-04-11  
+**Feature**: [../spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Validation completed in one iteration.
+- Specification is ready for `/speckit.clarify` or `/speckit.plan`.

--- a/.specify/features/017-dashboard-operator-ux/pages/00-shared.md
+++ b/.specify/features/017-dashboard-operator-ux/pages/00-shared.md
@@ -1,0 +1,459 @@
+# Spec 00 — Shared Foundation (Helpers, CSS, Glossary, Trust)
+
+**Parent**: `../spec.md`
+**Phase**: 1 (first to land)
+**Depends on**: nothing
+**Blocks**: `01-home.md`, `02-threats.md`, `03-health.md`, `04-intel.md`
+**Status**: Draft — awaiting implementation approval
+
+## Scope
+
+Foundational JavaScript helpers, CSS classes, glossary constants, and the unified incident-trust function that every page spec in Phase 1 depends on. Must land **before** any page-specific work.
+
+**In scope**:
+- Severity helpers (`helpers.js`)
+- Temporal-window helper (`helpers.js`)
+- Canonical glossary constant (`helpers.js`)
+- Severity-scaled alert classes (`app.css`)
+- Shared `.table-wrap` utility class (`app.css`)
+- Unified `isIncidentTrusted()` with corrected trust rule (`helpers.js`) — removes the duplicate in `home.js` and the inlined variant in `threats.js`
+- Guaranteed boot-time load of `_trustedIps` / `_trustedUsers` (fix Bug A if present)
+- Label rename in global header checkbox (`index.html`, located by `#hideAllowlisted`) — single exception to "no HTML in shared" rule because the checkbox is shared UI across all 4 pages
+
+**Out of scope**:
+- Any page-specific copy changes (Home, Threats, Health, Intel)
+- Any other HTML edit besides the one label rename on the `#hideAllowlisted` checkbox in `index.html`
+- Any backend change (`dashboard.rs`, Rust)
+- Dashboard mode toggle (P2-8)
+- Full tooltip/hover system (P2-9)
+- Detector-level false positive fixes (e.g., `reverse_shell:netcat_shell` matching legitimate `rsync --server` or interactive `python3 -c`) — this spec only makes them visible; detector tuning is separate work
+- Backend support for custom temporal-window params
+- Internationalization — UI copy stays English only
+
+## Current state
+
+### `helpers.js` (212 lines, ES5-style)
+
+Already exists:
+
+- `DETECTOR_LABELS` map — `helpers.js:10-26`
+- `humanLabel(slug)` — `helpers.js:28`
+- `outcomeBadgeHtml(outcome)` — `helpers.js:54-62` (returns `.badge-contained`, `.badge-noise`, `.badge-unresolved`, `.badge-monitor`)
+- `contextLine(outcome, severity)` — `helpers.js:70-85`
+- `timeAgo(ts)` — `helpers.js:165-172`
+- `getUnresolved()` — `helpers.js:2-8`
+- `isPrivateIp(ip)` — `helpers.js:109-113` (also duplicated at `home.js:81-85`)
+- `isIncidentTrusted(inc)` — `helpers.js:115-133` (also duplicated at `home.js:87-105`; `threats.js:14-16` has a third inlined variant that only calls `isIpTrusted`/`isPrivateIp` without the `hasExternalIp` catch-all)
+
+Missing (net-new for Phase 1):
+
+- No severity → CSS class helper
+- No max-severity helper
+- No temporal-window label helper
+- No canonical glossary constant
+- No single-source-of-truth `isIncidentTrusted()`
+
+### `app.css`
+
+Color vars at `app.css:12-16`:
+
+- `--ok: #4ade80`
+- `--warn: #ffc566`
+- `--danger: #f43f5e`
+- `--accent: #78e5ff`
+- `--orange: #ff9a55`
+
+Existing severity precedent:
+
+- `app.css:426-428`: `.dot-event-critical` (danger), `.dot-event-high` (warn), `.dot-event-medium` (warn/transparent)
+- `app.css:471-475`: `.bk-event-crit`, `.bk-event-high`, `.bk-event-med` — same color ramp pattern, reused for consistency
+
+Missing:
+
+- No `.alert-*` scaled-tone classes for banner/callout containers
+- No `.table-wrap` responsive wrapper utility
+
+### `index.html` header (shared UI)
+
+- Element: `<input type="checkbox" id="hideAllowlisted" checked onchange="toggleAllowlistFilter()" ...> Hide trusted`
+- Located by `id="hideAllowlisted"` — line number intentionally not pinned, since line numbers drift with unrelated edits
+- Checkbox lives in the global header, visible and active on all 4 pages (Home, Threats, Health, Intel)
+
+### `state.js`
+
+- `state.hideAllowlisted = true` default — `state.js:14`
+
+### `threats.js`
+
+- `_trustedIps = []` global — `threats.js:79`
+- `_trustedUsers = []` global — `threats.js:80`
+- `isIpTrusted(ip)` — `threats.js:82-...`
+- `toggleAllowlistFilter()` — `threats.js:101-105` — **lazy-loads** `_trustedIps`/`_trustedUsers` from `actionCfg` only when the checkbox is clicked AND `_trustedIps.length === 0`
+
+### `actions.js`
+
+- Line 8-9: `_trustedIps = actionCfg.trusted_ips || []; _trustedUsers = actionCfg.trusted_users || [];`
+- **Unknown**: whether `actions.js` runs at dashboard boot or only on-demand. Verification required during implementation (see Pre-implementation checks).
+
+## Observed problems (foundation gaps)
+
+- **FG-1**: Severity referenced ad-hoc across pages, no central function. Pages cannot scale tone without duplicating logic.
+- **FG-2**: No temporal-window labeling utility. KPIs show raw numbers with no window context.
+- **FG-3**: UI terminology not centrally defined. Consistent today but undocumented — copy review risks drift.
+- **FG-4**: No reusable responsive `<table>` wrapper.
+- **FG-5**: `isIncidentTrusted()` is duplicated in `helpers.js:115-133` and `home.js:87-105` (same code), with a third partial variant inlined in `threats.js:14-16` that omits the `hasExternalIp` catch-all. Three call sites, three subtly different behaviors. Drift risk.
+- **FG-6** (**critical**): the `!hasExternalIp → trusted` catch-all at `helpers.js:131` and `home.js:103` silently hides incidents with no IP entity. Measured on prod `incidents-2026-04-11.jsonl` (24,900 incidents for the day):
+
+  | Severity | No-IP count | Filter verdict today | Notes |
+  |---|---|---|---|
+  | medium | 23,673 | **HIDDEN** | host_drift, medium kill_chain (`forming 2/3 bits`), dns_c2, rootkit, kernel_module, network_sniffing, sandbox_evasion, discovery_burst |
+  | high | 404 | **HIDDEN** | rootkit, kernel_module, sandbox_evasion, discovery_burst, high kill_chain |
+  | **critical** | **13** | **HIDDEN** | 10 `kill_chain:detected:REVERSE_SHELL:…` completed LSM detections + 3 reverse_shell pattern matches |
+  | low | 25 | **HIDDEN** | suspicious_execution with user entity only |
+
+  Total: **96.9%** of today's incidents are filtered by this rule. **13 critical and 404 high severity events per day are invisible to the operator.**
+
+  Sample of a hidden critical (verbatim from prod):
+
+  ```
+  incident_id: "kill_chain:detected:REVERSE_SHELL:657329:2026-04-11T09:34Z"
+  severity:    "critical"
+  title:       "Kill chain detected: REVERSE_SHELL (PID 657329, ruby)"
+  summary:     "PID 657329 (ruby) completed REVERSE_SHELL pattern
+                (socket + dup_stdin + dup_stdout). Kernel LSM will
+                block next execve()."
+  entities:    []
+  ```
+
+  Counterpoint: sample of 5 medium-hidden incidents (validated — these *should* stay hidden):
+
+  ```
+  {"det":"host_drift","title":"Host drift: unknown executed from non-standard path","entities":[{"type":"path","value":"sudo"}]}
+  {"det":"kill_chain","title":"Kill chain forming: EXPLOIT_SHELL (2/3 bits, PID 670552)","entities":[]}
+  {"det":"kill_chain","title":"Kill chain forming: EXPLOIT_SHELL (2/3 bits, PID 666797)","entities":[]}
+  {"det":"kill_chain","title":"Kill chain forming: EXPLOIT_SHELL (2/3 bits, PID 668599)","entities":[]}
+  {"det":"kill_chain","title":"Kill chain forming: REVERSE_SHELL (2/3 bits, PID 659723)","entities":[]}
+  ```
+
+  These are near-miss patterns (2/3 bits, incomplete) and the agent's own sudo calls — genuine noise. The corrected rule preserves hiding for these.
+
+- **FG-7**: `threats.js:101-105` lazy-loads `_trustedIps`/`_trustedUsers` only when the user clicks the checkbox. If the user never clicks (and the checkbox is checked by default), `_trustedIps` stays empty forever, making `isIpTrusted()` return `false` for everything — so `isIncidentTrusted()` effectively only filters RFC1918 private IPs, not the actual configured allowlist. **Bug existence is conditional on whether `actions.js` also loads the allowlist at boot.** Verification required during implementation.
+
+## Proposed changes
+
+### Change 1 — Severity helpers in `helpers.js`
+
+**Where**: after `DETECTOR_LABELS` block (after line 26), before `humanLabel()`.
+
+| Function | Input | Output | Behavior |
+|---|---|---|---|
+| `severityClass(sev)` | `'critical' \| 'high' \| 'medium' \| 'low' \| 'info'` or null | CSS class from `alert-*` family | lowercase; unknown → `'alert-info'` |
+| `severityLabel(sev)` | same | `'Critical' \| 'High' \| 'Medium' \| 'Low' \| 'Info'` | capitalize; fallback `'Info'` |
+| `severityRank(sev)` | same | `4` (critical) → `0` (info), `-1` unknown | for comparison/sort |
+| `maxSeverity(incidents)` | array of objects with `.severity` or `.effective_severity` | highest severity string, `'info'` if empty | prefers `effective_severity` per existing convention at `home.js:168` |
+
+Pure additions. **Risk**: low.
+
+### Change 2 — Temporal-window helper in `helpers.js`
+
+**Where**: after `timeAgo()` (after line 172).
+
+| Function | Input | Output |
+|---|---|---|
+| `formatWindow(kind)` | `'live' \| 'today' \| 'last_24h' \| 'last_6h' \| 'last_hour' \| 'since_start'` | `'Live' \| 'Today' \| 'Last 24h' \| 'Last 6h' \| 'Last hour' \| 'Since startup'`; unknown → `''` |
+
+Pure addition. **Risk**: low.
+
+### Change 3 — Canonical glossary in `helpers.js`
+
+**Where**: `helpers.js`, file-level scope (placement fine-tuned in implementation).
+
+```
+GLOSSARY = {
+  threat:     'A detected security event that may pose risk.',
+  incident:   'A threat recorded by the backend (same concept, internal name).',
+  unresolved: 'A threat that has not been handled automatically and awaits your review.',
+  contained:  'A threat that has been blocked, killed, monitored, or suspended automatically.',
+  open:       'A threat with no containment action taken yet.',
+  resolved:   'A threat that has been closed — either contained or dismissed.',
+  noise:      'A low-signal detection the system chose not to act on.'
+}
+```
+
+Pure addition. **Risk**: low.
+
+### Change 4 — Severity-scaled alert classes in `app.css`
+
+**Where**: after `:root` vars block (around line 18), labeled `/* ── Severity-scaled alert classes (spec 017 Phase 1) ── */`.
+
+| Class | Tone | Base color |
+|---|---|---|
+| `.alert-critical` | strong red | `--danger` |
+| `.alert-high` | orange | `--orange` |
+| `.alert-medium` | amber | `--warn` |
+| `.alert-low` | cyan | `--accent` |
+| `.alert-info` | neutral | `--muted`/`--ok` low alpha |
+
+Each class scales border color, background alpha, and left-border accent. Text color inside the alert is **not** set by the class so existing typography keeps working. Reference: `app.css:471-475` `.bk-event-*` pattern. **Risk**: low.
+
+### Change 5 — `.table-wrap` utility class in `app.css`
+
+**Where**: near existing responsive section (placement decided in implementation).
+
+- Desktop: `overflow-x: auto; -webkit-overflow-scrolling: touch; width: 100%`
+- Mobile (`@media (max-width: 600px)`): safety-net horizontal scroll; the actual table → cards transformation for Intel lives in `04-intel.md` and will extend this class
+
+Pure addition. **Risk**: low.
+
+### Change 6 — Unified `isIncidentTrusted()` in `helpers.js`
+
+**Where**: `helpers.js`, replacing the existing function at lines 115-133.
+
+**Deletions**:
+
+- Duplicate `isIncidentTrusted` at `home.js:87-105` — removed
+- Duplicate `isPrivateIp` at `home.js:81-85` — removed (keep the one at `helpers.js:109-113`)
+- Inlined variant at `threats.js:14-16` — replaced with a call to the unified `isIncidentTrusted()`
+
+**New function contract**:
+
+```
+function isIncidentTrusted(inc)
+  Input: incident object (from /api/incidents or graph snapshot)
+  Output: boolean — true means "considered noise, hide from view when
+          state.hideAllowlisted is on"; false means "show"
+
+  Rules, in order:
+
+  Rule 1 (severity gate):
+    Read effective_severity, falling back to severity. Lowercase.
+    If value is 'critical' or 'high', return false unconditionally.
+    High and critical must never be filtered by the trust rule,
+    regardless of entity shape. This is the core fix for FG-6.
+
+  Rule 2 (entity walk, for medium/low/info only):
+    Walk inc.entities. Accept both object form ({type, value}) and
+    legacy string form ("Type:value").
+    Track:
+      - sawExternalIp:    any entity of type 'ip' was seen
+      - allIpsTrusted:    every ip seen is in _trustedIps OR isPrivateIp
+      - sawUntrustedUser: any entity of type 'user' not in _trustedUsers
+
+    After the walk:
+      If sawExternalIp AND NOT allIpsTrusted → return false
+         (at least one non-trusted external IP → show)
+      If sawUntrustedUser → return false
+         (non-trusted user activity → show)
+      Otherwise → return true
+         (all IPs trusted OR no IP and no non-trusted user → hide)
+
+  The sub-high catch-all "no IP means trusted" is preserved by this
+  last branch, which is essential for suppressing 44K+ medium
+  process/kernel noise events per day.
+```
+
+**Key difference from current behavior**:
+
+- **Deleted**: the unconditional catch-all `if (!hasExternalIp) return true;` at `helpers.js:131` / `home.js:103`
+- **Added**: Rule 1 severity gate
+- **Result**: critical and high always visible; medium/low with no IP entity stay hidden (by Rule 2's default branch); medium/low with untrusted user or external IP now correctly shown
+
+**Measured impact** on prod data `incidents-2026-04-11.jsonl`:
+
+| Severity | Visible before | Visible after | Δ |
+|---|---|---|---|
+| critical | 27 | 40 | **+13** |
+| high | 97 | 501 | **+404** |
+| medium | 664 | 664 | 0 |
+| low | 0 | 25 | **+25** |
+| **Total** | **788** | **1,230** | **+442 (+56%)** |
+
+The 21,960 medium `kill_chain forming` incidents, 23,673 medium host_drift incidents, and 25 low suspicious_execution-with-trusted-user incidents stay hidden by design (baseline noise). If future data shows any of these classes deserves visibility, that's a separate rule change in a follow-up spec.
+
+**Risk**: medium — this changes observable behavior of every page that filters incidents. Verification: confirm that after deploy, the critical and high severity items visible in the Home feed strictly include everything that `/api/incidents` returns with `severity ∈ {critical, high}`, regardless of entity shape. Confirm the sample `kill_chain:detected:REVERSE_SHELL:...` critical from FG-6 is now visible (or an equivalent kill_chain critical if that specific one aged out). The measured single-day count delta in the table above is illustrative, not a target.
+
+### Change 7 — Guaranteed boot-time load of `_trustedIps` / `_trustedUsers`
+
+**Pre-implementation verification** (must run before editing any file):
+
+Grep for `loadJson('/api/action/config')` and trace when it executes:
+
+- **If** it runs at dashboard boot (via `init()` or module load in `actions.js`/`nav.js`/equivalent) → Bug A does not exist. The lazy-load branch in `threats.js:102-105` is redundant but harmless. Delete it for cleanliness, do not add new boot code.
+- **If** it runs only on-demand (when the user opens Threats, triggers an action, or clicks the checkbox) → Bug A is real. Add an explicit boot-time call in the dashboard init path. Candidate location: wherever `loadJson('/api/status')` runs at boot today (most likely in `nav.js` init or `home.js loadHome()`).
+
+The spec commits to **the outcome**: after this change lands, `_trustedIps` and `_trustedUsers` MUST be populated before the first `isIncidentTrusted()` call in the rendering pipeline, regardless of whether the user has interacted with the checkbox.
+
+**Verification**: open a fresh dashboard, devtools console immediately after load, confirm that `_allowlistLoaded === true` AND that `JSON.stringify(_trustedIps)` / `JSON.stringify(_trustedUsers)` deep-equal the `trusted_ips` / `trusted_users` fields of a fresh `loadJson('/api/action/config')` response, including when the backend returns empty arrays.
+
+**Risk**: low if redundant (no change needed); medium if fix required (boot sequencing affects all filter call sites).
+
+### Change 8 — Label rename on the `#hideAllowlisted` checkbox in `index.html`
+
+**Where**: `index.html`, the single line that contains `id="hideAllowlisted"`. Located by id, not by line number.
+
+**Before**:
+
+```
+... onchange="toggleAllowlistFilter()" ...> Hide trusted
+```
+
+**After**:
+
+```
+... onchange="toggleAllowlistFilter()" ...> Hide known-safe sources
+```
+
+Only the visible label text changes. `id="hideAllowlisted"`, the `onchange` handler, and all JS references stay identical.
+
+**Reason**: "Trusted" is jargon for a non-technical operator. "Known-safe sources" tells her what the toggle actually does without requiring context about the allowlist concept.
+
+**Scope exception**: this is the only HTML edit in `00-shared.md`. Kept here rather than moved to `01-home.md` because the checkbox lives in the global header and is visible on all 4 pages — the label belongs with the foundation layer.
+
+**Risk**: low. Single-line text edit.
+
+## Pre-implementation checks (must pass before any file edit)
+
+1. **Check `actions.js` boot behavior** for Change 7. Grep for `loadJson('/api/action/config')`. Determine whether it runs at boot or on-demand. Decide whether Change 7 needs a new boot call or is a pure cleanup.
+2. **Grep for any other call site** of `isIncidentTrusted` or `isPrivateIp` not already listed in FG-5 (`home.js`, `helpers.js`, `threats.js`, `sse.js`). Confirm removing the duplicates in `home.js` doesn't break a hidden caller.
+3. **Confirm `incident.effective_severity`** field exists and is populated in the JSON shape returned by `/api/incidents`. Already observed at `home.js:168` and `incidents-2026-04-11.jsonl` samples, but re-verify on the active build during implementation.
+4. **Pull one more sample** of the 5 medium-hidden examples from FG-6 during the implementation session — confirm they're still shape-compatible with the new rule (i.e., still correctly hidden by Rule 2's default branch).
+
+If any check fails, stop and update the spec before editing files.
+
+## Acceptance criteria
+
+### Helpers + CSS + glossary (Changes 1-5)
+
+- [ ] `helpers.js` has global symbols: `severityClass`, `severityLabel`, `severityRank`, `maxSeverity`, `formatWindow`, `GLOSSARY`
+- [ ] `severityClass('critical')` → `'alert-critical'`
+- [ ] `severityClass(null)` → `'alert-info'`
+- [ ] `severityClass('HIGH')` → `'alert-high'` (case-insensitive)
+- [ ] `maxSeverity([{severity:'low'},{severity:'critical'},{severity:'medium'}])` → `'critical'`
+- [ ] `maxSeverity([])` → `'info'`
+- [ ] `maxSeverity([{effective_severity:'high',severity:'low'}])` → `'high'` (prefers `effective_severity`)
+- [ ] `formatWindow('last_24h')` → `'Last 24h'`
+- [ ] `formatWindow('nope')` → `''`
+- [ ] `GLOSSARY.contained` is a non-empty English string
+- [ ] `app.css` has 5 `.alert-*` classes visible in browser devtools
+- [ ] `.alert-critical` applied to a test `<div>` shows red tint; `.alert-info` shows neutral
+- [ ] `app.css` has `.table-wrap` with `overflow-x: auto`
+
+### Unified trust (Changes 6-7)
+
+- [ ] `helpers.js` has a single `isIncidentTrusted()` with the new rule
+- [ ] `home.js:81-105` no longer contains `isIncidentTrusted` or `isPrivateIp`
+- [ ] `threats.js:14-16` inlined variant replaced with a call to the unified function
+- [ ] Critical incident with `entities: []` → `isIncidentTrusted()` returns **false** (show)
+- [ ] High incident with `entities: []` → returns **false** (show)
+- [ ] Medium incident with `entities: []` → returns **true** (hide)
+- [ ] Medium incident with `entities: [{type:'path', value:'sudo'}]` → returns **true** (hide)
+- [ ] Medium incident with `entities: [{type:'ip', value:'8.8.8.8'}]` (external, not in allowlist) → returns **false** (show)
+- [ ] Medium incident with `entities: [{type:'ip', value:'192.168.1.1'}]` → returns **true** (hide)
+- [ ] Medium incident with `entities: [{type:'user', value:'root'}]` when `_trustedUsers = ['root']` → returns **true**
+- [ ] Medium incident with `entities: [{type:'user', value:'eve'}]` when `_trustedUsers = ['root']` → returns **false**
+- [ ] Legacy string entity form `"ip:8.8.8.8"` parses equivalently to object form
+- [ ] Dashboard exposes a sentinel (for example `_allowlistLoaded`) that becomes `true` only after the initial `/api/action/config` load completes at boot
+- [ ] Immediately after boot (before any user interaction with the checkbox), the sentinel is `true` AND `_trustedIps` / `_trustedUsers` deep-equal the `trusted_ips` / `trusted_users` fields from the most recent `/api/action/config` response — **including the valid empty-array case** when the backend has no entries configured
+- [ ] `length >= 0` is explicitly NOT a sufficient criterion (always true) — the check must be equivalence to the fetched config
+
+### Label rename (Change 8)
+
+- [ ] The `#hideAllowlisted` checkbox label in `index.html` shows `Hide known-safe sources`
+- [ ] Checkbox still toggles `state.hideAllowlisted` correctly
+- [ ] `id="hideAllowlisted"` unchanged
+- [ ] `onchange="toggleAllowlistFilter()"` unchanged
+
+### Global
+
+- [ ] `git diff` on this spec's commit shows: additions to `helpers.js` and `app.css`, deletions of the `home.js` trust/private-ip duplicates, replacement of `threats.js` inlined variant with a call, and the single label rename in `index.html`. No unrelated changes.
+- [ ] Dashboard loads with zero new console errors on Home / Threats / Health / Intel
+- [ ] **Behavior, not count**: after deploy, for any critical or high severity incident observed in the raw `/api/incidents` feed, the same incident is also present in the rendered Home Recent Activity feed when "Hide known-safe sources" is ON. No critical or high incident may be hidden by the trust rule regardless of its entity shape.
+- [ ] **Behavior, not count**: for any medium or low incident where the entity walk would classify it as trusted (all IPs private or allowlisted, no non-trusted user, or no entities at all), the incident remains hidden when "Hide known-safe sources" is ON.
+- [ ] At least one `kill_chain:detected:*` critical is visible in the Home feed during the post-deploy observation window, provided the sensor emitted one (check prod `incidents-$(date +%Y-%m-%d).jsonl` for `kill_chain:detected:` presence)
+- [ ] The specific absolute counts observed during diagnosis (see FG-6 and Change 6 impact table) are illustrative historical measurements of a single day, **not pass/fail thresholds** — day-to-day variation in attack volume can swing the numbers significantly
+
+## Verification
+
+### Local (before deploy)
+
+1. `make build` — ensure compilation is clean
+2. Open dashboard locally, browser devtools console:
+   - `typeof severityClass === 'function'` → `true`
+   - `typeof formatWindow === 'function'` → `true`
+   - `typeof isIncidentTrusted === 'function'` → `true`
+   - `GLOSSARY.threat` → expected string
+   - `_allowlistLoaded === true` immediately at boot (before any user action)
+   - Manually fetch `loadJson('/api/action/config')` and confirm `JSON.stringify(_trustedIps)` equals `JSON.stringify(response.trusted_ips)`, and the same for `_trustedUsers` — including the case when both returned arrays are empty
+3. Devtools elements panel: apply `.alert-critical` then `.alert-info` to a test `<div>`, confirm tints match the table in Change 4
+4. Apply `.table-wrap` to a test `<div>` with wide children, confirm horizontal scroll
+5. Devtools console: manually invoke `isIncidentTrusted({severity:'critical', entities:[]})` → `false`; `isIncidentTrusted({severity:'medium', entities:[]})` → `true`; `isIncidentTrusted({severity:'medium', entities:[{type:'ip', value:'192.168.1.1'}]})` → `true`; `isIncidentTrusted({severity:'medium', entities:[{type:'ip', value:'8.8.8.8'}]})` → `false`
+6. Navigate Home / Threats / Health / Intel — confirm zero console errors
+7. Confirm Home Recent Activity feed shows more items than before (specifically: at least one kill_chain critical or high, and at least one rootkit/kernel_module high)
+
+### Post-deploy (prod at `130.162.171.105`)
+
+1. SSH in, run `sudo wc -l /var/lib/innerwarden/incidents-$(date +%Y-%m-%d).jsonl` — baseline of total for the day
+2. Open dashboard at the prod URL (authenticated), Home tab
+3. Compare the Recent Activity feed before/after the deploy on the same host. Expected behavior: strictly more critical and high severity items become visible (exact delta varies by daily attack volume and is not a pass/fail threshold)
+4. Confirm at least one `kill_chain:detected:` critical is visible in the feed (the Home spec adds feed truncation rules, so this is specifically a "does it appear anywhere before truncation" check)
+5. Check label: "Hide known-safe sources" shown in the global header checkbox on all 4 pages
+6. Toggle the checkbox off → feed shows strictly more items; toggle back on → filter reapplies. Confirm no stale state
+7. Zero new console errors across Home / Threats / Health / Intel
+8. Navigate to Threats — confirm the same trust rule applies consistently there (no duplicate/divergent filtering)
+
+### Rollback
+
+Single-commit revert. No runtime state touched, no DB changes, no migration. File-level revert is sufficient.
+
+## Post-rollout noise monitoring
+
+Rule 1 (high/critical never hidden by the trust rule) is load-bearing. It assumes the sensor's severity classifier is stable. If a detector starts emitting large volumes of false-positive high/critical incidents — a concrete example already seen during the diagnostic: `reverse_shell:netcat_shell` matching legitimate `rsync --server` and my own interactive `python3 -c` during SSH work — the operator will be flooded.
+
+**Commitment for the 24 hours following deploy**:
+
+- Observe the rate of critical + high items appearing in the Home Recent Activity feed. The diagnostic baseline (single day, illustrative) was ~124 shown per day (27 critical + 97 high); after the fix the expected order of magnitude is several hundred shown per day.
+- If the post-deploy rate of critical/high shown clearly exceeds the illustrative expectation by an order of magnitude (roughly: more than ~5,000 critical+high per day, equivalent to ~200/hour), treat it as a **detector quality regression**, not a UX regression.
+- **The correct remediation in that case is to quiet the noisy detector** (allowlist tuning, signature adjust, severity downgrade in the rule config) — NOT to revert the trust rule. The trust rule is doing its job: surfacing what the sensor said was serious.
+- **Rollback triggers for spec 017 Phase 1 (00-shared) specifically**: only one of these should trigger a revert of this commit:
+  1. `isIncidentTrusted()` returns a wrong verdict on any of the Acceptance Criteria test cases in production
+  2. A new JavaScript console error on any of Home / Threats / Health / Intel attributable to the change
+  3. The `_allowlistLoaded` sentinel never becomes `true` (meaning `/api/action/config` is not being loaded at boot and the rule can't be evaluated against a known allowlist)
+- **Detector noise alone (item above) does NOT trigger revert of this commit.**
+
+This note exists to prevent conflating two different problems after rollout:
+- **(a)** operator sees more alerts because events were previously hidden incorrectly — intended outcome of this spec, keep it
+- **(b)** operator sees more alerts because a detector became unstable — out of scope of this spec, fix the detector
+
+---
+
+## Implementation commit message (draft)
+
+```
+feat(dashboard): unified severity + trust foundation (spec 017 Phase 1, 00-shared)
+
+- Add severityClass/Label/Rank/maxSeverity helpers in helpers.js
+- Add formatWindow helper for temporal KPI labels
+- Add GLOSSARY constant with canonical English definitions
+- Add .alert-critical/high/medium/low/info CSS classes
+- Add .table-wrap utility for responsive tables
+- Unify isIncidentTrusted in helpers.js (single source of truth)
+- Remove duplicate isIncidentTrusted + isPrivateIp from home.js
+- Replace inlined trust variant in threats.js with call to unified fn
+- Fix FG-6: add severity gate so critical/high always visible
+  regardless of entity shape; preserve sub-high catch-all for noise
+- Fix FG-7 (Bug A): guarantee _trustedIps/_trustedUsers load at boot
+- Rename "Hide trusted" to "Hide known-safe sources" in header
+
+Illustrative single-day sample (prod incidents-2026-04-11.jsonl, 24,900
+incidents). These numbers describe one day's observation, NOT a target —
+daily variation in attack volume can swing them significantly:
+  Visible incidents: ~788 → ~1,230 on that day
+  Critical shown: +13 (includes previously hidden kill_chain LSM detections)
+  High shown: +404
+  Medium kill_chain forming + medium host_drift noise stay hidden by design
+
+The behavioral guarantee is that critical and high incidents are never
+hidden by the trust rule — not a specific count delta.
+
+Ref: .specify/features/017-dashboard-operator-ux/pages/00-shared.md
+```

--- a/.specify/features/017-dashboard-operator-ux/pages/01-home.md
+++ b/.specify/features/017-dashboard-operator-ux/pages/01-home.md
@@ -1,0 +1,692 @@
+# Spec 01 — Home Tab
+
+**Parent**: `../spec.md`
+**Phase**: 1
+**Depends on**: `00-shared.md` must land and be implemented first (provides severity helpers, `formatWindow`, `GLOSSARY`, `.alert-*` classes, unified `isIncidentTrusted`, `_allowlistLoaded` sentinel)
+**Blocks**: nothing directly. Change 8 defines a contract consumed by `02-threats.md`. Change 10 surfaces signals also displayed by `03-health.md`.
+**Status**: Draft — awaiting implementation approval
+
+## Product philosophy
+
+**Home never demands. Home only informs and observes.**
+
+InnerWarden is an AI-first security agent that decides and acts. The operator is an observer, not a triager. The canonical user experience is:
+
+- 99%+ of the time: the dashboard reassures that the AI is handling things
+- Ideally 0 times per year: the operator must make a decision
+- 3–5 times per year at most: something unusual happens that the operator might want to look at, but even then the UI describes the unusual state — it never orders the operator to act
+
+Every line of copy, every color, every CTA on Home is written under this philosophy. **The AI is the subject of every sentence. The operator is the reader.**
+
+## Scope
+
+**In scope**:
+- Rename `openHighCritical` → `activeHighCritical` in `home.js`; fix its computation (use `effective_severity`, apply the same trust-filtered base as Recent Activity)
+- Three hero states via a new `computeHomeState()` function: **AI Protection Active** / **AI Responding to Active Threats** / **System Health Alert**
+- "Now" section with 2 lines only (What happened / What the system did) — no third line, ever
+- Fixed temporal sub-labels on 3 Home KPIs (Today / Today / Live (today))
+- Recent Activity hierarchy combining severity AND outcome; `OPEN` badge text → `ACTIVE`; `.alert-critical` banned from feed rows (reserved for hero state 3)
+- Data Collection simplification with human-labeled collectors
+- AI Briefing empty state copy replaced with approved reassuring text
+- Observational `View activity →` link (secondary, always present); `View system health →` link visible only in state 3
+- Home call sites use unified `isIncidentTrusted` / `isPrivateIp` from helpers.js
+- New `/api/responses` fetch in `loadHome()` for System Health Alert detection
+- 4 state-3 triggers: sensor stall, orphaned responses, revert_failed, revert_failures within the last 24 hours
+- Explicit state priority ordering to prevent flicker when multiple signals fire
+
+**Out of scope**:
+- All other pages (Threats / Health / Intel)
+- Dashboard mode toggle (P2-8)
+- Full tooltip/hover system (P2-9)
+- Any backend change (unless noted under T4 in Change 10)
+- Detector-level false-positive tuning
+- Internationalization — copy stays English
+
+## Current state
+
+### `home.js` (~205 lines)
+
+- `loadHome()` — fetches `/api/status`, `/api/overview`, `/api/incidents?limit=100`, `/api/sensors`. Computes `openHighCritical` using `severity` (not `effective_severity`), no trust filter applied.
+- `updateHomeBanner()` — binary `status-hero danger` / `status-hero safe`; inline red `Review Threats →` button; sub-text `"X contained · Y noise filtered"`; meta strip with `MODE` and `❤ Ns ago`.
+- `updateHomeKpis()` — renders 3 cards as raw numbers, no temporal labels.
+- `loadBriefing()` — empty-state fallback: `"Click Generate to create your first briefing."`
+- `buildHomeFeed()` — filters via `isIncidentTrusted` when `state.hideAllowlisted`; renders chronologically; all OPEN items tagged with red `badge-unresolved`.
+- After 00-shared lands: `home.js` no longer contains local `isIncidentTrusted` / `isPrivateIp` duplicates.
+
+### `index.html` Home view
+
+- `#homeHero`, `#homeHeroIcon`, `#homeHeroTitle`, `#homeHeroSub`, `#homeStatusMeta`
+- `#homeKpiThreats`, `#homeKpiResponded`, `#homeKpiEvents`
+- `#briefingSection`, `#briefingContent`, `#briefingBtn`
+- `#homeFeed`
+- Collector strip section
+
+### Screenshot evidence (2026-04-11)
+
+See parent spec discussion. Key baseline problems:
+1. Header `🛡 PROTECTED · OPEN · AI 0` (green) contradicts banner `9 Unresolved Threats` (dark red)
+2. KPIs `112 / 2 / 85,503` without temporal windows create mental-math confusion
+3. Banner is always dark red for any open item regardless of severity
+4. Recent Activity items uniformly red, no hierarchy
+5. Data Collection lists raw collector slugs (`tcp_stream`, `auditd`, `http_capture`)
+6. AI Briefing empty state is clinical
+
+## Observed problems
+
+- **HP-1**: The word `unresolved` appears in the banner title. Incompatible with AI-first philosophy — it implies human pending work.
+- **HP-2**: Hero tone is binary (danger / safe). Cannot express "AI is responding to non-trivial activity" without shouting red.
+- **HP-3**: `openHighCritical` computation uses `severity` (not `effective_severity`) and skips the allowlist filter, causing banner-vs-feed mismatch.
+- **HP-4**: Review Threats button is a primary red CTA, projecting operator urgency. Wrong signal for an AI-first tool.
+- **HP-5**: Recent Activity rows are visually uniform. Operator cannot distinguish "AI processing a kill chain" from "trivial port scan logged".
+- **HP-6**: AI Briefing empty state reads like a chore.
+- **HP-7**: Data Collection exposes raw slugs. No meaning for the primary operator.
+- **HP-8**: No UI signal for the 3–5x/year exception states (sensor stall, response drift, execution failure).
+- **HP-9**: Hero state is derived only from incident counts. System health (sensor responsiveness, response drift) never reaches Home.
+- **HP-10**: Vocabulary across the tab includes `Unresolved`, `needs`, `pending`, `awaiting`, `review`, all imperative-voice terms the AI-first model rejects.
+
+## Proposed changes
+
+### Change 1 — Rename `openHighCritical` → `activeHighCritical`, fix computation
+
+**Where**: `home.js loadHome()`.
+
+**Fix**:
+
+1. Rename the variable from `openHighCritical` to `activeHighCritical`. Reflects AI-first framing.
+2. Compute from the same filtered base as Recent Activity:
+   ```
+   var base = state.hideAllowlisted
+     ? items.filter(function(i) { return !isIncidentTrusted(i); })
+     : items;
+   ```
+3. Filter using `effective_severity` with fallback:
+   ```
+   var activeHighCriticalList = base.filter(function(i) {
+     var sev = (i.effective_severity || i.severity || '').toLowerCase();
+     return i.outcome === 'open' && (sev === 'critical' || sev === 'high');
+   });
+   var activeHighCritical = activeHighCriticalList.length;
+   ```
+4. Pass the filtered **list** (not just count) to `updateHomeBanner` so Change 2 can call `maxSeverity()`.
+
+**Internal naming note**: `outcome === 'open'` stays in the data-model field name — it is the backend's field. The rename applies only to JS variable names within `home.js`.
+
+**Risk**: low.
+
+### Change 2 — Three hero states via `computeHomeState()`
+
+**Where**: `home.js`; new `computeHomeState()` function; rewrite of `updateHomeBanner()` to consume its output.
+
+**New function contract**:
+
+```
+function computeHomeState(payload)
+  Input: {
+    status,                  // /api/status response
+    overview,                // /api/overview response
+    responsesData,           // /api/responses response (new fetch, Change 10)
+    activeHighCriticalList   // from Change 1
+  }
+
+  Output: {
+    state: 'protection_active' | 'ai_responding' | 'health_alert',
+    maxSeverity: 'info'|'low'|'medium'|'high'|'critical',
+    heroClass: string,       // 'status-hero alert-{class}'
+    heroIcon: string,
+    heroTitle: string,
+    heroSub: string,
+    healthAlertReasons: array of strings  // empty unless state === 'health_alert'
+  }
+```
+
+**State priority (critical — prevents flicker)**:
+
+The function MUST evaluate triggers in this fixed order. First match wins. Later triggers cannot override earlier ones in the same evaluation.
+
+```
+Priority 1 (highest): state 3 = 'health_alert'
+    Fired by Change 10 triggers T1, T2, T3, T4.
+    Sub-priority within health_alert for the displayed reason:
+      T1 (sensor stall)           — highest, always wins
+      T2 (orphaned responses)     — second
+      T3 (revert_failed)          — third
+      T4 (revert_failures 24h)    — fourth
+    All matching triggers still populate healthAlertReasons[],
+    but heroSub uses the first matching trigger's text.
+
+Priority 2: state 2 = 'ai_responding'
+    Fired when activeHighCriticalList.length > 0 AND no state-3
+    trigger is active.
+
+Priority 3 (lowest): state 1 = 'protection_active'
+    Default state when neither priority 1 nor 2 matches.
+```
+
+**Rationale**: without a fixed priority, a rapid refresh cycle where `/api/responses` and `/api/status` land at slightly different times could bounce the hero between state 2 and state 3 (flicker). The fixed priority guarantees that once a state-3 signal appears, it wins until all triggers clear, regardless of how many critical incidents are open. This mirrors the operator's mental model: "system health" outranks "AI activity level" — if the system is sick, that's the headline.
+
+**State 1 — AI Protection Active** (baseline)
+
+| Field | Value |
+|---|---|
+| `state` | `'protection_active'` |
+| `heroClass` | `'status-hero alert-info'` |
+| `heroIcon` | `'🛡'` |
+| `heroTitle` | `'AI Protection Active'` |
+| `heroSub` | `'All systems monitoring. AI is watching.'` |
+
+**State 2 — AI Responding to Active Threats**
+
+Tone is informational, scaled by `maxSeverity(activeHighCriticalList)` but never red.
+
+| `maxSeverity` | `heroClass` | `heroIcon` | `heroTitle` |
+|---|---|---|---|
+| critical | `'status-hero alert-high'` (orange) | `'⚡'` | `'AI Responding to Critical Activity'` |
+| high | `'status-hero alert-medium'` (amber) | `'⚡'` | `'AI Responding to High-Severity Activity'` |
+| medium | `'status-hero alert-low'` (cyan) | `'⚡'` | `'AI Responding'` |
+
+`heroSub` format: `'Processing {N} active threat{s}. No action from you.'`
+
+Where `{N}` is `activeHighCriticalList.length`. The phrase `"No action from you"` is a deliberate, repeated reassurance.
+
+**State 3 — System Health Alert**
+
+Informational red. Describes what is unusual and what the AI is doing about it. Never imperative.
+
+| Field | Value |
+|---|---|
+| `state` | `'health_alert'` |
+| `heroClass` | `'status-hero alert-critical'` |
+| `heroIcon` | `'⚠'` |
+| `heroTitle` | `'System Health Alert'` |
+| `heroSub` | `healthAlertReasons[0]` (per Change 10 trigger sub-priority) |
+
+**Risk**: medium. Centralizes state decision. Needs visual validation across transitions.
+
+### Change 3 — "Now" section (2 lines, always observational)
+
+**Where**: new section in `index.html` between `#homeHero` and the KPI row.
+
+**HTML**:
+
+```
+<section id="homeNow" class="home-section">
+  <h3>Now</h3>
+  <ul class="home-now-list">
+    <li id="homeNowWhat"></li>
+    <li id="homeNowDid"></li>
+  </ul>
+</section>
+```
+
+Exactly 2 `<li>` elements. No third. No `#homeNowTodo`. The structural absence of a third line encodes the AI-first principle: the canonical answer to "what do you need to do?" is nothing, so the question is not asked.
+
+**New JS** in `home.js`: `updateHomeNow(overview, activeHighCritical, stale)`.
+
+**Line 1 — What happened** (observational):
+
+```
+"{eventsCount} events detected in the last 24 hours."
+```
+
+Or when `eventsCount === 0`:
+
+```
+"No events detected in the last 24 hours."
+```
+
+`eventsCount` comes from `overview.events_count`.
+
+When `status.last_telemetry_secs > 120 && <= 600` (soft stale, not state 3 yet), prefix line 1 with:
+
+```
+"Telemetry is a few minutes behind. "
+```
+
+**Line 2 — What the system did** (observational + reassuring):
+
+```
+"AI contained {contained} automatically. Filtered {noise} as noise. Currently processing {active}."
+```
+
+Where:
+- `contained` = `overview.ai_responded || 0`
+- `noise` = `overview.ai_ignored || 0`
+- `active` = `activeHighCritical` (from Change 1)
+
+When all three are zero:
+
+```
+"AI is monitoring. No actions taken yet."
+```
+
+**CSS**: `.home-section`, `.home-now-list` — minimal layout. No severity tint on the Now section itself.
+
+**Risk**: low.
+
+### Change 4 — Temporal-window sub-labels on KPIs
+
+**Where**: `home.js updateHomeKpis()` and matching `index.html`.
+
+| KPI id | Sub-label | Source |
+|---|---|---|
+| `homeKpiThreats` (Threats Detected) | `Today` | `formatWindow('today')` |
+| `homeKpiResponded` (Contained) | `Today` | `formatWindow('today')` |
+| `homeKpiEvents` (Events) | `Live (today)` | literal string |
+
+**HTML**: add `<span class="kpi-window">` to each KPI card.
+
+**CSS**: `.kpi-window` — 0.65rem, `color: var(--muted)`, `white-space: nowrap`.
+
+**Risk**: low.
+
+### Change 5 — Recent Activity hierarchy (severity × outcome)
+
+**Where**: `home.js buildHomeFeed()` and `helpers.js outcomeBadgeHtml()`.
+
+**Badge rename**: in `outcomeBadgeHtml()` at `helpers.js:54-62`, change the rendered text `'OPEN'` → `'ACTIVE'`. The CSS class `badge-unresolved` stays (internal name only), but visible text and any visible label uses `ACTIVE`.
+
+**Row container class** — combination of severity AND outcome:
+
+| Severity | Outcome | Container class | Visual weight |
+|---|---|---|---|
+| critical | open | `feed-row alert-high` | prominent orange — NOT red |
+| high | open | `feed-row alert-medium` | amber |
+| medium | open | `feed-row alert-low` | cyan |
+| low / info | open | `feed-row feed-muted` | very subtle gray |
+| any | blocked / killed / contained / suspended | `feed-row feed-handled` | muted, subtle green left border |
+| any | ignored (noise) | `feed-row feed-noise` | very muted gray |
+| any | monitored | `feed-row feed-monitor` | subtle info tint |
+| any | honeypot | `feed-row feed-honeypot` | orange informational |
+
+**Critical constraint**: no row in the feed uses `.alert-critical`. Red is reserved exclusively for the hero in state 3.
+
+**Sort order** (was chronological):
+- Primary: `outcome === 'open' ? 0 : 1` — active items above handled
+- Secondary: `severityRank(effective_severity || severity)` desc
+- Tertiary: `ts` desc
+
+**Empty-state copy** when filtered list is empty:
+
+```
+"No events in view. AI is monitoring."
+```
+
+**New CSS classes**: `.feed-row`, `.feed-muted`, `.feed-handled`, `.feed-noise`, `.feed-monitor`, `.feed-honeypot`. Exact styling in implementation.
+
+**Risk**: medium. Visual weight of every feed row changes.
+
+### Change 6 — Data Collection simplification
+
+**Where**: `home.js updateCollectorStrip()` and matching `index.html`.
+
+**Fix**:
+
+1. Top line: `"{active}/{total} data sources active"`.
+2. Color by ratio:
+   - `active === total` → `.alert-info`
+   - `active / total >= 0.8` → `.alert-low`
+   - `active / total < 0.8` → `.alert-medium`
+3. `[Show details]` / `[Hide details]` toggle. Details **collapsed by default**.
+4. Expanded: render human-readable labels via new `COLLECTOR_LABELS` map in `helpers.js` (colocated with `DETECTOR_LABELS`).
+
+Proposed `COLLECTOR_LABELS`:
+
+| Slug | Label |
+|---|---|
+| `tcp_stream` | Network traffic |
+| `http_capture` | Web requests |
+| `dns_capture` | DNS lookups |
+| `tls_fingerprint` | TLS fingerprints |
+| `auth_log` | Login attempts |
+| `auditd` | System audit log |
+| `journald` | System journal |
+| `docker` | Docker events |
+| `proc_maps` | Process memory |
+| `fanotify_watch` | File changes |
+| `kernel_integrity` | Kernel integrity |
+| `cgroup_abuse` | Resource usage |
+| `ebpf_syscall` | Kernel system calls |
+| `firmware_integrity` | Firmware integrity |
+| (fallback) | `humanLabel(slug)` title-case |
+
+**Risk**: low-medium.
+
+### Change 7 — AI Briefing empty state copy
+
+**Where**: `home.js loadBriefing()` — the `else` branch when `!data.available`.
+
+**Fix**: replace the current fallback with the approved English copy:
+
+> `"No briefing yet. You're protected, and we are still monitoring. Generate a briefing now for a quick summary."`
+
+Override `data.message` on the empty case. Backend error paths (rate-limit, etc.) are unaffected.
+
+**Risk**: low.
+
+### Change 8 — `View activity` as secondary observational link
+
+**Where**: removal of the existing red inline button from `updateHomeBanner()`; addition of new subordinate links.
+
+**Fix**:
+
+1. **Remove** the inline red `Review Threats →` button at `home.js:42-46`. The hero no longer contains an action.
+2. **Add** a discreet `View activity →` link in a subordinate location (hero footer or Now section corner). Visible in all 3 states. Secondary visual weight. Consistent appearance.
+3. **Add** a second discreet `View system health →` link. Hidden in states 1 and 2. Visible only in state 3, next to `View activity`.
+4. Handler functions:
+   ```
+   function viewActivity() {
+     state.autoSelectOnThreatsOpen = 'first_critical_or_high';
+     showView('investigate');
+   }
+   function viewSystemHealth() {
+     showView('health');
+   }
+   ```
+5. The string `'first_critical_or_high'` is the **contract** with `02-threats.md`. Consume-once semantics (read-and-clear) are 02-threats.md's responsibility.
+6. Copy and visual weight: both links are small, muted underline or arrow style, same typography. Neither projects urgency.
+
+**Graceful degradation note**: when this spec lands before `03-health.md`, the `View system health →` link navigates to an unimproved Health tab that may not surface the exception context described in the hero subtitle. This is **acceptable degradation**: the hero subtitle already contains the descriptive information, the link just offers additional context that will improve once `03-health.md` lands. Documented here as a non-blocking cross-spec dependency, not a defect.
+
+**Risk**: low.
+
+### Change 9 — Home uses unified trust helpers from 00-shared
+
+**Where**: `home.js` call sites.
+
+**Fix**: verify that after 00-shared removes the `isIncidentTrusted` and `isPrivateIp` duplicates from `home.js`, all Home call sites resolve correctly to the unified `helpers.js` versions. `helpers.js` loads before `home.js` in the HTML, so resolution should be automatic. Listed as an explicit verification gate.
+
+**Risk**: low.
+
+### Change 10 — System Health Alert detection
+
+**Where**: `home.js loadHome()` adds a 5th fetch `/api/responses`. New function `detectHealthAlerts()` evaluates 4 triggers.
+
+**New fetch**:
+
+```
+loadHome() fetches now:
+  /api/status
+  /api/overview
+  /api/incidents?limit=100
+  /api/sensors
+  /api/responses         <-- new
+```
+
+**Four exception triggers** — any one fires state 3:
+
+| # | Condition | Sub-priority | Descriptive text (`healthAlertReasons` entry) |
+|---|---|---|---|
+| T1 | `status.last_telemetry_secs > 600` | 1 (highest) | `"Sensor has not reported for {X} minutes. AI is operating on cached signals."` |
+| T2 | `responsesData.state_counts.orphaned > 0` | 2 | `"{N} response(s) completed with drift. AI is retrying."` |
+| T3 | `responsesData.state_counts.revert_failed > 0` | 3 | `"{N} response revert(s) failed. AI has logged the failures."` |
+| T4 | revert failures **within the last 24 hours** > 0 | 4 (lowest) | `"Recent revert failures are recorded in the system health log."` |
+
+**T4 implementation note (backend dependency)**:
+
+T4 requires a 24h-windowed count of revert failures, not a cumulative counter. The current `responsesData.totals.revert_failures` field appears to be cumulative since agent boot — using it directly would keep Home in state 3 permanently after any historical failure, which contradicts the 3–5x/year rarity goal.
+
+Two options during implementation:
+
+- **(a)** Backend adds a new field `responsesData.totals.revert_failures_last_24h` or equivalent. T4 uses it. This is the preferred path.
+- **(b)** Backend has no 24h-windowed field yet. T4 is **disabled on Home for Phase 1** (still honored by `03-health.md` for the Health tab's cumulative view). A follow-up spec tracks adding the 24h field.
+
+The implementation chooses (a) if feasible, otherwise falls back to (b) — not a blocker for this spec. Document the choice made in the implementation commit.
+
+**State priority summary** (mirrors Change 2):
+
+```
+State 3 (health_alert)
+  T1: sensor stall   (highest sub-priority)
+  T2: orphaned
+  T3: revert_failed
+  T4: revert_failures_last_24h  (lowest sub-priority, backend-dependent)
+State 2 (ai_responding)         — only when no state-3 trigger is active
+State 1 (protection_active)     — default
+```
+
+No state transition can skip priority levels. If any state-3 trigger is active, state 2 cannot render even with `activeHighCritical > 0`.
+
+**Soft stale cue (not state 3)** for `last_telemetry_secs` in the 120–600s range:
+
+- Meta strip shows `"Data may be delayed · {X}s since last telemetry"` in amber
+- Now section line 1 is prefixed with `"Telemetry is a few minutes behind. "`
+- Hero state is still determined by the other signals (stays state 1 or 2)
+
+**Out of Phase 1**: other exception triggers (AI engine unreachable, correlation engine error, integration auth failures). Deferred.
+
+**Risk**: medium. Introduces a new state, a new fetch, and state-transition logic requiring visual validation.
+
+## Banned vocabulary in Home UI
+
+The following English terms/phrases are prohibited in any string rendered to the operator from Home (`home.js`, the Home portion of `index.html`, any Home-scoped CSS content, and `COLLECTOR_LABELS` / other shared helper strings consumed by Home):
+
+- `unresolved`
+- `open incident` (as a user-facing phrase; `outcome === 'open'` in code is fine)
+- `needs review` / `needs attention` / `needs your attention`
+- `action required` / `action needed` / `escalation required`
+- `pending` (as a noun describing operator work)
+- `awaiting` (as in "awaiting your input")
+- `manual triage` / `manual check needed`
+- `investigate now`
+- `you must` / `you need to` / `please`
+- `decide` / `take action`
+- `review` used as a verb directed at the operator (`review this`, `review the threats`)
+- Internal field names like `overview.unresolved_count` may appear in JS code (reading the backend field) — **banned only in strings rendered to the UI**.
+
+**Acceptance criterion**: a grep over `home.js`, the Home HTML block, and Home CSS — scoped to string literals and visible content — returns zero matches on this list.
+
+Approved replacements:
+
+| Banned | Approved |
+|---|---|
+| `unresolved` | `active` |
+| `open incident` | `active event` or omit |
+| `needs review` | (omit; or `being processed by AI`) |
+| `needs your attention` | (omit) |
+| `action required` / `escalation required` | (omit; operators take no action) |
+| `pending` | `active` or `processing` |
+| `manual triage` / `manual check needed` | (omit) |
+| `investigate now` | `view activity` (as a discreet link) |
+| `review threats` | `view activity` |
+| `take action` | (omit) |
+
+## Pre-implementation checks
+
+1. Confirm 00-shared is implemented and green on the working branch.
+2. Confirm `effective_severity` field is populated on `/api/incidents` responses.
+3. Confirm `status.last_telemetry_secs` is reliably bounded after sensor restart.
+4. Confirm `/api/responses` returns `state_counts.orphaned`, `state_counts.revert_failed`, `totals.revert_failures` fields.
+5. Check whether a 24h-windowed revert-failures field exists on `/api/responses`. If yes, T4 uses it (option a). If no, T4 is disabled on Home for Phase 1 (option b). Record the choice in the commit.
+6. Grep for external callers of `updateHomeBanner`, `updateHomeKpis`, `loadHome` outside `home.js`.
+7. Confirm `state.autoSelectOnThreatsOpen` is unused elsewhere in `state.js`.
+8. Confirm `outcomeBadgeHtml()` is the only place generating the `OPEN` badge text. If any page inlines the string `'OPEN'` bypassing the helper, flag for parallel update.
+9. Visual sanity check at ~390px mobile width for the proposed Now section layout.
+
+If any check fails, stop and update the spec.
+
+## Acceptance criteria
+
+### State machine
+
+- [ ] With zero open incidents and no exception triggers → hero state 1 (`alert-info`, shield, `AI Protection Active`).
+- [ ] With at least one open critical or high incident (filtered base) and no exception triggers → hero state 2 with tone scaled by `maxSeverity`: critical→`alert-high`, high→`alert-medium`, medium→`alert-low`. **Never red.**
+- [ ] State-3 triggers always outrank state-2: when T1/T2/T3/T4 and `activeHighCritical > 0` are simultaneously true, hero renders state 3.
+- [ ] State-3 sub-priority: T1 > T2 > T3 > T4. The displayed `heroSub` is the text of the highest-priority active trigger.
+- [ ] State transitions do not flicker across rapid refresh cycles — a single `loadHome()` result determines the state deterministically based on priority order.
+- [ ] `status.last_telemetry_secs > 600` → state 3 with sensor-stall subtitle.
+- [ ] `responsesData.state_counts.orphaned > 0` → state 3 with drift subtitle (when T1 is not active).
+- [ ] `responsesData.state_counts.revert_failed > 0` → state 3 with revert-failed subtitle (when T1/T2 are not active).
+- [ ] If T4 is enabled (option a), `revert_failures_last_24h > 0` → state 3 with the recent-failures subtitle (when T1/T2/T3 are not active).
+- [ ] If T4 is disabled (option b), past cumulative failures never fire a state 3 on Home.
+
+### Banner/feed consistency
+
+- [ ] `activeHighCritical` count used by the hero and Now section line 2 equals exactly the number of `active` items in the Recent Activity feed with severity critical or high.
+- [ ] Toggling `hideAllowlisted` on/off keeps `activeHighCritical` and feed count exactly synchronized.
+- [ ] No allowlisted incident is counted in `activeHighCritical` or shown in the feed when the toggle is on.
+
+### Copy and tone
+
+- [ ] No string visible to the operator on Home contains any banned term listed in the "Banned vocabulary" section.
+- [ ] The word `ACTIVE` appears in the feed badges where `OPEN` used to; the class `badge-unresolved` is still used internally in CSS.
+- [ ] The phrase `"No action from you"` or equivalent reassurance appears in state 2's hero subtitle.
+- [ ] AI Briefing empty-state copy matches exactly the approved text in Change 7.
+
+### Now section
+
+- [ ] Exactly 2 `<li>` elements (`#homeNowWhat`, `#homeNowDid`). No third line element exists in the DOM.
+- [ ] Line 1 uses `overview.events_count`, not incident counts.
+- [ ] Line 2 names "AI" as the subject of the sentence.
+- [ ] When `last_telemetry_secs > 120 && <= 600`, line 1 is prefixed with `"Telemetry is a few minutes behind. "`.
+
+### KPIs
+
+- [ ] Each KPI card shows a sub-label: `Today`, `Today`, `Live (today)` in that order.
+- [ ] No KPI is rendered as a raw number without a window indication.
+
+### Recent Activity
+
+- [ ] Open items sort above contained items regardless of timestamp.
+- [ ] Within open items, sort by severity desc, then ts desc.
+- [ ] Open critical row uses `.alert-high` (orange), NOT `.alert-critical`.
+- [ ] No row in `#homeFeed` uses `.alert-critical`.
+- [ ] Contained rows use `.feed-handled` (muted, no severity tint).
+- [ ] Noise rows use `.feed-noise` (very muted).
+- [ ] Empty-state copy reads `"No events in view. AI is monitoring."`
+
+### Data Collection
+
+- [ ] Top line: `"{active}/{total} data sources active"`.
+- [ ] Details collapsed by default; expand shows human-labeled rows from `COLLECTOR_LABELS`.
+- [ ] No raw collector slug visible without expansion.
+
+### Observation links
+
+- [ ] No red inline button in the hero in any state.
+- [ ] `View activity →` link visible in all 3 states, subordinate visual weight.
+- [ ] `View system health →` link hidden in states 1 and 2, visible in state 3.
+- [ ] Clicking `View activity` sets `state.autoSelectOnThreatsOpen = 'first_critical_or_high'` and navigates to Threats.
+- [ ] After Threats consumes the flag (per `02-threats.md`), `state.autoSelectOnThreatsOpen === null`.
+
+### Global
+
+- [ ] Zero new console errors on Home / Threats / Health / Intel.
+- [ ] `git diff` on this spec's commit shows changes only in `home.js`, `index.html`, `helpers.js`, and `app.css`.
+- [ ] Your wife, on a fresh Home load, describes the state in her own words as "calm" / "nothing to worry about" / "system is handling things". **Observational validation.**
+
+## Verification
+
+### Local (before deploy)
+
+1. `make build`
+2. Open dashboard locally, devtools console:
+   - `typeof computeHomeState === 'function'` → `true`
+   - `typeof updateHomeNow === 'function'` → `true`
+   - `typeof viewActivity === 'function'` → `true`
+   - `typeof viewSystemHealth === 'function'` → `true`
+   - `typeof COLLECTOR_LABELS === 'object'` → `true`
+3. Inject state variations via devtools:
+   - Empty incident list + healthy responses → state 1 (`alert-info`, shield, `AI Protection Active`)
+   - Single critical open incident → state 2 (`alert-high`, `AI Responding to Critical Activity`, `No action from you`)
+   - Single medium open incident → state 2 (`alert-low`, `AI Responding`)
+   - `last_telemetry_secs = 700` → state 3 (`alert-critical`, sensor-stall subtitle)
+   - `responsesData.state_counts.orphaned = 2` AND no stall → state 3, orphan subtitle
+   - Both stall AND orphan active → state 3, **stall subtitle** (priority T1 wins)
+4. Verify banned-vocabulary grep on loaded Home source → zero matches.
+5. Toggle `hideAllowlisted` — banner count and feed count stay equal.
+6. Click `View activity` — confirm `state.autoSelectOnThreatsOpen === 'first_critical_or_high'`.
+7. In state 1, confirm `View system health` link is hidden; `View activity` is still present.
+8. Navigate all 4 tabs — zero console errors.
+9. Visual check at ~390px mobile width.
+
+### Post-deploy (prod at `130.162.171.105`)
+
+1. Fresh Home load. Take a screenshot for side-by-side comparison with the 2026-04-11 baseline.
+2. Confirm hero is in state 1 or 2, NOT red, when the incident mix is normal.
+3. Confirm Now section has exactly 2 lines, observational, AI-first language.
+4. Confirm KPI sub-labels present and match the fixed mapping.
+5. Confirm Recent Activity hierarchy visible; no red rows; ACTIVE badge instead of OPEN.
+6. Confirm Data Collection summary line; details collapsed by default.
+7. Confirm AI Briefing empty copy matches.
+8. SSH in, `sudo systemctl stop innerwarden-sensor`. Wait ~12 minutes. Refresh Home — confirm hero transitions to state 3 red `System Health Alert` with sensor-stall subtitle and `View system health` link visible. Restart sensor. Confirm hero returns to state 1/2 within the next load cycle.
+9. Zero new console errors across all 4 tabs.
+
+### Rollback
+
+Single-commit revert. No state, DB, or migration touched. File-level revert sufficient.
+
+## Post-rollout notes
+
+- **Primary validation is observational**: ask your wife to describe what she sees on Home. If her words are any form of "something is wrong, I should do X", iterate on copy and visual weight BEFORE declaring done. No automated metric substitutes for this.
+- **Philosophical guard**: any future edit to Home that re-introduces imperative-voice copy or a primary red CTA outside state 3 should be rejected at review time. The AI-first tone is the deliverable, not a style preference.
+- **Cross-spec contracts**:
+  - `state.autoSelectOnThreatsOpen = 'first_critical_or_high'` is a dead write unless `02-threats.md` implements the read-and-clear. If `02-threats.md` is delayed, `View activity` still navigates (graceful degradation).
+  - `View system health →` link in state 3 navigates to Health tab. Before `03-health.md` lands, the Health tab may not surface the exception context. Acceptable degradation — hero subtitle already carries the description.
+- **Threshold tuning**: the `last_telemetry_secs` thresholds (120s soft, 600s state 3) are empirical starting points. Tune after a week of observation.
+- **State 3 frequency target**: with a healthy install, state 3 should fire **fewer than 5 times per year**. If it starts firing multiple times per week, that is itself a signal that something in the backend is unstable — fix the backend, do not raise the thresholds.
+- **T4 backend dependency**: if option (b) is chosen (T4 disabled), track as a follow-up spec to add a 24h-windowed revert-failures field on `/api/responses`. Health tab still uses cumulative for its own views.
+
+---
+
+## Implementation commit message (draft)
+
+```
+feat(dashboard): Home tab AI-first operator UX (spec 017 Phase 1, 01-home)
+
+Restructure Home around the product principle "the operator ideally
+never needs to decide anything". The AI is the subject of every
+sentence; the operator reads state, never receives commands. Red
+color is reserved for the rare System Health Alert state; everything
+else is calm or informationally scaled.
+
+State machine (new computeHomeState() in home.js):
+- State 1: AI Protection Active (baseline, .alert-info, shield icon)
+- State 2: AI Responding to Active Threats (scaled .alert-low through
+  .alert-high by maxSeverity; orange maximum, never red; subtitle
+  always includes "No action from you")
+- State 3: System Health Alert (.alert-critical, only for sensor
+  stall >600s, response drift, revert failure; descriptive subtitle,
+  observational not imperative)
+
+Fixed state priority to prevent flicker:
+  state 3 (T1 > T2 > T3 > T4) > state 2 > state 1
+
+Home no longer contains any demand/imperative copy. A banned-
+vocabulary grep is part of acceptance criteria. Words removed
+from UI: unresolved, open incident, needs review, needs attention,
+action required, escalation required, pending, awaiting,
+manual triage, manual check needed, investigate now, you must,
+take action, review (as verb directed at operator).
+
+- Rename openHighCritical -> activeHighCritical in home.js
+- Fix computation to use effective_severity and the same
+  trust-filtered base as Recent Activity
+- New "Now" section with 2 lines only (What happened / What the
+  system did); no "what you need to do" line, ever
+- Fixed temporal KPI sub-labels: Today / Today / Live (today)
+- Recent Activity rows use severity x outcome hierarchy; open+critical
+  maps to .alert-high (orange) NOT .alert-critical; no feed row uses
+  red; OPEN badge text renamed to ACTIVE in helpers.js
+- Data Collection simplified: N/M summary line + collapsed details
+  with human-readable COLLECTOR_LABELS from helpers.js
+- AI Briefing empty state copy: "No briefing yet. You're protected,
+  and we are still monitoring. Generate a briefing now for a quick
+  summary."
+- Remove red inline Review Threats button; add secondary discreet
+  "View activity" link (always present) and "View system health"
+  link (only in state 3)
+- Add 5th fetch /api/responses in loadHome() for System Health
+  Alert detection; 4 triggers with fixed sub-priority
+- T4 (recent revert failures) uses 24h window, not cumulative;
+  if backend lacks a 24h field, T4 is disabled on Home for Phase 1
+  and tracked as follow-up
+- Home call sites use unified isIncidentTrusted/isPrivateIp from
+  helpers.js (already deleted by 00-shared)
+
+Validation is perceptual (observational with the primary operator),
+not metric-based. State 3 is expected to fire fewer than 5 times
+per year in a healthy install.
+
+Depends on: .specify/features/017-dashboard-operator-ux/pages/00-shared.md
+Ref: .specify/features/017-dashboard-operator-ux/pages/01-home.md
+```

--- a/.specify/features/017-dashboard-operator-ux/pages/02-threats.md
+++ b/.specify/features/017-dashboard-operator-ux/pages/02-threats.md
@@ -1,0 +1,47 @@
+# Spec 02 — Threats Tab (AI Audit Trail)
+
+**Parent**: `../spec.md`
+**Phase**: 1
+**Depends on**: `00-shared.md`, `01-home.md`
+**Status**: Implementation
+
+## Product philosophy
+
+**Threats is not a triage queue. Threats is an audit trail.**
+
+The operator installed an AI agent to handle security autonomously. The AI decides and acts. There is no human in the decision loop except in extreme cases (0-5 times per year). Therefore:
+
+- There is no "OPEN" status. Every threat has a decided state.
+- The operator reads outcomes, not work items.
+- The primary grouping is by OUTCOME (what the AI did), not by detector (what was found).
+- "Needs your attention" exists but should ideally always show 0.
+
+## Outcome model
+
+| Outcome | Meaning | Operator action | Frequency |
+|---------|---------|-----------------|-----------|
+| **Blocked** | AI blocked with high confidence | None. See that it worked. | Several/day |
+| **Honeypot** | AI redirected to honeypot for intel | None. Can inspect sessions. | Some/day |
+| **Observing** | AI collecting more data before deciding | None. AI decides on its own. | Some/day |
+| **Dismissed** | AI evaluated and discarded (noise, FP, low risk) | None. Audit trail only. | Majority |
+| **Needs attention** | AI genuinely needs human input | Only case requiring action. | 0-5/year |
+
+The old statuses `open` and `active` map to **Observing** — the AI is processing, not demanding operator action.
+
+## Scope
+
+**In scope**:
+- Regroup entity list by outcome instead of by detector
+- Outcome-first KPIs: "Blocked" / "Observing" / "Needs attention" with temporal labels
+- Hero state aligned with 01-home 3-state system
+- Badge rename: OPEN → removed, ACTIVE → OBSERVING
+- Home → Threats navigation pre-selects highest-priority item
+- Section title: "Defense Activity" → "AI Defense Log"
+- Guidance summary at top of journey: "What happened / What the AI did"
+
+**Out of scope**:
+- Backend changes to outcome computation
+- Mobile layout (separate PR)
+- "Needs attention" escalation logic (requires AI confidence threshold — future work)
+- Full journey rewrite
+- Internationalization

--- a/.specify/features/017-dashboard-operator-ux/spec.md
+++ b/.specify/features/017-dashboard-operator-ux/spec.md
@@ -1,0 +1,127 @@
+# Feature Specification: Dashboard Operator UX and QA Reliability
+
+**Feature Branch**: `017-dashboard-operator-ux`  
+**Created**: 2026-04-11  
+**Status**: Draft  
+**Origin**: Originally authored as `001-dashboard-operator-ux` in the monorepo-level `_innerwarden/specs/` directory on 2026-04-11. Moved into `innerwarden/.specify/features/` the same day and renamed to the `017-` slot to avoid collision with the pre-existing `001-telegram-interactive-triage` feature. **Internal feature lineage is 001; operational slot in this repo is 017.** All internal references (per-page specs under `pages/`, commit messages, the git branch, the `CLAUDE.md` features table) use `017-dashboard-operator-ux` to match the on-disk path.  
+**Input**: User description: "Revisao QA inicial e UX profunda do dashboard para dois perfis de operador (esposa foco Home/Threats/Health/Intel e marido tecnico eventual), priorizando nao assustar sem gravidade, nao deixar usuario perdido e corrigir inconsistencias de estado e entendimento operacional"
+
+## User Scenarios & Testing *(mandatory)*
+
+
+### User Story 1 - Operadora entende risco atual sem se assustar (Priority: P1)
+
+Como operadora principal (esposa), eu quero abrir a Home e entender em poucos segundos o que esta acontecendo, o que ja foi tratado e o que precisa da minha atencao, para manter o controle sem entrar em panico.
+
+**Why this priority**: Esta e a jornada mais frequente e mais critica para operacao diaria. Se falhar, a usuaria perde confianca e pode ignorar risco real ou reagir exageradamente.
+
+**Independent Test**: Pode ser testada integralmente apenas na Home com dados reais e simulados, validando leitura do estado, proximos passos e tom da mensagem.
+
+**Acceptance Scenarios**:
+
+1. **Given** que existem ameacas abertas de severidade alta ou critica, **When** a usuaria abre a Home, **Then** ela ve um resumo claro de risco atual, acao recomendada e prioridade sem contradicoes entre contador, banner e lista recente.
+2. **Given** que nao existem ameacas graves ativas, **When** a usuaria abre a Home, **Then** a interface usa tom informativo (nao alarmista), explicando que o sistema esta monitorando e o que foi contido.
+3. **Given** dados de alta variacao temporal, **When** a usuaria consulta os KPIs, **Then** cada numero exibe contexto de janela temporal para evitar interpretacao errada.
+
+---
+
+### User Story 2 - Operadora navega para investigacao sem se perder (Priority: P1)
+
+Como operadora principal (esposa), eu quero sair de Home para Threats e chegar no detalhe certo com orientacao de proximo passo, para agir com seguranca mesmo sem perfil tecnico profundo.
+
+**Why this priority**: Mesmo com uma Home clara, a jornada quebra se a usuaria nao souber onde clicar ou onde comecar ao entrar em Threats.
+
+**Independent Test**: Pode ser testada com fluxo direto Home -> Review Threats -> Threats -> detalhe de ameaca, sem depender de Health/Intel.
+
+**Acceptance Scenarios**:
+
+1. **Given** que existe pelo menos uma ameaca ativa prioritaria, **When** a usuaria clica em "Review Threats" na Home, **Then** ela chega em Threats com item prioritario selecionado ou claramente destacado para iniciar investigacao.
+2. **Given** que a usuaria ja esta no detalhe de ameaca, **When** ela consulta o topo da tela, **Then** ela entende em linguagem simples status atual, nivel de urgencia e acao recomendada.
+3. **Given** que a usuaria usa mobile, **When** ela navega entre Home e Threats, **Then** o conteudo critico permanece legivel sem cortar informacao essencial.
+
+---
+
+### User Story 3 - Parceiro tecnico valida diagnostico rapidamente (Priority: P2)
+
+Como operador tecnico eventual (marido), eu quero consultar Health e Intel com profundidade e confianca de que os textos refletem o estado operacional real, para apoiar decisoes sem ruído.
+
+**Why this priority**: O apoio tecnico e ocasional, mas decisivo em momentos de risco alto e em ajustes de confiabilidade.
+
+**Independent Test**: Pode ser testada com navegacao direta em Health e Intel, verificando coerencia entre mensagem exibida e estado operacional.
+
+**Acceptance Scenarios**:
+
+1. **Given** que nao houve acao de bloqueio executada recentemente, **When** o operador consulta Health, **Then** a mensagem principal nao afirma bloqueio ativo em tempo real sem evidencia correspondente.
+2. **Given** que Intel possui grande volume de dados, **When** o operador tecnico acessa a aba em desktop ou mobile, **Then** ele consegue interpretar os dados sem erro funcional e com estrutura legivel.
+3. **Given** que existe discrepancia de dados entre fontes, **When** o operador tecnico navega pelas telas, **Then** o sistema sinaliza estado possivelmente desatualizado em vez de mostrar informacao contraditoria.
+
+---
+
+### User Story 4 - Qualidade de dados e UX monitoradas continuamente (Priority: P2)
+
+Como equipe de produto e operacao, queremos regras de QA funcional e UX para evitar regressao de consistencia, tom e orientacao ao usuario, para manter confianca ao longo do tempo.
+
+**Why this priority**: Reduz retrabalho e impede regressao em correcoes que ja foram entregues.
+
+**Independent Test**: Pode ser testada por checklist objetiva com criterios de consistencia, navegacao e legibilidade por perfil.
+
+**Acceptance Scenarios**:
+
+1. **Given** uma nova versao do dashboard, **When** a bateria de revisao QA/UX e executada, **Then** inconsistencias criticas entre estado de risco e mensagens sao identificadas antes de considerar a versao pronta.
+2. **Given** o perfil da esposa como primario, **When** a revisao de UX e executada, **Then** o fluxo Home/Threats/Health/Intel nao deixa a usuaria perdida e nao usa tom alarmista sem gravidade real.
+
+### Edge Cases
+
+- Contadores e banners divergem durante picos de atualizacao (ex.: Home indica risco resolvido enquanto lista mostra ameacas abertas).
+- Nao ha eventos novos, mas o ultimo estado foi grave; a interface precisa evitar alarme residual sem ocultar historico relevante.
+- Existem muitas ameacas em pouco tempo; a usuaria precisa ver prioridade e acao em vez de lista caotica.
+- Dados de telemetria ficam temporariamente atrasados; o sistema deve comunicar possivel defasagem sem quebrar fluxo.
+- Em mobile, tabelas extensas (especialmente Intel) ultrapassam largura da tela e escondem colunas essenciais.
+- Operadora abre Threats via CTA e nao encontra detalhe selecionado automaticamente, gerando duvida sobre o proximo passo.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: O dashboard MUST apresentar estado de risco consistente entre Home, Threats, Health e Intel para o mesmo momento de observacao.
+- **FR-002**: O dashboard MUST evitar mensagens alarmistas quando nao houver gravidade alta ou critica ativa.
+- **FR-003**: O dashboard MUST escalar tom e destaque visual de acordo com gravidade operacional real, com niveis distintos de informativo, atencao e urgente.
+- **FR-004**: A Home MUST mostrar um resumo operacional com tres respostas explicitas: o que aconteceu, o que ja foi tratado e o que precisa ser feito agora.
+- **FR-005**: A Home MUST oferecer caminho direto para investigacao quando houver pendencias relevantes.
+- **FR-006**: O fluxo Home -> Threats MUST levar a operadora para uma lista priorizada e com proximo passo claro.
+- **FR-007**: Threats MUST apresentar detalhe de incidente com status atual, contexto minimo e acao recomendada em linguagem compreensivel para operador nao tecnico.
+- **FR-008**: Health MUST refletir capacidade de resposta real, evitando afirmar acao automatica sem evidencia operacional correspondente.
+- **FR-009**: Intel MUST permanecer funcional em todas as subabas, sem erro de carregamento e sem degradar leitura essencial.
+- **FR-010**: Intel em mobile MUST expor dados prioritarios de forma legivel, mesmo quando houver muitas colunas ou grande volume.
+- **FR-011**: KPIs de alto impacto MUST exibir janela temporal ou referencia de atualizacao para reduzir interpretacao ambigua.
+- **FR-012**: O dashboard MUST indicar quando informacoes estao possivelmente defasadas ou em sincronizacao parcial.
+- **FR-013**: A interface MUST preservar acessibilidade basica de navegacao por teclado em elementos interativos principais.
+- **FR-014**: O sistema MUST suportar dois perfis de leitura: operador principal (resumo orientado a acao) e operador tecnico (diagnostico detalhado).
+- **FR-015**: Cada release MUST ser validada por checklist de QA e UX voltada aos fluxos Home, Threats, Health e Intel.
+
+### Key Entities *(include if feature involves data)*
+
+- **Operator Profile**: Representa tipo de usuario (operadora principal ou suporte tecnico), com necessidade de profundidade e linguagem diferentes.
+- **Operational Risk Snapshot**: Estado consolidado do momento, contendo severidade, quantidade de pendencias, tratativas realizadas e nivel de urgencia recomendado.
+- **Threat Investigation Context**: Conjunto de informacoes de investigacao exibidas no Threats, incluindo status da ameaca, narrativa curta, proximos passos e evidencias principais.
+- **Health Capability State**: Estado operacional das capacidades de protecao e resposta, incluindo disponibilidade, efetividade recente e confiabilidade percebida.
+- **Intel View State**: Estado de visualizacao de inteligencia com foco em legibilidade, filtros e acesso a dados prioritarios por dispositivo.
+- **UX Guidance Block**: Bloco textual orientado a acao que descreve o que o usuario deve fazer agora sem sobrecarga cognitiva.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Em cenarios com risco ativo, a operadora principal identifica estado atual e proxima acao em ate 30 segundos em 90% dos testes guiados.
+- **SC-002**: Inconsistencias criticas entre estado exibido na Home e estado de ameacas abertas sao reduzidas a 0 ocorrencias nos testes de regressao.
+- **SC-003**: Em validacao mobile, 100% das informacoes prioritarias de Home, Threats, Health e Intel permanecem legiveis sem perda de entendimento da acao recomendada.
+- **SC-004**: Em revisao com usuarios alvo, pelo menos 85% classificam a comunicacao de risco como clara e nao alarmista quando nao ha gravidade critica ativa.
+- **SC-005**: O fluxo Home -> Threats permite chegar ao contexto de investigacao inicial em no maximo 2 interacoes em 95% dos cenarios de teste.
+
+## Assumptions
+
+- O servidor e de capacidade basica, portanto mensagens e fluxo devem priorizar clareza e estabilidade de leitura em vez de densidade visual excessiva.
+- A esposa e a operadora principal e acessa regularmente Home, Threats, Health e Intel; o marido acessa de forma ocasional para apoio tecnico.
+- O projeto mantera os quatro modulos principais como superfice de operacao prioritaria no curto prazo.
+- A experiencia deve funcionar em desktop e mobile sem exigir treinamento tecnico formal para a operadora principal.
+- A consistencia de estado entre telas e fonte de dados e requisito funcional, nao apenas melhoria estetica.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,6 +110,8 @@ ADR: `docs/internal/adr/0001-project-taxonomy.md`
 | 010 | Detector Migration (Phase 3) | **3A-3C Done**: 27 graph detectors + 10 correlation rules + dedup + config flag. 3D partial (metrics deferred). 29 tests. |
 | 013 | Graph Single Source of Truth (Phase 7) | **COMPLETE** (Gaps 1,2,4,5 done). Daily dated snapshots, FP tracking in graph, monthly report from snapshots, 6h window from event_timeline. Gap 3 deferred (telemetry stays JSONL by design). |
 | 014 | Graph Full Connectivity | **COMPLETE** (Phases A-D + leftover). 8 → 18 active relations. tcp_stream/eBPF/memory/cgroup/incident-PID all ingested. Bug fixes: missing `--features ebpf` flag, filename/path field mismatch, 200MB JSONL cap dropping events. Edges 12K → 33K, Process nodes 411 → 4470. |
+| 016 | Unified SQLite Store | **Draft** P0 release blocker. Replaces JSONL + redb + JSON snapshots with single `innerwarden.db`. Fixes silent-drop compliance bug. 10-day work, 14 maintenance tasks, 5 long-running tests. Spec only, no plan/tasks yet. |
+| 017 | Dashboard Operator UX | **Draft** P1. Two personas (primary operator + technical fallback). 15 FRs covering state consistency, non-alarmist tone, mobile legibility, stale-data indicators. Spec validated, no plan yet. |
 
 ## Divida tecnica
 

--- a/crates/agent/src/briefing.rs
+++ b/crates/agent/src/briefing.rs
@@ -89,19 +89,38 @@ pub fn build_briefing_context(kg: &Arc<RwLock<KnowledgeGraph>>) -> String {
                     contained += 1;
                 }
                 None => {
-                    unresolved += 1;
-                    let sev = severity.to_lowercase();
-                    if sev == "high" || sev == "critical" {
-                        unresolved_high_crit += 1;
-                        let entity = graph
-                            .outgoing_edges(id)
+                    // Check if this "unresolved" incident only involves
+                    // self-traffic IPs — if so, it's a pre-fix FP that
+                    // wasn't marked research_only. Don't count it as
+                    // needing attention.
+                    let entities: Vec<String> = graph
+                        .outgoing_edges(id)
+                        .iter()
+                        .filter(|e| e.relation == Relation::TriggeredBy)
+                        .filter_map(|e| graph.get_node(e.to))
+                        .filter_map(|n| {
+                            if let Node::Ip { addr, .. } = n {
+                                Some(addr.clone())
+                            } else {
+                                None
+                            }
+                        })
+                        .collect();
+                    let all_self = !entities.is_empty()
+                        && entities
                             .iter()
-                            .find(|e| e.relation == Relation::TriggeredBy)
-                            .and_then(|e| graph.get_node(e.to))
-                            .map(|n| n.label())
-                            .unwrap_or_default();
-                        if unresolved_list.len() < 10 {
-                            unresolved_list.push((sev, title.clone(), entity));
+                            .all(|ip| crate::cloud_safelist::is_self_traffic_ip(ip));
+                    if all_self {
+                        ignored += 1; // Treat as noise for briefing purposes
+                    } else {
+                        unresolved += 1;
+                        let sev = severity.to_lowercase();
+                        if sev == "high" || sev == "critical" {
+                            unresolved_high_crit += 1;
+                            let entity = entities.first().cloned().unwrap_or_default();
+                            if unresolved_list.len() < 10 {
+                                unresolved_list.push((sev, title.clone(), entity));
+                            }
                         }
                     }
                 }
@@ -176,27 +195,43 @@ pub fn build_briefing_context(kg: &Arc<RwLock<KnowledgeGraph>>) -> String {
         "LOW"
     };
 
+    // Count unique blocked IPs (not decisions — matches dashboard KPI)
+    let blocked_ips: std::collections::HashSet<&str> = actions_taken
+        .iter()
+        .filter_map(|a| {
+            if a.starts_with("Blocked IP ") {
+                a.split_whitespace().nth(2)
+            } else {
+                None
+            }
+        })
+        .collect();
+
     // Build context
-    let total = incident_nodes.len();
+    let operator_incidents = contained + unresolved; // excludes research_only
     let mut ctx = format!(
         "SECURITY INTELLIGENCE CONTEXT — {}\n\n\
          SITUATION STATUS:\n\
-         - Total incidents today: {}\n\
-         - CONTAINED (AI blocked/monitored/responded): {} — these are RESOLVED, not active threats\n\
-         - IGNORED by AI (noise/false positives): {} — confirmed non-threats\n\
-         - UNRESOLVED (no AI decision yet): {} — of which {} are high/critical severity\n\
-         - The system is in GUARD mode: AI auto-blocks high-confidence threats\n\n\
-         IMPORTANT: {} of {} incidents are already handled. The system is actively defending.\n\
-         Only {} incident{} need{} human attention.\n\n",
+         - Operator-relevant incidents today: {}\n\
+         - BLOCKED: {} unique IP{} auto-blocked by AI\n\
+         - OBSERVING: {} incidents being monitored (AI is handling, no human action needed)\n\
+         - IGNORED: {} confirmed non-threats\n\
+         - The server uses SSH key-only authentication — password brute-force cannot succeed\n\
+         - Most external activity is routine internet scanning that fails at protocol level\n\n\
+         IMPORTANT: The AI is handling everything. {} of {} incidents are already resolved or being monitored.\n\
+         Human attention needed: {}.\n\n",
         Utc::now().format("%Y-%m-%d"),
-        total,
-        contained,
+        operator_incidents,
+        blocked_ips.len(),
+        if blocked_ips.len() == 1 { "" } else { "s" },
+        unresolved,
         ignored,
-        unresolved, unresolved_high_crit,
-        contained + ignored, total,
-        unresolved_high_crit,
-        if unresolved_high_crit == 1 { "" } else { "s" },
-        if unresolved_high_crit == 1 { "s" } else { "" },
+        contained + unresolved, operator_incidents,
+        if unresolved_high_crit == 0 {
+            "NONE — everything is handled".to_string()
+        } else {
+            format!("{} high/critical items to review", unresolved_high_crit)
+        },
     );
 
     if !actions_taken.is_empty() {

--- a/crates/agent/src/briefing.rs
+++ b/crates/agent/src/briefing.rs
@@ -44,9 +44,16 @@ pub fn build_briefing_context(kg: &Arc<RwLock<KnowledgeGraph>>) -> String {
             decision,
             decision_target,
             auto_executed,
+            research_only,
             ..
         }) = graph.get_node(id)
         {
+            // Skip research-only incidents — these are self-traffic (agent
+            // notifications, cloud metadata, CrowdSec polling) that pollute
+            // the briefing with false "threats" like Telegram API IPs.
+            if *research_only {
+                continue;
+            }
             *by_detector.entry(detector.clone()).or_default() += 1;
             *by_severity.entry(severity.to_lowercase()).or_default() += 1;
 
@@ -110,9 +117,13 @@ pub fn build_briefing_context(kg: &Arc<RwLock<KnowledgeGraph>>) -> String {
             detector,
             decision,
             decision_target,
+            research_only,
             ..
         }) = graph.get_node(inc_id)
         {
+            if *research_only {
+                continue;
+            }
             for edge in graph.outgoing_edges(inc_id) {
                 if edge.relation != Relation::TriggeredBy {
                     continue;
@@ -123,7 +134,12 @@ pub fn build_briefing_context(kg: &Arc<RwLock<KnowledgeGraph>>) -> String {
                 {
                     if *is_internal {
                         continue;
-                    } // Skip server's own IPs
+                    }
+                    // Skip self-traffic IPs (cloud providers, agent services,
+                    // local interfaces) — same filter as investigation.rs
+                    if crate::cloud_safelist::is_self_traffic_ip(addr) {
+                        continue;
+                    }
                     let entry = ip_data
                         .entry(addr.clone())
                         .or_insert((0, Vec::new(), false));
@@ -241,24 +257,28 @@ pub fn build_briefing_context(kg: &Arc<RwLock<KnowledgeGraph>>) -> String {
 /// The LLM prompt for generating the briefing.
 pub fn briefing_prompt(context: &str) -> String {
     format!(
-        "You are a senior security analyst writing a daily briefing for a server operator.\n\
+        "You are the AI security agent writing a daily briefing for a non-technical server operator.\n\
+         \n\
+         This server is protected by InnerWarden — an autonomous AI security agent that blocks \
+         threats automatically. The operator does NOT need to take action on most items. \
+         SSH uses key-only authentication (password login disabled). Most activity from \
+         external IPs is routine internet scanning that fails at the protocol level.\n\
          \n\
          CRITICAL RULES:\n\
-         - Incidents marked CONTAINED are RESOLVED — do NOT treat them as active threats\n\
-         - Incidents marked IGNORED are confirmed noise — do NOT recommend action on them\n\
-         - Only UNRESOLVED incidents need attention\n\
-         - IPs marked [ALREADY BLOCKED] are handled — do NOT recommend blocking them again\n\
-         - Internal IPs (10.x, 192.168.x, 127.x) are the server itself — NOT attackers\n\
-         - The system AUTO-BLOCKS threats. Most detections are already handled.\n\
+         - CONTAINED/BLOCKED items are RESOLVED — present them as success, not active threats\n\
+         - IGNORED items are confirmed noise — do not mention them\n\
+         - UNRESOLVED items are being OBSERVED by the AI — only flag if genuinely dangerous\n\
+         - Routine scanners (SSH malformed strings, port probes) are NOT dangerous and NOT urgent\n\
+         - Do NOT recommend 'updating passwords' or generic security advice\n\
+         - Be reassuring when the server is safe. Be direct only when something is genuinely dangerous.\n\
+         - Write for someone who is NOT a security professional\n\
          \n\
-         Write a concise briefing with these sections:\n\
-         1. **THREAT LEVEL** — one word + one sentence. Base it on UNRESOLVED count, not total.\n\
-         2. **EXECUTIVE SUMMARY** — 2-3 sentences. Be accurate about what's resolved vs active.\n\
-         3. **WHAT WAS HANDLED** — bullet list of AI actions taken (blocks, kills, monitors)\n\
-         4. **NEEDS ATTENTION** — only UNRESOLVED high/critical threats with specific actions\n\
-         5. **RECOMMENDATIONS** — 2-3 actionable steps for TODAY\n\
+         Write a SHORT briefing (under 150 words) with:\n\
+         1. **STATUS** — one sentence: is the server safe right now?\n\
+         2. **WHAT THE AI DID** — 2-3 bullets of actions taken (blocks, monitoring)\n\
+         3. **NEEDS ATTENTION** — only if something genuinely requires human decision (rare)\n\
          \n\
-         Be accurate. Do not exaggerate. If most threats are contained, say so.\n\
+         Tone: calm, confident, specific. Like a trusted security guard giving a morning report.\n\
          \n\
          ---\n\
          \n\

--- a/crates/agent/src/cloud_safelist.rs
+++ b/crates/agent/src/cloud_safelist.rs
@@ -46,6 +46,13 @@ impl CidrRange {
 static CLOUD_RANGES: OnceLock<Vec<CidrRange>> = OnceLock::new();
 static CLOUD_PROVIDER_COUNT: OnceLock<usize> = OnceLock::new();
 
+/// Local interface IPs of the host the agent runs on (eth0, bond0, etc.).
+/// Populated at startup via `init_local_interface_ips()`. Traffic with
+/// src_ip == one of these is the host itself talking to the outside world,
+/// which in incidents like "Packet flood from 10.0.0.238" is the server's
+/// own VPC IP misclassified as an attacker.
+static LOCAL_INTERFACE_IPS: OnceLock<Vec<u32>> = OnceLock::new();
+
 /// Cloudflare IPv4 ranges (from https://www.cloudflare.com/ips-v4).
 /// Updated 2026-04-01. These rarely change.
 const CLOUDFLARE_RANGES: &[&str] = &[
@@ -78,6 +85,18 @@ const AGENT_SERVICE_RANGES: &[&str] = &[
     "91.108.4.0/22",
     "91.108.56.0/22",
     "95.161.64.0/20",
+    // CrowdSec CAPI (cloud threat intelligence API) — hosted on AWS
+    // eu-west-1. The local CrowdSec agent (pid crowdsec, uid 0) polls
+    // these IPs for community blocklists and pushes local decisions.
+    // Observed 2026-04-12: 6 AWS eu-west-1 IPs appearing as
+    // "Cross-layer chain: Cryptominer Deployment Chain" because the
+    // correlation engine saw crowdsec outbound + CPU spike = CL-014 FP.
+    // CrowdSec uses an ELB that rotates across the /16, so we safelist
+    // the ranges that the eu-west-1 ELBs live in.
+    "52.48.0.0/14",   // AWS eu-west-1 ELB range (covers 52.48-51.x)
+    "63.32.0.0/14",   // AWS eu-west-1 ELB range (covers 63.32-35.x)
+    "18.200.0.0/14",  // AWS eu-west-1 ELB range (covers 18.200-203.x)
+    "3.248.0.0/13",   // AWS eu-west-1 ELB range (covers 3.248-255.x)
     // ip-api.com (GeoIP enrichment used by crate::geoip)
     "208.95.112.0/24",
     // Canonical / Ubuntu archive + snapcraft + livepatch
@@ -95,8 +114,22 @@ const AGENT_SERVICE_RANGES: &[&str] = &[
 const ORACLE_PEER_RANGES: &[&str] = &[
     "138.1.16.0/22",    // OCI peer range
     "140.91.0.0/16",    // OCI London peers
-    "147.154.224.0/20", // OCI customer /20 that the server peers with
+    "147.154.224.0/19", // OCI peer /19 — covers gomon (147.154.245.65) + other OCI infra
     "193.122.0.0/15",   // OCI EU-London
+];
+
+/// Link-local and cloud instance metadata ranges. Every major cloud uses
+/// 169.254.169.254 for instance metadata (IMDS); Oracle, AWS, GCP, Azure
+/// all share the convention. 169.254.0.0/16 is the IPv4 link-local range
+/// (RFC 3927). Traffic to any of these is self-infrastructure by definition
+/// — the operator never cares about "exfil to 169.254.169.254" or
+/// "slowloris on metadata endpoint". Observed 2026-04-11 as
+/// "Slow HTTP connection (possible slowloris)" FP fired by agent host
+/// polling the OCI metadata service.
+const LINK_LOCAL_RANGES: &[&str] = &[
+    "169.254.0.0/16",  // IPv4 link-local (RFC 3927), includes all IMDS endpoints
+    "127.0.0.0/8",     // loopback — never operator-relevant as a remote dst
+    "224.0.0.0/4",     // multicast
 ];
 
 /// Major cloud provider CIDR ranges that should not be auto-blocked.
@@ -196,6 +229,7 @@ pub fn init() {
         .chain(CLOUD_PROVIDER_RANGES.iter())
         .chain(AGENT_SERVICE_RANGES.iter())
         .chain(ORACLE_PEER_RANGES.iter())
+        .chain(LINK_LOCAL_RANGES.iter())
     {
         if let Some(r) = CidrRange::from_str(cidr) {
             ranges.push(r);
@@ -206,18 +240,88 @@ pub fn init() {
     let _ = CLOUD_RANGES.set(ranges);
     let _ = CLOUD_PROVIDER_COUNT.set(count);
     info!(ranges = count, "Cloud provider safelist loaded");
+
+    // Best-effort: read the host's own IPv4 interface addresses so
+    // incidents with src/dst == own IP can be recognized as self-traffic.
+    // Falls back to an empty list if /proc/net/fib_trie is unreadable;
+    // that just means the own-IP detection is a no-op, not a crash.
+    init_local_interface_ips();
+}
+
+/// Populate `LOCAL_INTERFACE_IPS` from `/proc/net/fib_trie`. This file
+/// exposes every locally-bound IPv4 address (loopback, eth0, docker0, etc.)
+/// as `|-- <ip>` lines followed by `/32 host LOCAL`. Parsing is deliberately
+/// forgiving — any unexpected format just yields an empty list.
+fn init_local_interface_ips() {
+    let content = match std::fs::read_to_string("/proc/net/fib_trie") {
+        Ok(c) => c,
+        Err(_) => {
+            let _ = LOCAL_INTERFACE_IPS.set(Vec::new());
+            return;
+        }
+    };
+
+    let mut ips: Vec<u32> = Vec::new();
+    let lines: Vec<&str> = content.lines().collect();
+    for (i, line) in lines.iter().enumerate() {
+        let trimmed = line.trim_start();
+        // Each local address appears as "|-- <ip>" with the next non-empty
+        // line containing "/32 host LOCAL". We accept any line whose next
+        // line mentions "host LOCAL" — the routing table can tag as
+        // "host BROADCAST" or "host LINK" too, which we ignore.
+        if let Some(rest) = trimmed.strip_prefix("|-- ") {
+            if let Some(next) = lines.get(i + 1) {
+                if next.contains("host LOCAL") {
+                    if let Ok(std::net::IpAddr::V4(v4)) = rest.trim().parse::<IpAddr>() {
+                        ips.push(u32::from(v4));
+                    }
+                }
+            }
+        }
+    }
+
+    ips.sort_unstable();
+    ips.dedup();
+    let n = ips.len();
+    let _ = LOCAL_INTERFACE_IPS.set(ips);
+    info!(
+        local_ips = n,
+        "Local interface IPs loaded for self-traffic detection"
+    );
 }
 
 /// Returns true if the IP should be treated as *self-traffic* — either a
 /// known cloud provider, the agent's own notification / enrichment
-/// endpoints (Telegram, GeoIP), or the OCI peer ranges of the host the
-/// agent runs on.
+/// endpoints (Telegram, GeoIP), the OCI peer ranges of the host the
+/// agent runs on, link-local / metadata IPs, OR one of the host's own
+/// IPv4 interface addresses.
 ///
 /// Callers that generate operator-facing incidents should use this to
 /// flag the incident as `research_only` instead of surfacing it in the
 /// threats feed.
 pub fn is_self_traffic_ip(ip_str: &str) -> bool {
-    is_cloud_provider_ip(ip_str)
+    is_cloud_provider_ip(ip_str) || is_local_interface_ip(ip_str)
+}
+
+/// Returns true if `ip_str` is one of the host's own locally-bound IPv4
+/// addresses (populated at startup from `/proc/net/fib_trie`). This
+/// catches the case where a sensor detector emits an incident whose
+/// only IP entity is the server's own VPC/eth0 address — observed
+/// 2026-04-11 as "Packet flood → 10.0.0.238" and "Slow HTTP from
+/// 10.0.0.238 → 169.254.169.254" FPs. Returns false if the local-IP
+/// list could not be loaded (best-effort).
+pub fn is_local_interface_ip(ip_str: &str) -> bool {
+    let Ok(ip) = ip_str.parse::<IpAddr>() else {
+        return false;
+    };
+    let ip_u32 = match ip {
+        IpAddr::V4(v4) => u32::from(v4),
+        _ => return false,
+    };
+    match LOCAL_INTERFACE_IPS.get() {
+        Some(list) => list.binary_search(&ip_u32).is_ok(),
+        None => false,
+    }
 }
 
 /// Returns true if `comm` is the agent itself or one of its spawned

--- a/crates/agent/src/cloud_safelist.rs
+++ b/crates/agent/src/cloud_safelist.rs
@@ -336,6 +336,8 @@ pub fn is_agent_process(comm: &str) -> bool {
             | "innerwarden-watchdog"
             | "tokio-rt-worker"
             | "openclaw-gatewa"
+            | "crowdsec"
+            | "gomon"
     )
 }
 

--- a/crates/agent/src/correlation_engine.rs
+++ b/crates/agent/src/correlation_engine.rs
@@ -863,6 +863,14 @@ fn builtin_rules() -> Vec<CorrelationRule> {
             severity: Severity::Critical,
         },
         // CL-014: Cryptominer deployment
+        //
+        // Requires entity match on BOTH stages so that the CPU abuse
+        // comes from the SAME process/container that made the outbound
+        // connection. Without this, any unrelated CPU spike (cargo
+        // build, snap refresh) + any outbound connect (CrowdSec polling,
+        // Telegram notification) would fire "Cryptominer Deployment
+        // Chain". Observed 2026-04-12: 21 false Cryptominer chains per
+        // day from CrowdSec CAPI polling + cargo build CPU spike.
         CorrelationRule {
             id: "CL-014".into(),
             name: "Cryptominer Deployment Chain".into(),
@@ -878,7 +886,7 @@ fn builtin_rules() -> Vec<CorrelationRule> {
                 RuleStage {
                     layer: None,
                     kind_patterns: vec!["crypto_miner".into(), "cgroup.cpu_abuse".into()],
-                    entity_must_match: false,
+                    entity_must_match: true,
                 },
             ],
             window_secs: 600,

--- a/crates/agent/src/dashboard/data_api.rs
+++ b/crates/agent/src/dashboard/data_api.rs
@@ -389,6 +389,147 @@ pub(super) async fn api_briefing_generate(
 }
 
 // ---------------------------------------------------------------------------
+// AI Explain — ask the AI to explain a threat in plain language
+// ---------------------------------------------------------------------------
+
+pub(super) async fn api_ai_explain(
+    State(state): State<DashboardState>,
+    Query(query): Query<AiExplainQuery>,
+) -> Json<serde_json::Value> {
+    let subject_type = query.r#type.as_deref().unwrap_or("ip");
+    let subject_value = match query.value.as_deref() {
+        Some(v) if !v.is_empty() => v,
+        _ => {
+            return Json(serde_json::json!({
+                "error": "Missing 'value' parameter"
+            }))
+        }
+    };
+
+    let Some(ref ai) = state.ai_provider else {
+        return Json(serde_json::json!({
+            "error": "AI provider not configured. Enable AI in agent.toml."
+        }));
+    };
+
+    // Build context from the knowledge graph: incidents, decisions,
+    // events linked to this entity. Keep it compact for the LLM.
+    let context = {
+        use crate::knowledge_graph::types::*;
+        let graph = state.knowledge_graph.read().unwrap();
+
+        // Find the entity node
+        let target_node = match subject_type {
+            "ip" => graph
+                .nodes_of_type(NodeType::Ip)
+                .iter()
+                .find(|&&id| {
+                    matches!(graph.get_node(id), Some(Node::Ip { addr, .. }) if addr == subject_value)
+                })
+                .copied(),
+            _ => None,
+        };
+
+        let Some(node_id) = target_node else {
+            return Json(serde_json::json!({
+                "explanation": format!("No data found for {} '{}'.", subject_type, subject_value)
+            }));
+        };
+
+        // Collect incidents linked to this entity
+        let mut incident_lines: Vec<String> = Vec::new();
+        let mut decision_lines: Vec<String> = Vec::new();
+
+        for edge in graph.incoming_edges(node_id) {
+            if edge.relation != Relation::TriggeredBy {
+                continue;
+            }
+            if let Some(Node::Incident {
+                detector,
+                severity,
+                title,
+                summary,
+                decision,
+                decision_reason,
+                research_only,
+                auto_executed,
+                ts,
+                ..
+            }) = graph.get_node(edge.from)
+            {
+                if *research_only {
+                    continue;
+                }
+                incident_lines.push(format!(
+                    "- [{}] {}: {} (detector: {}, ts: {})",
+                    severity.to_uppercase(),
+                    title,
+                    summary,
+                    detector,
+                    ts.format("%H:%M:%S")
+                ));
+                if let Some(dec) = decision {
+                    let reason = decision_reason
+                        .as_deref()
+                        .unwrap_or("no reason recorded");
+                    let executed = if *auto_executed { "executed" } else { "recommended" };
+                    decision_lines.push(format!(
+                        "- AI {} {}: {}",
+                        executed, dec, reason
+                    ));
+                }
+            }
+        }
+
+        // Count events
+        let event_count = graph
+            .all_edges(node_id)
+            .iter()
+            .filter(|e| e.relation == Relation::ConnectedTo || e.relation == Relation::AcceptedFrom)
+            .count();
+
+        format!(
+            "Entity: {} {}\nEvent count: {}\n\nIncidents ({}):\n{}\n\nAI Decisions ({}):\n{}",
+            subject_type,
+            subject_value,
+            event_count,
+            incident_lines.len(),
+            if incident_lines.is_empty() {
+                "None".to_string()
+            } else {
+                incident_lines.join("\n")
+            },
+            decision_lines.len(),
+            if decision_lines.is_empty() {
+                "None".to_string()
+            } else {
+                decision_lines.join("\n")
+            },
+        )
+    };
+
+    let system = "You are a security assistant explaining threats to a non-technical person. \
+        This server is protected by InnerWarden (an AI security agent) and uses SSH key-only authentication (password login is disabled). \
+        Explain in plain English: what happened, whether it's actually dangerous, and whether any action is needed. \
+        Base your answer strictly on the incident data provided — the title and summary tell you exactly what happened. \
+        Most activity you'll see is routine internet noise (bots scanning every IP on the internet). Failed connection attempts from scanners are NOT dangerous. \
+        Only say it's dangerous if the attacker actually got past the initial connection (authentication success, shell access, data exfiltration). \
+        Keep your explanation to 2-3 sentences. No jargon. No generic security advice like 'update passwords'. Be specific to what happened.";
+
+    let user_msg = format!(
+        "Explain this activity to me in simple terms. Should I be worried?\n\n{}",
+        context
+    );
+
+    match ai.chat(system, &user_msg).await {
+        Ok(explanation) => Json(serde_json::json!({ "explanation": explanation })),
+        Err(e) => Json(serde_json::json!({
+            "error": format!("AI call failed: {}", e)
+        })),
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Business logic - overview (graph-based, Phase 6A)
 // ---------------------------------------------------------------------------
 

--- a/crates/agent/src/dashboard/data_api.rs
+++ b/crates/agent/src/dashboard/data_api.rs
@@ -62,6 +62,7 @@ pub(super) async fn api_overview(
         if let Some(Node::Incident {
             detector,
             decision,
+            decision_target,
             severity,
             is_allowlisted,
             research_only,
@@ -89,13 +90,20 @@ pub(super) async fn api_overview(
                         safely_resolved += 1;
                     }
                     "request_confirmation" => {
-                        // awaiting human approval → unresolved
                         ai_confirmed += 1;
                         unresolved_count += 1;
                     }
                     _ => {
                         ai_confirmed += 1;
-                        ai_responded += 1;
+                        // Only count as "responded" if the target looks like
+                        // an IP. Pre-fix FPs like sandbox_evasion blocked a
+                        // PID (numeric string) which is not a real response.
+                        let target_is_ip = decision_target
+                            .as_ref()
+                            .is_some_and(|t| t.contains('.'));
+                        if target_is_ip {
+                            ai_responded += 1;
+                        }
                         safely_resolved += 1;
                     }
                 }
@@ -559,6 +567,7 @@ pub(super) fn compute_overview_from_graph(
         if let Some(Node::Incident {
             detector,
             decision,
+            decision_target,
             severity,
             is_allowlisted,
             research_only,
@@ -591,7 +600,12 @@ pub(super) fn compute_overview_from_graph(
                     }
                     _ => {
                         ai_confirmed += 1;
-                        ai_responded += 1;
+                        let target_is_ip = decision_target
+                            .as_ref()
+                            .is_some_and(|t| t.contains('.'));
+                        if target_is_ip {
+                            ai_responded += 1;
+                        }
                         safely_resolved += 1;
                     }
                 }

--- a/crates/agent/src/dashboard/frontend/css/app.css
+++ b/crates/agent/src/dashboard/frontend/css/app.css
@@ -1183,6 +1183,15 @@
     .threat-group .attacker-card:last-child { border-bottom:none; }
     .threat-group-needs-action { border-color:rgba(244,63,94,0.25); }
     .threat-group-needs-action .threat-group-header { background:rgba(244,63,94,0.04); }
+
+    /* Outcome-group accent borders (02-threats AI audit trail) */
+    .outcome-attention { border-color:rgba(244,63,94,0.3); }
+    .outcome-attention .threat-group-header { background:rgba(244,63,94,0.06); }
+    .outcome-blocked .threat-group-header { background:rgba(74,222,128,0.04); }
+    .outcome-honeypot .threat-group-header { background:rgba(255,165,0,0.04); }
+    .outcome-observing .threat-group-header { background:rgba(120,229,255,0.04); }
+    .outcome-dismissed { opacity:0.7; }
+
     /* Incident humanization */
     .entry-contained .evidence-card { opacity:0.7; border-left:2px solid var(--ok); }
     .entry-open .evidence-card { border-left:2px solid var(--danger); }

--- a/crates/agent/src/dashboard/frontend/css/app.css
+++ b/crates/agent/src/dashboard/frontend/css/app.css
@@ -20,6 +20,43 @@
       --surface: #091121;
       --bg: #040814;
     }
+    /* ── Severity-scaled alert classes (spec 017 Phase 1, 00-shared) ── */
+    /* Container-level tone classes. Text color is NOT set here so
+       existing typography keeps working. Used by hero banners, feed
+       rows, and callouts across pages. */
+    .alert-critical {
+      border: 1px solid rgba(244, 63, 94, 0.55);
+      border-left: 3px solid var(--danger);
+      background: rgba(244, 63, 94, 0.08);
+    }
+    .alert-high {
+      border: 1px solid rgba(255, 154, 85, 0.55);
+      border-left: 3px solid var(--orange);
+      background: rgba(255, 154, 85, 0.08);
+    }
+    .alert-medium {
+      border: 1px solid rgba(255, 197, 102, 0.50);
+      border-left: 3px solid var(--warn);
+      background: rgba(255, 197, 102, 0.07);
+    }
+    .alert-low {
+      border: 1px solid rgba(120, 229, 255, 0.40);
+      border-left: 3px solid var(--accent);
+      background: rgba(120, 229, 255, 0.05);
+    }
+    .alert-info {
+      border: 1px solid rgba(74, 222, 128, 0.35);
+      border-left: 3px solid var(--ok);
+      background: rgba(74, 222, 128, 0.05);
+    }
+    /* Responsive table wrapper utility. Provides horizontal scroll
+       as a safety net on narrow viewports. Page specs (e.g. Intel)
+       may extend this with stacked-card media queries. */
+    .table-wrap {
+      overflow-x: auto;
+      -webkit-overflow-scrolling: touch;
+      width: 100%;
+    }
     /* Ambient cyber grid - matches site's cyber-shell */
     body::before {
       content: "";

--- a/crates/agent/src/dashboard/frontend/css/app.css
+++ b/crates/agent/src/dashboard/frontend/css/app.css
@@ -1503,3 +1503,157 @@
     }
     .hud-panel-title::after { content:''; display:block; width:2.2em; height:1px; margin-top:0.6em;
       background:linear-gradient(90deg, rgba(120,229,255,0.7), rgba(120,229,255,0.1)); }
+
+    /* ── Home tab — spec 017 Phase 1 (01-home) ───────────────────── */
+    /* Hero status-meta strip (MODE, telemetry, links) */
+    .home-status-meta {
+      display:flex; flex-wrap:wrap; gap:14px; align-items:center;
+      margin-top:10px; font-size:0.66rem; color:var(--muted);
+      letter-spacing:0.04em;
+    }
+    .home-meta-item {
+      display:inline-flex; align-items:center; gap:4px;
+      color:var(--muted);
+    }
+    .home-meta-links {
+      margin-left:auto; display:flex; gap:14px; flex-wrap:wrap;
+    }
+    .home-link {
+      color:var(--accent); text-decoration:none;
+      font-size:0.66rem; font-weight:500; letter-spacing:0.02em;
+      border-bottom:1px dashed rgba(120,229,255,0.35);
+      padding-bottom:1px; cursor:pointer;
+      transition:color 0.15s, border-color 0.15s;
+    }
+    .home-link:hover {
+      color:var(--text); border-color:rgba(120,229,255,0.8);
+    }
+    .home-stale-soft {
+      color:var(--warn); font-weight:500;
+    }
+    .home-stale-strong {
+      color:var(--danger); font-weight:600;
+    }
+
+    /* "Now" section — 2 observational lines */
+    .home-now {
+      padding:16px 20px;
+    }
+    .home-now .home-section-title {
+      font-size:0.62rem; letter-spacing:0.22em;
+      text-transform:uppercase; color:var(--muted);
+      margin-bottom:10px;
+    }
+    .home-now-list {
+      list-style:none; padding:0; margin:0;
+      display:flex; flex-direction:column; gap:6px;
+    }
+    .home-now-list li {
+      font-size:0.82rem; line-height:1.55; color:var(--text);
+    }
+
+    /* KPI temporal sub-label */
+    .kpi-window {
+      font-size:0.62rem; color:var(--muted);
+      text-transform:none; letter-spacing:0.02em;
+      margin-top:3px; white-space:nowrap;
+    }
+
+    /* Recent Activity feed rows — severity × outcome hierarchy */
+    .feed-row {
+      display:flex; align-items:center; gap:12px;
+      padding:10px 14px; margin:6px 0;
+      border-radius:8px;
+      border-left:3px solid transparent;
+      background:rgba(9,17,33,0.4);
+      cursor:pointer;
+      transition:background 0.15s;
+    }
+    .feed-row:hover {
+      background:rgba(15,26,49,0.7);
+    }
+    .feed-row .activity-icon {
+      font-size:1rem; flex-shrink:0;
+    }
+    .feed-row .activity-time {
+      font-size:0.66rem; color:var(--dim);
+      white-space:nowrap; flex-shrink:0;
+      font-family:'JetBrains Mono',monospace;
+    }
+    /* Handled outcomes — subtle green border, muted content */
+    .feed-handled {
+      border-left-color:var(--ok);
+      opacity:0.82;
+      background:rgba(74,222,128,0.04);
+    }
+    .feed-muted {
+      border-left-color:rgba(138,157,179,0.3);
+      opacity:0.72;
+    }
+    .feed-noise {
+      border-left-color:transparent;
+      opacity:0.48;
+    }
+    .feed-monitor {
+      border-left-color:var(--accent);
+      background:rgba(120,229,255,0.04);
+      opacity:0.85;
+    }
+    .feed-honeypot {
+      border-left-color:var(--orange);
+      background:rgba(255,154,85,0.05);
+      opacity:0.9;
+    }
+
+    /* Feed empty state */
+    .home-feed-empty {
+      padding:34px 20px; text-align:center;
+    }
+    .home-feed-empty-icon {
+      font-size:1.4rem; margin-bottom:8px;
+    }
+    .home-feed-empty-title {
+      color:var(--ok); font-size:0.84rem; font-weight:600;
+    }
+    .home-feed-empty-sub {
+      color:var(--dim); font-size:0.72rem; margin-top:4px;
+    }
+
+    /* Data Collection — summary + collapsible details */
+    .collector-summary-line {
+      display:flex; align-items:center; gap:12px;
+      padding:10px 14px; border-radius:8px;
+      font-size:0.82rem; color:var(--text);
+    }
+    .collector-details-toggle {
+      margin-left:auto;
+      background:transparent; border:1px solid var(--line);
+      color:var(--muted); font-size:0.66rem;
+      padding:4px 10px; border-radius:6px; cursor:pointer;
+      transition:color 0.15s, border-color 0.15s;
+    }
+    .collector-details-toggle:hover {
+      color:var(--accent); border-color:var(--accent);
+    }
+    .collector-details {
+      margin-top:8px; padding:8px 0;
+      border-top:1px solid var(--line);
+    }
+    .collector-idle-note {
+      font-size:0.66rem; color:var(--dim); margin-top:6px;
+    }
+
+    /* AI Briefing empty-state */
+    .briefing-empty {
+      color:var(--muted); font-size:0.78rem; line-height:1.55;
+      padding:6px 0;
+    }
+
+    /* Mobile polish */
+    @media (max-width: 600px) {
+      .home-status-meta { gap:8px; font-size:0.62rem; }
+      .home-meta-links { margin-left:0; width:100%; }
+      .home-now-list li { font-size:0.78rem; }
+      .collector-summary-line { flex-wrap:wrap; }
+      .collector-details-toggle { margin-left:0; }
+    }

--- a/crates/agent/src/dashboard/frontend/html/index.html
+++ b/crates/agent/src/dashboard/frontend/html/index.html
@@ -42,8 +42,8 @@
       <span class="status-badge status-badge-read" id="modeBadge">READ-ONLY</span>
       <span class="status-badge status-badge-ai-off" id="aiBadge">AI: off</span>
       <span class="status-badge" id="versionBadge" style="background:rgba(120,229,255,0.08);color:var(--accent);font-size:0.58rem"></span>
-      <label style="display:flex;align-items:center;gap:3px;font-size:0.58rem;color:var(--muted);cursor:pointer;user-select:none;margin-left:4px" title="Hide events from allowlisted IPs and users">
-        <input type="checkbox" id="hideAllowlisted" checked onchange="toggleAllowlistFilter()" style="margin:0;cursor:pointer;width:12px;height:12px"> Hide trusted
+      <label style="display:flex;align-items:center;gap:3px;font-size:0.58rem;color:var(--muted);cursor:pointer;user-select:none;margin-left:4px" title="Hide events from known-safe IPs and users">
+        <input type="checkbox" id="hideAllowlisted" checked onchange="toggleAllowlistFilter()" style="margin:0;cursor:pointer;width:12px;height:12px"> Hide known-safe sources
       </label>
     </div>
     <span id="refreshStatus"></span>

--- a/crates/agent/src/dashboard/frontend/html/index.html
+++ b/crates/agent/src/dashboard/frontend/html/index.html
@@ -151,11 +151,11 @@
   <div class="app-body" id="viewInvestigate" style="display:none">
     <aside class="left-panel">
       <div class="kpi-grid" style="grid-template-columns: repeat(3,1fr)">
-        <div class="kpi-card"><div class="kpi-label">Threats</div><div class="kpi-value" id="kpi-confirmed" style="color:var(--accent)">0</div></div>
-        <div class="kpi-card"><div class="kpi-label">Contained</div><div class="kpi-value" id="kpi-responded" style="color:#27ae60">0</div></div>
-        <div class="kpi-card"><div class="kpi-label">Events</div><div class="kpi-value" id="kpi-events">0</div></div>
+        <div class="kpi-card"><div class="kpi-value" id="kpi-confirmed" style="color:var(--ok)">0</div><div class="kpi-label">Blocked</div><div class="kpi-window">Today</div></div>
+        <div class="kpi-card"><div class="kpi-value" id="kpi-responded" style="color:var(--accent)">0</div><div class="kpi-label">Observing</div><div class="kpi-window">Now</div></div>
+        <div class="kpi-card"><div class="kpi-value" id="kpi-noise" style="color:var(--muted)">0</div><div class="kpi-label">Needs attention</div><div class="kpi-window">Today</div></div>
       </div>
-      <div style="display:none"><span id="kpi-noise">0</span><span id="kpi-incidents">0</span><span id="kpi-attackers">0</span></div>
+      <div style="display:none"><span id="kpi-incidents">0</span><span id="kpi-attackers">0</span><span id="kpi-events">0</span></div>
       <div class="filters" style="grid-template-columns:1fr auto;margin-bottom:6px">
         <input id="flt-date" type="date" class="full" style="grid-column:1/-1" />
         <button id="flt-adv-toggle" type="button" class="full" style="background:transparent;border:none;color:var(--muted);font-size:0.68rem;cursor:pointer;text-align:left;padding:2px 0" onclick="toggleAdvFilters()">▸ Advanced filters</button>
@@ -191,7 +191,7 @@
       <div class="search-wrap">
         <input id="entitySearch" type="search" placeholder="search threats…" autocomplete="off" spellcheck="false" />
       </div>
-      <div class="section-title" id="entityTitle">Defense Activity</div>
+      <div class="section-title" id="entityTitle">AI Defense Log</div>
       <div id="attackerList"><div class="empty">Loading…</div></div>
     </aside>
     <main class="right-panel" id="rightPanel">

--- a/crates/agent/src/dashboard/frontend/html/index.html
+++ b/crates/agent/src/dashboard/frontend/html/index.html
@@ -42,9 +42,9 @@
       <span class="status-badge status-badge-read" id="modeBadge">READ-ONLY</span>
       <span class="status-badge status-badge-ai-off" id="aiBadge">AI: off</span>
       <span class="status-badge" id="versionBadge" style="background:rgba(120,229,255,0.08);color:var(--accent);font-size:0.58rem"></span>
-      <label style="display:flex;align-items:center;gap:3px;font-size:0.58rem;color:var(--muted);cursor:pointer;user-select:none;margin-left:4px" title="Hide events from known-safe IPs and users">
-        <input type="checkbox" id="hideAllowlisted" checked onchange="toggleAllowlistFilter()" style="margin:0;cursor:pointer;width:12px;height:12px"> Hide known-safe sources
-      </label>
+      <!-- Toggle removed: research_only server-side filter handles self-traffic.
+           The checkbox element is kept hidden so JS references don't break. -->
+      <input type="checkbox" id="hideAllowlisted" checked style="display:none">
     </div>
     <span id="refreshStatus"></span>
     <div class="main-nav">

--- a/crates/agent/src/dashboard/frontend/html/index.html
+++ b/crates/agent/src/dashboard/frontend/html/index.html
@@ -86,20 +86,20 @@
       </ul>
     </section>
     <div class="home-kpi-row">
-      <div class="home-kpi-big" onclick="viewActivity()">
-        <div class="kpi-value" id="homeKpiThreats" style="color:var(--accent)">0</div>
-        <div class="kpi-label">Threats Detected</div>
+      <div class="home-kpi-big" onclick="showContained()">
+        <div class="kpi-value" id="homeKpiThreats" style="color:var(--ok)">0</div>
+        <div class="kpi-label">Blocked</div>
         <div class="kpi-window" id="homeKpiThreatsWindow">Today</div>
       </div>
-      <div class="home-kpi-big" onclick="showContained()">
-        <div class="kpi-value" id="homeKpiResponded" style="color:#27ae60">0</div>
-        <div class="kpi-label">Contained</div>
+      <div class="home-kpi-big" onclick="viewActivity()">
+        <div class="kpi-value" id="homeKpiResponded" style="color:var(--accent)">0</div>
+        <div class="kpi-label">Incidents</div>
         <div class="kpi-window" id="homeKpiRespondedWindow">Today</div>
       </div>
       <div class="home-kpi-big" onclick="showView('sensors')">
         <div class="kpi-value" id="homeKpiEvents" style="color:var(--accent)">0</div>
-        <div class="kpi-label">Events</div>
-        <div class="kpi-window" id="homeKpiEventsWindow">Live (today)</div>
+        <div class="kpi-label">Events Scanned</div>
+        <div class="kpi-window" id="homeKpiEventsWindow">Today</div>
       </div>
     </div>
     <div class="home-section" id="briefingSection" style="display:none">

--- a/crates/agent/src/dashboard/frontend/html/index.html
+++ b/crates/agent/src/dashboard/frontend/html/index.html
@@ -72,24 +72,34 @@
 
   <!-- ── Home view ── -->
   <div class="report-view" id="viewHome" style="display:none">
-    <div class="status-hero safe" id="homeHero">
-      <div class="status-hero-icon" id="homeHeroIcon">✅</div>
+    <div class="status-hero alert-info" id="homeHero">
+      <div class="status-hero-icon" id="homeHeroIcon">🛡</div>
       <div class="status-hero-title" id="homeHeroTitle">Loading…</div>
       <div class="status-hero-sub" id="homeHeroSub"></div>
       <div class="home-status-meta" id="homeStatusMeta"></div>
     </div>
+    <section id="homeNow" class="home-section home-now">
+      <div class="home-section-title">Now</div>
+      <ul class="home-now-list">
+        <li id="homeNowWhat">Loading…</li>
+        <li id="homeNowDid"></li>
+      </ul>
+    </section>
     <div class="home-kpi-row">
-      <div class="home-kpi-big" onclick="showView('investigate')">
+      <div class="home-kpi-big" onclick="viewActivity()">
         <div class="kpi-value" id="homeKpiThreats" style="color:var(--accent)">0</div>
         <div class="kpi-label">Threats Detected</div>
+        <div class="kpi-window" id="homeKpiThreatsWindow">Today</div>
       </div>
       <div class="home-kpi-big" onclick="showContained()">
         <div class="kpi-value" id="homeKpiResponded" style="color:#27ae60">0</div>
         <div class="kpi-label">Contained</div>
+        <div class="kpi-window" id="homeKpiRespondedWindow">Today</div>
       </div>
       <div class="home-kpi-big" onclick="showView('sensors')">
         <div class="kpi-value" id="homeKpiEvents" style="color:var(--accent)">0</div>
-        <div class="kpi-label">Events Today</div>
+        <div class="kpi-label">Events</div>
+        <div class="kpi-window" id="homeKpiEventsWindow">Live (today)</div>
       </div>
     </div>
     <div class="home-section" id="briefingSection" style="display:none">

--- a/crates/agent/src/dashboard/frontend/js/actions.js
+++ b/crates/agent/src/dashboard/frontend/js/actions.js
@@ -1,12 +1,18 @@
 // ── D3 - action state ─────────────────────────────────────────────────
 let actionCfg = null;
 let pendingAction = null; // { type: 'block_ip'|'suspend_user', ip, user }
+// Sentinel set to true only after /api/action/config has been loaded
+// at boot. Diagnostic for spec 017 — distinguishes "allowlist loaded
+// and genuinely empty" from "allowlist never loaded" (both show
+// length === 0 but mean very different things).
+var _allowlistLoaded = false;
 
 async function loadActionConfig() {
   try {
     actionCfg = await loadJson('/api/action/config');
     _trustedIps = actionCfg.trusted_ips || [];
     _trustedUsers = actionCfg.trusted_users || [];
+    _allowlistLoaded = true;
     const badge = document.getElementById('modeBadge');
     const aiBadge = document.getElementById('aiBadge');
     // Mode badge

--- a/crates/agent/src/dashboard/frontend/js/api.js
+++ b/crates/agent/src/dashboard/frontend/js/api.js
@@ -13,7 +13,7 @@ const fmtDateTime = (ts) => {
   return isNaN(d) ? String(ts) : d.toLocaleString();
 };
 
-const outcomeLabel = (o) => ({blocked:'CONTAINED', active:'ACTIVE', monitoring:'MONITORING', honeypot:'HONEYPOT', unknown:'UNKNOWN'}[o] || o.toUpperCase());
+const outcomeLabel = (o) => ({blocked:'CONTAINED', active:'OBSERVING', monitoring:'OBSERVING', honeypot:'HONEYPOT', needs_attention:'NEEDS ATTENTION', dismissed:'DISMISSED', unknown:'UNKNOWN'}[o] || o.toUpperCase());
 const outcomeCls   = (o) => 'bo bo-' + (o || 'unknown');
 
 const sevCls = (s) => ({'critical':'sc-critical','high':'sc-high','medium':'sc-medium','low':'sc-low','info':'sc-info'}[s] || '');

--- a/crates/agent/src/dashboard/frontend/js/helpers.js
+++ b/crates/agent/src/dashboard/frontend/js/helpers.js
@@ -191,7 +191,11 @@ function entryOutcomeClass(entry) {
 }
 
 function toggleDetail(btn) {
-  var body = btn.parentElement.nextElementSibling;
+  // Find .detail-body within the same evidence-card, not by sibling
+  // position (the header/title/context divs sit between the button
+  // and the detail body, breaking nextElementSibling).
+  var card = btn.closest('.evidence-card');
+  var body = card ? card.querySelector('.detail-body') : null;
   if (!body) return;
   body.classList.toggle('open');
   btn.textContent = body.classList.contains('open') ? 'Hide details' : 'Show details';

--- a/crates/agent/src/dashboard/frontend/js/helpers.js
+++ b/crates/agent/src/dashboard/frontend/js/helpers.js
@@ -1,3 +1,16 @@
+// ── Canonical UI glossary (spec 017 shared foundation) ────────────────
+// Single source of truth for user-facing UI term definitions. Consumed
+// by page specs for title= tooltips and copy review.
+var GLOSSARY = {
+  threat:     'A detected security event that may pose risk.',
+  incident:   'A threat recorded by the backend (same concept, internal name).',
+  unresolved: 'A threat that has not been handled automatically and awaits your review.',
+  contained:  'A threat that has been blocked, killed, monitored, or suspended automatically.',
+  open:       'A threat with no containment action taken yet.',
+  resolved:   'A threat that has been closed — either contained or dismissed.',
+  noise:      'A low-signal detection the system chose not to act on.'
+};
+
 // ── Confidence system helpers ─────────────────────────────────────────
 function getUnresolved() {
   var ov = window._lastOverview || {};
@@ -24,6 +37,50 @@ var DETECTOR_LABELS = {
   suspicious_archive: 'Suspicious archive creation', logging_config_change: 'Logging config changed',
   timing_anomaly: 'Timing anomaly'
 };
+
+// ── Severity helpers (spec 017 shared foundation) ─────────────────────
+// Map severity strings to CSS classes, human labels, and numeric ranks.
+// Used by every page spec that renders severity-scaled tone.
+function severityClass(sev) {
+  var s = (sev || '').toString().toLowerCase();
+  if (s === 'critical') return 'alert-critical';
+  if (s === 'high')     return 'alert-high';
+  if (s === 'medium')   return 'alert-medium';
+  if (s === 'low')      return 'alert-low';
+  return 'alert-info';
+}
+
+function severityLabel(sev) {
+  var s = (sev || '').toString().toLowerCase();
+  if (s === 'critical') return 'Critical';
+  if (s === 'high')     return 'High';
+  if (s === 'medium')   return 'Medium';
+  if (s === 'low')      return 'Low';
+  return 'Info';
+}
+
+function severityRank(sev) {
+  var s = (sev || '').toString().toLowerCase();
+  if (s === 'critical') return 4;
+  if (s === 'high')     return 3;
+  if (s === 'medium')   return 2;
+  if (s === 'low')      return 1;
+  if (s === 'info')     return 0;
+  return -1;
+}
+
+// Return the highest severity string found in a list of objects
+// with .severity or .effective_severity. Prefers effective_severity.
+function maxSeverity(list) {
+  var best = -1;
+  var bestName = 'info';
+  (list || []).forEach(function(item) {
+    var sev = item && (item.effective_severity || item.severity);
+    var rank = severityRank(sev);
+    if (rank > best) { best = rank; bestName = (sev || '').toString().toLowerCase() || 'info'; }
+  });
+  return best >= 0 ? bestName : 'info';
+}
 
 function humanLabel(slug) {
   return DETECTOR_LABELS[slug] || slug.replace(/_/g, ' ').replace(/\b\w/g, function(c) { return c.toUpperCase(); });
@@ -112,24 +169,46 @@ function isPrivateIp(ip) {
     /^172\.(1[6-9]|2\d|3[01])\./.test(ip);
 }
 
+// Unified incident-trust check (spec 017 Change 6).
+// Returns true when the incident should be hidden while
+// state.hideAllowlisted is on; false when it should be shown.
+//
+// Rule 1 (severity gate): critical/high are NEVER filtered by trust —
+//   they must always reach the operator regardless of entity shape.
+//
+// Rule 2 (entity walk, for medium/low/info): inspect entities. If any
+//   external non-trusted IP is present, show. If any non-trusted user
+//   is present, show. Otherwise hide (handles allowlisted-only and
+//   no-entity noise like host_drift sudo or kill_chain forming).
 function isIncidentTrusted(inc) {
-  var entities = inc.entities || [];
-  var hasExternalIp = false;
+  var sev = ((inc && (inc.effective_severity || inc.severity)) || '').toString().toLowerCase();
+  if (sev === 'critical' || sev === 'high') return false;
+
+  var entities = (inc && inc.entities) || [];
+  var sawExternalIp = false;
+  var allIpsTrusted = true;
+  var sawUntrustedUser = false;
+
   for (var i = 0; i < entities.length; i++) {
     var e = entities[i];
     var eType = (typeof e === 'string') ? (e.split(':')[0] || '') : (e.type || '');
-    var eVal = (typeof e === 'string') ? (e.split(':').slice(1).join(':') || '') : (e.value || '');
-    if (eType.toLowerCase() === 'ip') {
-      if (isIpTrusted(eVal) || isPrivateIp(eVal)) return true;
-      hasExternalIp = true;
+    var eVal  = (typeof e === 'string') ? (e.split(':').slice(1).join(':') || '') : (e.value || '');
+    eType = eType.toLowerCase();
+
+    if (eType === 'ip') {
+      sawExternalIp = true;
+      if (!isIpTrusted(eVal) && !isPrivateIp(eVal)) {
+        allIpsTrusted = false;
+      }
     }
-    if (eType.toLowerCase() === 'user') {
-      if (_trustedUsers.indexOf(eVal) >= 0) return true;
+    if (eType === 'user') {
+      if (_trustedUsers.indexOf(eVal) < 0) sawUntrustedUser = true;
     }
   }
-  // No IP at all = internal/local activity = trusted
-  if (!hasExternalIp) return true;
-  return false;
+
+  if (sawExternalIp && !allIpsTrusted) return false;
+  if (sawUntrustedUser) return false;
+  return true;
 }
 
 
@@ -169,6 +248,21 @@ function timeAgo(ts) {
   if (diff < 3600) return Math.floor(diff/60) + 'm ago';
   if (diff < 86400) return Math.floor(diff/3600) + 'h ago';
   return Math.floor(diff/86400) + 'd ago';
+}
+
+// Temporal window label helper (spec 017 shared foundation).
+// Returns a canonical English label for a KPI time window.
+// Unknown kinds return '' so callers can omit the label gracefully.
+function formatWindow(kind) {
+  switch ((kind || '').toString()) {
+    case 'live':        return 'Live';
+    case 'today':       return 'Today';
+    case 'last_24h':    return 'Last 24h';
+    case 'last_6h':     return 'Last 6h';
+    case 'last_hour':   return 'Last hour';
+    case 'since_start': return 'Since startup';
+    default:            return '';
+  }
 }
 
 function handleCardClickByValue(type, value) {

--- a/crates/agent/src/dashboard/frontend/js/helpers.js
+++ b/crates/agent/src/dashboard/frontend/js/helpers.js
@@ -20,6 +20,41 @@ function getUnresolved() {
   return { total: confirmed, unresolved: unresolved, handled: responded };
 }
 
+// Human-readable labels for sensor collectors (spec 017 Change 6).
+// Home's Data Collection section renders these instead of raw slugs
+// so the primary operator sees "Network traffic" rather than
+// "tcp_stream". Unknown slugs fall back to humanLabel().
+var COLLECTOR_LABELS = {
+  tcp_stream:         'Network traffic',
+  http_capture:       'Web requests',
+  dns_capture:        'DNS lookups',
+  tls_fingerprint:    'TLS fingerprints',
+  auth_log:           'Login attempts',
+  auditd:             'System audit log',
+  journald:           'System journal',
+  docker:             'Docker events',
+  proc_maps:          'Process memory',
+  fanotify_watch:     'File changes',
+  kernel_integrity:   'Kernel integrity',
+  cgroup_abuse:       'Resource usage',
+  ebpf_syscall:       'Kernel system calls',
+  firmware_integrity: 'Firmware integrity',
+  nginx_access:       'Web server access',
+  nginx_error:        'Web server errors',
+  syslog_firewall:    'Firewall log',
+  falco_log:          'Falco events',
+  suricata_eve:       'Suricata alerts',
+  wazuh_alerts:       'Wazuh alerts',
+  osquery_log:        'osquery events',
+  macos_log:          'macOS log',
+  cloudtrail:         'AWS CloudTrail',
+  integrity:          'File integrity'
+};
+
+function collectorLabel(slug) {
+  return COLLECTOR_LABELS[slug] || humanLabel(slug);
+}
+
 var DETECTOR_LABELS = {
   ssh_bruteforce: 'SSH login attempts', credential_stuffing: 'Credential testing',
   host_drift: 'Unexpected process', execution_guard: 'Command monitoring',
@@ -112,7 +147,7 @@ function outcomeBadgeHtml(outcome) {
   if (outcome === 'blocked' || outcome === 'killed' || outcome === 'contained' || outcome === 'suspended')
     return '<span class="badge-contained">CONTAINED</span>';
   if (outcome === 'ignored') return '<span class="badge-noise">NOISE</span>';
-  if (outcome === 'open') return '<span class="badge-unresolved">OPEN</span>';
+  if (outcome === 'open') return '<span class="badge-unresolved">ACTIVE</span>';
   if (outcome === 'monitored') return '<span class="badge-monitor" style="font-size:0.62rem;padding:2px 7px;border-radius:4px">MONITORING</span>';
   if (outcome === 'honeypot') return '<span style="font-size:0.62rem;padding:2px 7px;border-radius:4px;background:rgba(255,140,66,0.12);color:var(--orange);font-weight:600">HONEYPOT</span>';
   return '';

--- a/crates/agent/src/dashboard/frontend/js/helpers.js
+++ b/crates/agent/src/dashboard/frontend/js/helpers.js
@@ -145,11 +145,12 @@ function aggregateIncidents(incidents) {
 
 function outcomeBadgeHtml(outcome) {
   if (outcome === 'blocked' || outcome === 'killed' || outcome === 'contained' || outcome === 'suspended')
-    return '<span class="badge-contained">CONTAINED</span>';
-  if (outcome === 'ignored') return '<span class="badge-noise">NOISE</span>';
-  if (outcome === 'open') return '<span class="badge-unresolved">ACTIVE</span>';
-  if (outcome === 'monitored') return '<span class="badge-monitor" style="font-size:0.62rem;padding:2px 7px;border-radius:4px">MONITORING</span>';
+    return '<span class="badge-contained">BLOCKED</span>';
+  if (outcome === 'ignored' || outcome === 'dismissed') return '<span class="badge-noise">DISMISSED</span>';
+  if (outcome === 'monitoring' || outcome === 'monitored' || outcome === 'open' || outcome === 'active')
+    return '<span class="badge-monitor" style="font-size:0.62rem;padding:2px 7px;border-radius:4px">OBSERVING</span>';
   if (outcome === 'honeypot') return '<span style="font-size:0.62rem;padding:2px 7px;border-radius:4px;background:rgba(255,140,66,0.12);color:var(--orange);font-weight:600">HONEYPOT</span>';
+  if (outcome === 'needs_attention') return '<span class="badge-unresolved">NEEDS ATTENTION</span>';
   return '';
 }
 

--- a/crates/agent/src/dashboard/frontend/js/home.js
+++ b/crates/agent/src/dashboard/frontend/js/home.js
@@ -78,32 +78,6 @@ function updateHomeKpis(overview) {
   if (el) el.textContent = (overview.events_count || 0).toLocaleString();
 }
 
-function isPrivateIp(ip) {
-  return ip.startsWith('10.') || ip.startsWith('127.') || ip.startsWith('192.168.') ||
-    ip.startsWith('169.254.') || ip === '::1' || ip.startsWith('fc') || ip.startsWith('fd') ||
-    /^172\.(1[6-9]|2\d|3[01])\./.test(ip);
-}
-
-function isIncidentTrusted(inc) {
-  var entities = inc.entities || [];
-  var hasExternalIp = false;
-  for (var i = 0; i < entities.length; i++) {
-    var e = entities[i];
-    var eType = (typeof e === 'string') ? (e.split(':')[0] || '') : (e.type || '');
-    var eVal = (typeof e === 'string') ? (e.split(':').slice(1).join(':') || '') : (e.value || '');
-    if (eType.toLowerCase() === 'ip') {
-      if (isIpTrusted(eVal) || isPrivateIp(eVal)) return true;
-      hasExternalIp = true;
-    }
-    if (eType.toLowerCase() === 'user') {
-      if (_trustedUsers.indexOf(eVal) >= 0) return true;
-    }
-  }
-  // No IP at all = internal/local activity = trusted
-  if (!hasExternalIp) return true;
-  return false;
-}
-
 // ── AI Intelligence Briefing ────────────────────────────────────────
 async function loadBriefing() {
   var section = document.getElementById('briefingSection');

--- a/crates/agent/src/dashboard/frontend/js/home.js
+++ b/crates/agent/src/dashboard/frontend/js/home.js
@@ -19,6 +19,7 @@ async function loadHome() {
     ]);
     window._lastOverview = overview;
     window._agentMode = status.mode || 'guard';
+    window._lastIncidentList = incidentList.items || [];
 
     // Filtered base matches what Recent Activity will render.
     var items = incidentList.items || [];
@@ -36,7 +37,8 @@ async function loadHome() {
       status: status,
       overview: overview,
       responsesData: responsesData,
-      activeHighCriticalList: activeHighCriticalList
+      activeHighCriticalList: activeHighCriticalList,
+      allIncidents: items
     });
 
     // Soft stale: telemetry a few minutes behind but not yet state 3.
@@ -138,7 +140,16 @@ function computeHomeState(payload) {
 
   // Guard ON or no active threats: AI Protection Active.
   // The operator sees confidence, not alarm.
-  var blocked = overview.ai_responded || 0;
+  // Count unique blocked IPs (same logic as KPI, not decision count)
+  var blockedSet = new Set();
+  (payload.allIncidents || []).forEach(function(inc) {
+    if (inc.outcome === 'blocked' || inc.outcome === 'contained') {
+      (inc.entities || []).forEach(function(e) {
+        if ((e.type || '').toLowerCase() === 'ip' && e.value) blockedSet.add(e.value);
+      });
+    }
+  });
+  var blocked = blockedSet.size || (overview.ai_responded || 0);
   var observing = activeList.length;
   var subParts = [];
   if (blocked > 0) subParts.push(blocked + ' blocked');
@@ -205,7 +216,16 @@ function updateHomeNow(overview, activeCount, softStale, totalEventsScanned) {
   var didEl  = document.getElementById('homeNowDid');
   if (!whatEl || !didEl) return;
 
-  var contained = overview.ai_responded || 0;
+  // Use unique blocked IPs, not decision count (matches KPI + Threats)
+  var blockedIpsNow = new Set();
+  (window._lastIncidentList || []).forEach(function(inc) {
+    if (inc.outcome === 'blocked' || inc.outcome === 'contained') {
+      (inc.entities || []).forEach(function(e) {
+        if ((e.type || '').toLowerCase() === 'ip' && e.value) blockedIpsNow.add(e.value);
+      });
+    }
+  });
+  var contained = blockedIpsNow.size || (overview.ai_responded || 0);
   var total = totalEventsScanned || overview.events_count || 0;
 
   // Line 1 — Trust signal: volume scanned
@@ -234,8 +254,18 @@ function updateHomeNow(overview, activeCount, softStale, totalEventsScanned) {
 
 // ── KPIs with fixed temporal sub-labels ──────────────────────────────
 function updateHomeKpis(overview, totalEventsScanned) {
+  // Count unique IPs with block decisions (matches Threats tab entity count)
+  var blockedIps = new Set();
+  var items = (window._lastIncidentList || []);
+  items.forEach(function(inc) {
+    if (inc.outcome === 'blocked' || inc.outcome === 'contained') {
+      (inc.entities || []).forEach(function(e) {
+        if ((e.type || '').toLowerCase() === 'ip' && e.value) blockedIps.add(e.value);
+      });
+    }
+  });
   var el = document.getElementById('homeKpiThreats');
-  if (el) el.textContent = overview.ai_responded || 0;
+  if (el) el.textContent = blockedIps.size || overview.ai_responded || 0;
 
   el = document.getElementById('homeKpiResponded');
   if (el) el.textContent = overview.incidents_count || 0;

--- a/crates/agent/src/dashboard/frontend/js/home.js
+++ b/crates/agent/src/dashboard/frontend/js/home.js
@@ -1,81 +1,247 @@
-// ── Home view (top-level) ──────────────────────────────────────────────
+// ── Home view — spec 017 Phase 1 (01-home) ────────────────────────────
+// Philosophy: Home never demands. Home only informs and observes.
+// The AI is the subject of every sentence. The operator is a reader.
+// Red is reserved for System Health Alert (state 3) only.
+
+// Thresholds (tunable after observation)
+var HOME_TELEMETRY_STALE_SOFT_SECS = 120;   // amber soft cue
+var HOME_TELEMETRY_STALL_SECS      = 600;   // state 3 trigger
+var HOME_ORPHAN_WINDOW_MS          = 24 * 60 * 60 * 1000;   // 24h history walk
+
 async function loadHome() {
   try {
-    const [status, overview, incidentList, sensors] = await Promise.all([
+    const [status, overview, incidentList, sensors, responsesData] = await Promise.all([
       loadJson('/api/status'),
       loadJson('/api/overview'),
       loadJson('/api/incidents?limit=100'),
-      loadJson('/api/sensors')
+      loadJson('/api/sensors'),
+      loadJson('/api/responses').catch(function() { return {}; })
     ]);
     window._lastOverview = overview;
-    // Count open incidents (no decision) to fix "All Contained" while OPEN exists
-    const items = incidentList.items || [];
-    const openHighCritical = items.filter(i =>
-      i.outcome === 'open' && (i.severity === 'high' || i.severity === 'critical')
-    ).length;
-    updateHomeBanner(status, overview, openHighCritical);
+
+    // Filtered base matches what Recent Activity will render.
+    var items = incidentList.items || [];
+    var base = state.hideAllowlisted
+      ? items.filter(function(i) { return !isIncidentTrusted(i); })
+      : items;
+
+    // Items the AI is currently processing at high/critical priority.
+    var activeHighCriticalList = base.filter(function(i) {
+      var sev = (i.effective_severity || i.severity || '').toLowerCase();
+      return i.outcome === 'open' && (sev === 'critical' || sev === 'high');
+    });
+
+    var homeState = computeHomeState({
+      status: status,
+      overview: overview,
+      responsesData: responsesData,
+      activeHighCriticalList: activeHighCriticalList
+    });
+
+    // Soft stale: telemetry a few minutes behind but not yet state 3.
+    var telemetrySecs = (typeof status.last_telemetry_secs === 'number')
+      ? status.last_telemetry_secs : null;
+    var softStale = (telemetrySecs != null
+      && telemetrySecs > HOME_TELEMETRY_STALE_SOFT_SECS
+      && telemetrySecs <= HOME_TELEMETRY_STALL_SECS);
+
+    updateHomeBanner(status, homeState);
+    updateHomeNow(overview, activeHighCriticalList.length, softStale);
     updateHomeKpis(overview);
-    buildHomeFeed(items);
+    buildHomeFeed(base);
     updateCollectorStrip(sensors);
     loadBriefing();
   } catch(e) { console.warn('loadHome error:', e); }
 }
 
-function updateHomeBanner(status, overview, openHighCritical) {
-  var hero = document.getElementById('homeHero');
-  var icon = document.getElementById('homeHeroIcon');
+// ── State machine ────────────────────────────────────────────────────
+// Fixed priority to prevent flicker:
+//   state 3 (health_alert, T1 > T2 > T3) > state 2 (ai_responding) > state 1
+function computeHomeState(payload) {
+  var status = payload.status || {};
+  var overview = payload.overview || {};
+  var rd = payload.responsesData || {};
+  var activeList = payload.activeHighCriticalList || [];
+
+  // Priority 1: state 3 — System Health Alert. First trigger wins for heroSub.
+  var reasons = [];
+
+  // T1: sensor stall
+  var telemetrySecs = (typeof status.last_telemetry_secs === 'number')
+    ? status.last_telemetry_secs : null;
+  if (telemetrySecs != null && telemetrySecs > HOME_TELEMETRY_STALL_SECS) {
+    var mins = Math.floor(telemetrySecs / 60);
+    reasons.push('Sensor has not reported for ' + mins + ' minute' + (mins === 1 ? '' : 's') + '. AI is operating on cached signals.');
+  }
+
+  // T2: currently failing reverts
+  var stateCounts = rd.state_counts || {};
+  var revertFailed = +stateCounts.revert_failed || 0;
+  if (revertFailed > 0) {
+    reasons.push(revertFailed + ' response revert' + (revertFailed === 1 ? '' : 's') + ' currently failing. AI has logged the failures.');
+  }
+
+  // T3: recent orphans in history (walk last 24h)
+  var history = Array.isArray(rd.history) ? rd.history : [];
+  var now = Date.now();
+  var recentOrphans = history.filter(function(h) {
+    var reason = (h && h.reason) || '';
+    if (!reason.indexOf || reason.indexOf('orphaned') !== 0) return false;
+    var ts = h.reverted_at ? new Date(h.reverted_at).getTime() : 0;
+    return ts > 0 && (now - ts) < HOME_ORPHAN_WINDOW_MS;
+  }).length;
+  if (recentOrphans > 0) {
+    reasons.push(recentOrphans + ' response' + (recentOrphans === 1 ? '' : 's') + ' orphaned in the last 24 hours. AI gave up retrying.');
+  }
+
+  if (reasons.length > 0) {
+    return {
+      state: 'health_alert',
+      maxSeverity: 'critical',
+      heroClass: 'status-hero alert-critical',
+      heroIcon: '\u26A0',
+      heroTitle: 'System Health Alert',
+      heroSub: reasons[0],
+      healthAlertReasons: reasons
+    };
+  }
+
+  // Priority 2: state 2 — AI Responding to Active Threats.
+  if (activeList.length > 0) {
+    var maxSev = maxSeverity(activeList);
+    var heroClass, heroTitle;
+    if (maxSev === 'critical') {
+      heroClass = 'status-hero alert-high';
+      heroTitle = 'AI Responding to Critical Activity';
+    } else if (maxSev === 'high') {
+      heroClass = 'status-hero alert-medium';
+      heroTitle = 'AI Responding to High-Severity Activity';
+    } else {
+      heroClass = 'status-hero alert-low';
+      heroTitle = 'AI Responding';
+    }
+    var n = activeList.length;
+    return {
+      state: 'ai_responding',
+      maxSeverity: maxSev,
+      heroClass: heroClass,
+      heroIcon: '\u26A1',
+      heroTitle: heroTitle,
+      heroSub: 'Processing ' + n + ' active threat' + (n === 1 ? '' : 's') + '. No action from you.',
+      healthAlertReasons: []
+    };
+  }
+
+  // Priority 3: state 1 — AI Protection Active (baseline).
+  return {
+    state: 'protection_active',
+    maxSeverity: 'info',
+    heroClass: 'status-hero alert-info',
+    heroIcon: '\uD83D\uDEE1',
+    heroTitle: 'AI Protection Active',
+    heroSub: 'All systems monitoring. AI is watching.',
+    healthAlertReasons: []
+  };
+}
+
+// ── Hero ─────────────────────────────────────────────────────────────
+function updateHomeBanner(status, homeState) {
+  var hero  = document.getElementById('homeHero');
+  var icon  = document.getElementById('homeHeroIcon');
   var title = document.getElementById('homeHeroTitle');
-  var sub = document.getElementById('homeHeroSub');
-  var meta = document.getElementById('homeStatusMeta');
+  var sub   = document.getElementById('homeHeroSub');
+  var meta  = document.getElementById('homeStatusMeta');
   if (!hero || !icon || !title || !sub) return;
 
-  var u = getUnresolved();
-  var noise = overview.ai_ignored || 0;
-  var events = overview.events_count || 0;
-  // Include open high/critical incidents in unresolved count
-  var totalUnresolved = u.unresolved + (openHighCritical || 0);
-
-  if (totalUnresolved > 0) {
-    hero.className = 'status-hero danger';
-    icon.textContent = '\u26A0\uFE0F';
-    title.innerHTML = totalUnresolved + ' Unresolved Threat' + (totalUnresolved > 1 ? 's' : '') +
-      ' <button onclick="showView(\'investigate\')" style="' +
-      'margin-left:12px;padding:6px 16px;border-radius:8px;border:1px solid var(--danger);' +
-      'background:rgba(244,63,94,0.1);color:var(--danger);font-size:0.75rem;font-weight:700;' +
-      'cursor:pointer;vertical-align:middle' +
-      '">Review Threats \u2192</button>';
-    sub.textContent = u.handled + ' contained \u00B7 ' + noise + ' noise filtered';
-  } else if (u.total > 0) {
-    hero.className = 'status-hero safe';
-    icon.textContent = '\uD83D\uDEE1\uFE0F';
-    title.textContent = 'All Threats Contained';
-    sub.textContent = u.total + ' detected \u00B7 ' + u.handled + ' handled \u00B7 ' + noise + ' noise filtered';
-  } else {
-    hero.className = 'status-hero safe';
-    icon.textContent = '\u2705';
-    title.textContent = 'All Clear';
-    sub.textContent = 'No confirmed threats \u00B7 ' + events + ' events analyzed';
-  }
+  hero.className  = homeState.heroClass;
+  icon.textContent  = homeState.heroIcon;
+  title.textContent = homeState.heroTitle;
+  sub.textContent   = homeState.heroSub;
 
   if (meta) {
     var mode = (status.mode || 'read_only').replace('_', '-').toUpperCase();
-    var heartbeat = status.last_telemetry_secs != null ? status.last_telemetry_secs + 's ago' : 'n/a';
-    var aiText = status.ai_enabled ? (status.ai_provider || 'on') : 'off';
-    meta.innerHTML = '<span>MODE: ' + mode + '</span><span>\u2764 ' + heartbeat + '</span>';
+    var telemetrySecs = status.last_telemetry_secs;
+    var telemetryHtml;
+    if (typeof telemetrySecs !== 'number') {
+      telemetryHtml = '<span class="home-meta-item">\u2764 n/a</span>';
+    } else if (telemetrySecs > HOME_TELEMETRY_STALL_SECS) {
+      var m = Math.floor(telemetrySecs / 60);
+      telemetryHtml = '<span class="home-meta-item home-stale-strong">Data stalled \u00B7 ' + m + 'm since last telemetry</span>';
+    } else if (telemetrySecs > HOME_TELEMETRY_STALE_SOFT_SECS) {
+      telemetryHtml = '<span class="home-meta-item home-stale-soft">Data may be delayed \u00B7 ' + telemetrySecs + 's since last telemetry</span>';
+    } else {
+      telemetryHtml = '<span class="home-meta-item">\u2764 ' + telemetrySecs + 's ago</span>';
+    }
+
+    var links = '<a href="javascript:void(0)" class="home-link" onclick="viewActivity()">View activity \u2192</a>';
+    if (homeState.state === 'health_alert') {
+      links += ' <a href="javascript:void(0)" class="home-link" onclick="viewSystemHealth()">View system health \u2192</a>';
+    }
+
+    meta.innerHTML =
+      '<span class="home-meta-item">MODE: ' + mode + '</span>' +
+      telemetryHtml +
+      '<span class="home-meta-links">' + links + '</span>';
   }
 }
 
+// ── Now section (2 lines, always observational) ─────────────────────
+function updateHomeNow(overview, activeCount, softStale) {
+  var whatEl = document.getElementById('homeNowWhat');
+  var didEl  = document.getElementById('homeNowDid');
+  if (!whatEl || !didEl) return;
+
+  var eventsCount = overview.events_count || 0;
+  var contained   = overview.ai_responded || 0;
+  var noise       = overview.ai_ignored || 0;
+
+  // Line 1 — What happened
+  var line1;
+  if (eventsCount === 0) {
+    line1 = 'No events detected in the last 24 hours.';
+  } else {
+    line1 = eventsCount.toLocaleString() + ' events detected in the last 24 hours.';
+  }
+  if (softStale) {
+    line1 = 'Telemetry is a few minutes behind. ' + line1;
+  }
+
+  whatEl.textContent = line1;
+
+  // Line 2 — What the system did
+  var line2;
+  if (contained === 0 && noise === 0 && activeCount === 0) {
+    line2 = 'AI is monitoring. No actions taken yet.';
+  } else {
+    line2 = 'AI contained ' + contained + ' automatically. ' +
+            'Filtered ' + noise + ' as noise. ' +
+            'Currently processing ' + activeCount + '.';
+  }
+  didEl.textContent = line2;
+}
+
+// ── KPIs with fixed temporal sub-labels ──────────────────────────────
 function updateHomeKpis(overview) {
   var u = getUnresolved();
+
   var el = document.getElementById('homeKpiThreats');
-  if (el) {
-    el.textContent = u.total || 0;
-    el.style.color = u.unresolved > 0 ? 'var(--danger)' : u.total > 0 ? 'var(--ok)' : 'var(--accent)';
-  }
+  if (el) el.textContent = u.total || 0;
+
   el = document.getElementById('homeKpiResponded');
   if (el) el.textContent = overview.ai_responded || 0;
+
   el = document.getElementById('homeKpiEvents');
   if (el) el.textContent = (overview.events_count || 0).toLocaleString();
+
+  // Fixed sub-labels: Today / Today / Live (today)
+  setKpiWindow('homeKpiThreatsWindow',   formatWindow('today'));
+  setKpiWindow('homeKpiRespondedWindow', formatWindow('today'));
+  setKpiWindow('homeKpiEventsWindow',    'Live (today)');
+}
+
+function setKpiWindow(id, text) {
+  var el = document.getElementById(id);
+  if (el) el.textContent = text;
 }
 
 // ── AI Intelligence Briefing ────────────────────────────────────────
@@ -93,7 +259,10 @@ async function loadBriefing() {
         '<div>' + esc(data.summary).replace(/\n/g, '<br>').replace(/\*\*(.*?)\*\*/g, '<strong>$1</strong>') + '</div>';
       btn.textContent = 'Regenerate';
     } else {
-      content.innerHTML = '<div style="color:var(--dim);font-size:0.75rem">' + esc(data.message || 'Click Generate to create your first briefing.') + '</div>';
+      // Spec 017 Change 7 — exact approved English copy.
+      content.innerHTML = '<div class="briefing-empty">' +
+        esc("No briefing yet. You're protected, and we are still monitoring. Generate a briefing now for a quick summary.") +
+        '</div>';
     }
   } catch(e) {
     section.style.display = 'none';
@@ -121,18 +290,34 @@ async function generateBriefing() {
   if (btn) { btn.textContent = 'Regenerate'; btn.disabled = false; }
 }
 
+// ── Recent Activity (severity × outcome hierarchy, never red) ──────
 function buildHomeFeed(incidents) {
   var feedEl = document.getElementById('homeFeed');
   if (!feedEl) return;
-  // Filter trusted incidents if global toggle is on
-  if (state.hideAllowlisted) {
-    incidents = (incidents || []).filter(function(inc) { return !isIncidentTrusted(inc); });
-  }
-  if (!incidents || incidents.length === 0) {
-    feedEl.innerHTML = '<div style="padding:30px;text-align:center"><div style="font-size:1.2rem;margin-bottom:6px">\u2705</div><div style="color:var(--ok);font-size:0.82rem;font-weight:600">No security events</div><div style="color:var(--dim);font-size:0.72rem;margin-top:4px">All systems nominal</div></div>';
+
+  incidents = (incidents || []).slice();
+
+  if (incidents.length === 0) {
+    feedEl.innerHTML =
+      '<div class="home-feed-empty">' +
+      '<div class="home-feed-empty-icon">\u2705</div>' +
+      '<div class="home-feed-empty-title">No events in view.</div>' +
+      '<div class="home-feed-empty-sub">AI is monitoring.</div>' +
+      '</div>';
     return;
   }
-  // Chronological feed — most recent first, no aggregation
+
+  // Sort: open first, then severity desc, then ts desc.
+  incidents.sort(function(a, b) {
+    var ao = (a.outcome || 'open') === 'open' ? 0 : 1;
+    var bo = (b.outcome || 'open') === 'open' ? 0 : 1;
+    if (ao !== bo) return ao - bo;
+    var as = severityRank(a.effective_severity || a.severity);
+    var bs = severityRank(b.effective_severity || b.severity);
+    if (as !== bs) return bs - as;
+    return (new Date(b.ts).getTime() || 0) - (new Date(a.ts).getTime() || 0);
+  });
+
   var html = '<div class="activity-feed">';
   incidents.slice(0, 15).forEach(function(inc) {
     var slug = (inc.incident_id || '').split(':')[0] || '';
@@ -146,19 +331,37 @@ function buildHomeFeed(incidents) {
     });
     var ipVal = ipEntity ? (ipEntity.value || (typeof ipEntity === 'string' ? ipEntity.slice(3) : '')) : '';
 
-    var icon = '\u26A0\uFE0F';
-    if (outcome === 'blocked' || outcome === 'killed' || outcome === 'contained' || outcome === 'suspended') icon = '\uD83D\uDEE1\uFE0F';
+    // Row class: severity × outcome. Open + critical/high uses
+    // .alert-high / .alert-medium (orange/amber) — never .alert-critical.
+    var rowClass = 'feed-row';
+    if (outcome === 'blocked' || outcome === 'killed' || outcome === 'contained' || outcome === 'suspended') {
+      rowClass += ' feed-handled';
+    } else if (outcome === 'ignored') {
+      rowClass += ' feed-noise';
+    } else if (outcome === 'monitored') {
+      rowClass += ' feed-monitor';
+    } else if (outcome === 'honeypot') {
+      rowClass += ' feed-honeypot';
+    } else {
+      // open — scale by severity, but never red
+      if (sev === 'critical')    rowClass += ' alert-high';
+      else if (sev === 'high')   rowClass += ' alert-medium';
+      else if (sev === 'medium') rowClass += ' alert-low';
+      else                       rowClass += ' feed-muted';
+    }
+
+    var icon = '\u26A0';
+    if (outcome === 'blocked' || outcome === 'killed' || outcome === 'contained' || outcome === 'suspended') icon = '\uD83D\uDEE1';
     else if (outcome === 'ignored') icon = '\u2796';
-    else if (sev === 'critical' || sev === 'high') icon = '\uD83D\uDD34';
+    else if (sev === 'critical' || sev === 'high') icon = '\u26A1';
 
     var badge = outcomeBadgeHtml(outcome);
-    var rowOpacity = outcome === 'ignored' ? '0.5' : (outcome === 'open' ? '1' : '0.8');
 
-    html += '<div class="activity-row" style="opacity:' + rowOpacity + '" onclick="showView(\'investigate\');handleCardClickByValue(\'ip\',\'' + ipVal + '\')">' +
+    html += '<div class="' + rowClass + '" onclick="viewActivity();handleCardClickByValue(\'ip\',\'' + ipVal + '\')">' +
       '<span class="activity-icon">' + icon + '</span>' +
       '<div style="flex:1;min-width:0">' +
       '<div style="display:flex;align-items:center;gap:8px;flex-wrap:wrap">' +
-      '<span style="font-size:0.8rem;font-weight:600;color:var(--fg)">' + label + '</span>' +
+      '<span style="font-size:0.8rem;font-weight:600;color:var(--text)">' + label + '</span>' +
       badge +
       '</div>' +
       (ipVal ? '<div style="font-size:0.72rem;color:var(--muted);margin-top:2px;font-family:\'JetBrains Mono\',monospace">' + ipVal + '</div>' : '') +
@@ -170,25 +373,64 @@ function buildHomeFeed(incidents) {
   feedEl.innerHTML = html;
 }
 
+// ── Data Collection (summary + collapsed details) ───────────────────
 function updateCollectorStrip(sensors) {
   var stripEl = document.getElementById('homeCollectorStrip');
   if (!stripEl) return;
   var sources = sensors.sources || [];
   var active = sources.filter(function(s) { return s.count > 0; });
   var total = sources.length;
-  var html = '<div class="collector-summary-line">' + active.length + '/' + total + ' collectors active</div>';
+  var ratio = total > 0 ? (active.length / total) : 1;
+
+  var summaryClass = 'collector-summary-line';
+  if (ratio < 0.8) summaryClass += ' alert-medium';
+  else if (ratio < 1) summaryClass += ' alert-low';
+  else summaryClass += ' alert-info';
+
+  var html = '<div class="' + summaryClass + '">' +
+    active.length + ' of ' + total + ' data sources active' +
+    ' <button type="button" class="collector-details-toggle" onclick="toggleCollectorDetails()">Show details</button>' +
+    '</div>';
+
+  html += '<div id="homeCollectorDetails" class="collector-details" style="display:none">';
   active.forEach(function(s) {
     var color = sensorColor(s.name);
+    var label = typeof collectorLabel === 'function' ? collectorLabel(s.name) : s.name;
     html += '<div class="collector-row">' +
       '<span class="collector-dot" style="background:' + color + ';box-shadow:0 0 6px ' + color + '"></span>' +
-      '<span class="collector-name">' + s.name + '</span>' +
+      '<span class="collector-name">' + label + '</span>' +
       '<span class="collector-count" style="color:' + color + '">' + s.count.toLocaleString() + '</span>' +
       '</div>';
   });
   if (sources.length > active.length) {
     var idle = sources.length - active.length;
-    html += '<div style="font-size:0.68rem;color:var(--dim);margin-top:4px">' + idle + ' idle</div>';
+    html += '<div class="collector-idle-note">' + idle + ' idle</div>';
   }
+  html += '</div>';
   stripEl.innerHTML = html;
 }
 
+function toggleCollectorDetails() {
+  var el = document.getElementById('homeCollectorDetails');
+  if (!el) return;
+  var btn = document.querySelector('.collector-details-toggle');
+  if (el.style.display === 'none') {
+    el.style.display = '';
+    if (btn) btn.textContent = 'Hide details';
+  } else {
+    el.style.display = 'none';
+    if (btn) btn.textContent = 'Show details';
+  }
+}
+
+// ── Handoff links ────────────────────────────────────────────────────
+// Both links are observational. No imperative copy. The consume-once
+// semantics of autoSelectOnThreatsOpen are honored by 02-threats.md.
+function viewActivity() {
+  state.autoSelectOnThreatsOpen = 'first_critical_or_high';
+  showView('investigate');
+}
+
+function viewSystemHealth() {
+  showView('status');
+}

--- a/crates/agent/src/dashboard/frontend/js/home.js
+++ b/crates/agent/src/dashboard/frontend/js/home.js
@@ -18,6 +18,7 @@ async function loadHome() {
       loadJson('/api/responses').catch(function() { return {}; })
     ]);
     window._lastOverview = overview;
+    window._agentMode = status.mode || 'guard';
 
     // Filtered base matches what Recent Activity will render.
     var items = incidentList.items || [];
@@ -46,8 +47,13 @@ async function loadHome() {
       && telemetrySecs <= HOME_TELEMETRY_STALL_SECS);
 
     updateHomeBanner(status, homeState);
-    updateHomeNow(overview, activeHighCriticalList.length, softStale);
-    updateHomeKpis(overview);
+    // Total events scanned from sensors (trust signal: "3.3M scanned → 2 blocked")
+    var totalEventsScanned = 0;
+    (sensors.sources || []).forEach(function(s) { totalEventsScanned += s.count || 0; });
+    window._totalEventsScanned = totalEventsScanned;
+
+    updateHomeNow(overview, activeHighCriticalList.length, softStale, totalEventsScanned);
+    updateHomeKpis(overview, totalEventsScanned);
     buildHomeFeed(base);
     updateCollectorStrip(sensors);
     loadBriefing();
@@ -106,40 +112,48 @@ function computeHomeState(payload) {
     };
   }
 
-  // Priority 2: state 2 — AI Responding to Active Threats.
-  if (activeList.length > 0) {
-    var maxSev = maxSeverity(activeList);
-    var heroClass, heroTitle;
-    if (maxSev === 'critical') {
-      heroClass = 'status-hero alert-high';
-      heroTitle = 'AI Responding to Critical Activity';
-    } else if (maxSev === 'high') {
-      heroClass = 'status-hero alert-medium';
-      heroTitle = 'AI Responding to High-Severity Activity';
-    } else {
-      heroClass = 'status-hero alert-low';
-      heroTitle = 'AI Responding';
-    }
+  // Priority 2: state 2 — only triggers when the AI genuinely cannot
+  // handle something and needs the operator. With Guard ON, routine
+  // scanners and unresolved incidents are NOT "active threats" — the
+  // AI is processing them autonomously. State 2 only fires for future
+  // AI-escalated items (needs_attention field, not yet implemented).
+  //
+  // With Guard OFF (watch/read_only), ALL unresolved incidents become
+  // the operator's responsibility.
+  var isGuard = (status.mode || 'guard') === 'guard';
+
+  if (!isGuard && activeList.length > 0) {
+    // Guard OFF: operator must decide. Show alarm.
     var n = activeList.length;
     return {
       state: 'ai_responding',
-      maxSeverity: maxSev,
-      heroClass: heroClass,
-      heroIcon: '\u26A1',
-      heroTitle: heroTitle,
-      heroSub: 'Processing ' + n + ' active threat' + (n === 1 ? '' : 's') + '. No action from you.',
+      maxSeverity: maxSeverity(activeList),
+      heroClass: 'status-hero alert-high',
+      heroIcon: '\uD83D\uDC41',
+      heroTitle: 'Detection Mode',
+      heroSub: n + ' threat' + (n === 1 ? '' : 's') + ' detected. AI is watching only \u2014 enable Guard mode for automatic protection.',
       healthAlertReasons: []
     };
   }
 
-  // Priority 3: state 1 — AI Protection Active (baseline).
+  // Guard ON or no active threats: AI Protection Active.
+  // The operator sees confidence, not alarm.
+  var blocked = overview.ai_responded || 0;
+  var observing = activeList.length;
+  var subParts = [];
+  if (blocked > 0) subParts.push(blocked + ' blocked');
+  if (observing > 0) subParts.push(observing + ' observing');
+  var subText = subParts.length > 0
+    ? subParts.join(' \u00B7 ') + '. Everything handled automatically.'
+    : 'All systems monitoring. Nothing requires your attention.';
+
   return {
     state: 'protection_active',
     maxSeverity: 'info',
     heroClass: 'status-hero alert-info',
     heroIcon: '\uD83D\uDEE1',
     heroTitle: 'AI Protection Active',
-    heroSub: 'All systems monitoring. AI is watching.',
+    heroSub: subText,
     healthAlertReasons: []
   };
 }
@@ -186,52 +200,53 @@ function updateHomeBanner(status, homeState) {
 }
 
 // ── Now section (2 lines, always observational) ─────────────────────
-function updateHomeNow(overview, activeCount, softStale) {
+function updateHomeNow(overview, activeCount, softStale, totalEventsScanned) {
   var whatEl = document.getElementById('homeNowWhat');
   var didEl  = document.getElementById('homeNowDid');
   if (!whatEl || !didEl) return;
 
-  var eventsCount = overview.events_count || 0;
-  var contained   = overview.ai_responded || 0;
-  var noise       = overview.ai_ignored || 0;
+  var contained = overview.ai_responded || 0;
+  var total = totalEventsScanned || overview.events_count || 0;
 
-  // Line 1 — What happened
+  // Line 1 — Trust signal: volume scanned
   var line1;
-  if (eventsCount === 0) {
+  if (total === 0) {
     line1 = 'No events detected in the last 24 hours.';
   } else {
-    line1 = eventsCount.toLocaleString() + ' events detected in the last 24 hours.';
+    line1 = total.toLocaleString() + ' events monitored today.';
   }
   if (softStale) {
     line1 = 'Telemetry is a few minutes behind. ' + line1;
   }
-
   whatEl.textContent = line1;
 
-  // Line 2 — What the system did
+  // Line 2 — Outcome summary
   var line2;
-  if (contained === 0 && noise === 0 && activeCount === 0) {
-    line2 = 'AI is monitoring. No actions taken yet.';
+  if (contained === 0 && activeCount === 0) {
+    line2 = 'Nothing suspicious found. All systems operating normally.';
+  } else if (contained > 0 && activeCount === 0) {
+    line2 = 'Blocked ' + contained + ' threat' + (contained > 1 ? 's' : '') + ' automatically. Nothing requires your attention.';
   } else {
-    line2 = 'AI contained ' + contained + ' automatically. ' +
-            'Filtered ' + noise + ' as noise. ' +
-            'Currently processing ' + activeCount + '.';
+    line2 = 'Blocked ' + contained + ' automatically. Observing ' + activeCount + ' more. No action needed.';
   }
   didEl.textContent = line2;
 }
 
 // ── KPIs with fixed temporal sub-labels ──────────────────────────────
-function updateHomeKpis(overview) {
-  var u = getUnresolved();
-
+function updateHomeKpis(overview, totalEventsScanned) {
   var el = document.getElementById('homeKpiThreats');
-  if (el) el.textContent = u.total || 0;
-
-  el = document.getElementById('homeKpiResponded');
   if (el) el.textContent = overview.ai_responded || 0;
 
+  el = document.getElementById('homeKpiResponded');
+  if (el) el.textContent = overview.incidents_count || 0;
+
   el = document.getElementById('homeKpiEvents');
-  if (el) el.textContent = (overview.events_count || 0).toLocaleString();
+  var total = totalEventsScanned || overview.events_count || 0;
+  if (el) el.textContent = total >= 1000000
+    ? (total / 1000000).toFixed(1) + 'M'
+    : total >= 1000
+      ? (total / 1000).toFixed(0) + 'K'
+      : total.toLocaleString();
 
   // Fixed sub-labels: Today / Today / Live (today)
   setKpiWindow('homeKpiThreatsWindow',   formatWindow('today'));
@@ -355,7 +370,12 @@ function buildHomeFeed(incidents) {
     else if (outcome === 'ignored') icon = '\u2796';
     else if (sev === 'critical' || sev === 'high') icon = '\u26A1';
 
-    var badge = outcomeBadgeHtml(outcome);
+    // Map raw outcome to AI-first model: open/active → OBSERVING with Guard ON
+    var mappedOutcome = outcome;
+    if ((outcome === 'open' || outcome === 'active') && (window._agentMode || status?.mode || 'guard') === 'guard') {
+      mappedOutcome = 'monitoring';
+    }
+    var badge = outcomeBadgeHtml(mappedOutcome);
 
     html += '<div class="' + rowClass + '" onclick="viewActivity();handleCardClickByValue(\'ip\',\'' + ipVal + '\')">' +
       '<span class="activity-icon">' + icon + '</span>' +

--- a/crates/agent/src/dashboard/frontend/js/home.js
+++ b/crates/agent/src/dashboard/frontend/js/home.js
@@ -140,12 +140,12 @@ function computeHomeState(payload) {
 
   // Guard ON or no active threats: AI Protection Active.
   // The operator sees confidence, not alarm.
-  // Count unique blocked IPs (same logic as KPI, not decision count)
   var blockedSet = new Set();
   (payload.allIncidents || []).forEach(function(inc) {
     if (inc.outcome === 'blocked' || inc.outcome === 'contained') {
       (inc.entities || []).forEach(function(e) {
-        if ((e.type || '').toLowerCase() === 'ip' && e.value) blockedSet.add(e.value);
+        var s = typeof e === 'string' ? e : (e.value || '');
+        if (s.startsWith('ip:')) blockedSet.add(s.slice(3));
       });
     }
   });
@@ -216,16 +216,16 @@ function updateHomeNow(overview, activeCount, softStale, totalEventsScanned) {
   var didEl  = document.getElementById('homeNowDid');
   if (!whatEl || !didEl) return;
 
-  // Use unique blocked IPs, not decision count (matches KPI + Threats)
   var blockedIpsNow = new Set();
   (window._lastIncidentList || []).forEach(function(inc) {
     if (inc.outcome === 'blocked' || inc.outcome === 'contained') {
       (inc.entities || []).forEach(function(e) {
-        if ((e.type || '').toLowerCase() === 'ip' && e.value) blockedIpsNow.add(e.value);
+        var s = typeof e === 'string' ? e : (e.value || '');
+        if (s.startsWith('ip:')) blockedIpsNow.add(s.slice(3));
       });
     }
   });
-  var contained = blockedIpsNow.size || (overview.ai_responded || 0);
+  var contained = blockedIpsNow.size > 0 ? blockedIpsNow.size : (overview.ai_responded || 0);
   var total = totalEventsScanned || overview.events_count || 0;
 
   // Line 1 — Trust signal: volume scanned
@@ -254,18 +254,19 @@ function updateHomeNow(overview, activeCount, softStale, totalEventsScanned) {
 
 // ── KPIs with fixed temporal sub-labels ──────────────────────────────
 function updateHomeKpis(overview, totalEventsScanned) {
-  // Count unique IPs with block decisions (matches Threats tab entity count)
+  // Count unique IPs with block decisions (matches Threats tab entity count).
+  // API entities are strings "ip:1.2.3.4", not {type,value} objects.
   var blockedIps = new Set();
-  var items = (window._lastIncidentList || []);
-  items.forEach(function(inc) {
+  (window._lastIncidentList || []).forEach(function(inc) {
     if (inc.outcome === 'blocked' || inc.outcome === 'contained') {
       (inc.entities || []).forEach(function(e) {
-        if ((e.type || '').toLowerCase() === 'ip' && e.value) blockedIps.add(e.value);
+        var s = typeof e === 'string' ? e : (e.value || '');
+        if (s.startsWith('ip:')) blockedIps.add(s.slice(3));
       });
     }
   });
   var el = document.getElementById('homeKpiThreats');
-  if (el) el.textContent = blockedIps.size || overview.ai_responded || 0;
+  if (el) el.textContent = blockedIps.size > 0 ? blockedIps.size : (overview.ai_responded || 0);
 
   el = document.getElementById('homeKpiResponded');
   if (el) el.textContent = overview.incidents_count || 0;

--- a/crates/agent/src/dashboard/frontend/js/journey.js
+++ b/crates/agent/src/dashboard/frontend/js/journey.js
@@ -286,6 +286,31 @@ function renderEvidenceCard(entry, idx) {
     </div>`;
 }
 
+function toggleTimeline() {
+  var el = document.getElementById('timelineSection');
+  if (!el) return;
+  var isOpen = el.style.display !== 'none';
+  el.style.display = isOpen ? 'none' : 'block';
+}
+
+async function askAiExplain(subjectType, subjectValue) {
+  var resultEl = document.getElementById('aiExplainResult');
+  if (!resultEl) return;
+  resultEl.style.display = 'block';
+  resultEl.innerHTML = '<div style="font-size:0.75rem;color:var(--muted)">Asking AI to explain...</div>';
+  try {
+    var resp = await fetch('/api/ai-explain?type=' + encodeURIComponent(subjectType) + '&value=' + encodeURIComponent(subjectValue), { cache: 'no-store' });
+    if (!resp.ok) throw new Error('HTTP ' + resp.status);
+    var data = await resp.json();
+    resultEl.innerHTML =
+      '<div style="font-size:0.68rem;font-weight:700;color:var(--accent);letter-spacing:0.05em;text-transform:uppercase;margin-bottom:6px">\uD83E\uDD16 AI Explanation</div>' +
+      '<div style="font-size:0.8rem;color:var(--text);line-height:1.6">' + esc(data.explanation || 'No explanation available.') + '</div>';
+  } catch (e) {
+    resultEl.innerHTML =
+      '<div style="font-size:0.75rem;color:var(--warn)">AI explanation not available yet. This feature requires the AI provider to be configured and reachable.</div>';
+  }
+}
+
 function toggleRaw(idx) {
   const el = document.getElementById('raw-' + idx);
   if (!el) return;
@@ -413,7 +438,7 @@ async function loadJourney(subjectType, subjectValue) {
       </div>
       <div class="journey-header">
         <span class="journey-ip">${esc(j.subject || subjectValue)}</span>
-        <span class="${outcomeCls(j.outcome)}">${outcomeLabel(j.outcome)}</span>
+        <span class="${outcomeCls(j.outcome)}">${outcomeLabel(typeof outcomeOf === 'function' ? outcomeOf({outcome: j.outcome}) : j.outcome)}</span>
         <span class="journey-time">${esc(first)} → ${esc(last)}</span>
       </div>
       <div class="journey-subtitle">${esc((j.subject_type || subjectType).toUpperCase())} journey · ${j.entries.length} timeline entries · click any row to expand</div>
@@ -424,39 +449,93 @@ async function loadJourney(subjectType, subjectValue) {
       </div>
       ${renderVerdictCard(j)}
       ${(function() {
-        // TL;DR — auto-generated narrative from key entries
+        // TL;DR — human-readable narrative, mode-aware.
         const incidents = j.entries.filter(e => e.kind === 'incident');
         const decisions = j.entries.filter(e => e.kind === 'decision');
         const blocks = decisions.filter(e => (e.action||'').includes('block'));
         if (incidents.length === 0 && decisions.length === 0) return '';
 
         const topIncident = incidents.length > 0 ? incidents[0] : null;
-        const topDetector = topIncident ? (topIncident.detector || 'unknown') : '';
+        const topData = topIncident ? (topIncident.data || {}) : {};
+        const topDetector = topData.detector || (topData.incident_id || '').split(':')[0] || '';
+        const topTitle = topData.title || '';
         const wasBlocked = blocks.length > 0;
+        const isGuard = (window._agentMode || 'guard') === 'guard';
+        const isResolved = j.outcome === 'blocked' || j.outcome === 'honeypot';
+
+        // Collect all unique detectors across incidents for multi-detector signal
+        const allDetectors = new Set();
+        incidents.forEach(function(inc) {
+          var d = (inc.data || {}).detector || ((inc.data || {}).incident_id || '').split(':')[0] || '';
+          if (d) allDetectors.add(d);
+        });
+        const detLabels = Array.from(allDetectors).map(function(d) { return humanLabel(d); });
 
         let narrative = '';
         if (topIncident) {
-          narrative += '<strong>' + esc(topDetector.replace(/_/g, ' ')) + '</strong> detected';
+          // Use the incident title for specific context, detector label as category
+          if (topTitle && topTitle !== 'unknown') {
+            narrative += '<strong>' + esc(topTitle) + '</strong>';
+          } else {
+            narrative += '<strong>' + esc(detLabels[0] || 'Threat') + '</strong> detected';
+          }
           if (incidents.length > 1) narrative += ' (' + incidents.length + ' incidents total)';
+          if (detLabels.length > 1) {
+            narrative += '. Triggered <strong>' + detLabels.length + ' detectors</strong>: ' + esc(detLabels.join(', '));
+          }
           narrative += '. ';
         }
         if (wasBlocked) {
-          narrative += 'AI decided to <strong style="color:var(--ok)">block</strong>';
+          narrative += 'The AI <strong style="color:var(--ok)">blocked</strong> this threat';
           if (blocks.length > 1) narrative += ' (' + blocks.length + ' actions)';
           narrative += '. ';
         } else if (decisions.length > 0) {
           const action = decisions[0].action || 'monitor';
-          narrative += 'AI decided to <strong>' + esc(action) + '</strong>. ';
+          narrative += 'The AI decided to <strong>' + esc(action.replace(/_/g, ' ')) + '</strong>. ';
         }
-        if (j.outcome === 'blocked') {
-          narrative += 'Threat <strong style="color:var(--ok)">contained</strong>.';
-        } else if (j.outcome === 'active') {
-          narrative += 'Threat is <strong style="color:var(--danger)">still active</strong>.';
+        if (isResolved) {
+          narrative += 'Threat <strong style="color:var(--ok)">contained</strong>. No action needed.';
+        } else if (isGuard) {
+          narrative += 'The AI is <strong>still observing</strong> this activity.';
         }
 
-        return '<div style="padding:12px 16px;margin-bottom:12px;border-radius:10px;background:rgba(120,229,255,0.04);border:1px solid rgba(120,229,255,0.12)">' +
-          '<div style="font-size:0.68rem;font-weight:700;color:var(--accent);letter-spacing:0.05em;text-transform:uppercase;margin-bottom:4px">TL;DR</div>' +
+        let html = '<div style="padding:12px 16px;margin-bottom:12px;border-radius:10px;background:rgba(120,229,255,0.04);border:1px solid rgba(120,229,255,0.12)">' +
+          '<div style="font-size:0.68rem;font-weight:700;color:var(--accent);letter-spacing:0.05em;text-transform:uppercase;margin-bottom:4px">What happened</div>' +
           '<div style="font-size:0.8rem;color:var(--text);line-height:1.5">' + narrative + '</div></div>';
+
+        // When guard is OFF and the threat is NOT resolved, show a prominent
+        // decision block with AI recommendation + action buttons. This is
+        // the operator's moment to decide.
+        if (!isGuard && !isResolved && subjectType === 'ip') {
+          const topSev = topData.severity || '';
+          const sevHigh = topSev === 'critical' || topSev === 'high';
+          const hasThreatIntel = allDetectors.has('threat_intel') || allDetectors.has('graph_threat_intel');
+          const multiDetector = allDetectors.size > 1;
+
+          let recText = '';
+          if (hasThreatIntel && sevHigh) {
+            recText = 'This IP is in a <strong style="color:var(--danger)">known malicious threat feed</strong> and triggered ' + allDetectors.size + ' detectors. <strong>Blocking is strongly recommended.</strong>';
+          } else if (hasThreatIntel) {
+            recText = 'This IP is in a <strong>known malicious threat feed</strong>. The AI recommends blocking.';
+          } else if (sevHigh && multiDetector) {
+            recText = 'This is a <strong style="color:var(--danger)">' + esc(topSev) + ' severity</strong> threat that triggered ' + allDetectors.size + ' detectors. The AI recommends <strong>blocking this IP</strong>.';
+          } else if (sevHigh) {
+            recText = 'This is a <strong style="color:var(--danger)">' + esc(topSev) + ' severity</strong> threat. The AI recommends <strong>blocking this IP</strong>.';
+          } else {
+            recText = 'The AI detected suspicious activity from this IP. You can block it or continue observing.';
+          }
+
+          html += '<div style="padding:16px;margin-bottom:12px;border-radius:10px;background:rgba(244,63,94,0.06);border:1px solid rgba(244,63,94,0.2)">' +
+            '<div style="font-size:0.68rem;font-weight:700;color:var(--danger);letter-spacing:0.05em;text-transform:uppercase;margin-bottom:6px">\u26A0 Your decision needed</div>' +
+            '<div style="font-size:0.8rem;color:var(--text);line-height:1.5;margin-bottom:12px">' + recText + '</div>' +
+            '<div style="display:flex;gap:8px;flex-wrap:wrap">' +
+              '<button type="button" style="padding:8px 20px;font-size:0.8rem;font-weight:700;border-radius:8px;border:1px solid var(--danger);background:var(--danger);color:#fff;cursor:pointer" onclick="showActionModal(\'block_ip\',\'' + esc(subjectValue) + '\',null)">\u26D4 Block this IP</button>' +
+              '<button type="button" style="padding:8px 20px;font-size:0.8rem;border-radius:8px;border:1px solid var(--line);background:transparent;color:var(--muted);cursor:pointer" onclick="showToast(\'Continuing to observe\',\'ok\')">Keep observing</button>' +
+            '</div>' +
+          '</div>';
+        }
+
+        return html;
       })()}
       <!-- Attack graph available in Graph tab -->
       <div id="journeyGraphContainer" style="display:none"></div>
@@ -467,7 +546,7 @@ async function loadJourney(subjectType, subjectValue) {
           ${shortcutsHtml}
         </section>
         <section class="guided-card">
-          <div class="guided-title">Narrative Hints</div>
+          <div class="guided-title">Intelligence</div>
           ${hintsHtml}
         </section>
       </div>`;
@@ -501,10 +580,38 @@ async function loadJourney(subjectType, subjectValue) {
         </section>`;
     }
 
+    // ── AI Decision Reasoning (surfaced from decision entries) ─────────
+    // Show the AI's own reasoning prominently, before any technical data.
+    // This is the "why" that the operator needs to trust the AI's action.
+    const aiDecisions = j.entries.filter(e => e.kind === 'decision' && (e.data || {}).reason);
+    if (aiDecisions.length > 0) {
+      const dec = aiDecisions[0].data;
+      const conf = ((dec.confidence || 0) * 100).toFixed(0);
+      const wasExecuted = dec.auto_executed && !dec.dry_run;
+      const actionLabel = (dec.action_type || '').replace(/_/g, ' ');
+      html += '<div style="padding:14px 16px;margin-bottom:12px;border-radius:10px;background:rgba(74,222,128,0.04);border:1px solid rgba(74,222,128,0.15)">' +
+        '<div style="font-size:0.68rem;font-weight:700;color:var(--ok);letter-spacing:0.05em;text-transform:uppercase;margin-bottom:6px">' +
+        (wasExecuted ? '\uD83E\uDD16 AI Decision — ' + esc(actionLabel) + ' (' + conf + '% confidence)' : '\uD83E\uDD16 AI Analysis') +
+        '</div>' +
+        '<div style="font-size:0.78rem;color:var(--text);line-height:1.6">' + esc(dec.reason || '') + '</div>' +
+      '</div>';
+    }
+
+    // ── Ask AI button ─────────────────────────────────────────────────
+    html += '<div style="display:flex;gap:8px;margin-bottom:14px;flex-wrap:wrap">' +
+      '<button type="button" class="journey-btn" style="background:rgba(120,229,255,0.08);border-color:var(--accent);color:var(--accent)" ' +
+        'onclick="askAiExplain(\'' + esc(subjectType) + '\',\'' + esc(subjectValue) + '\')">' +
+        '\uD83E\uDD16 Ask AI to explain</button>' +
+      '<button type="button" class="journey-btn" onclick="toggleTimeline()">' +
+        '\uD83D\uDCCB Show ' + j.entries.length + ' technical entries</button>' +
+    '</div>';
+    html += '<div id="aiExplainResult" style="display:none;padding:14px 16px;margin-bottom:12px;border-radius:10px;background:rgba(120,229,255,0.04);border:1px solid rgba(120,229,255,0.12)"></div>';
+
+    // ── Chapter rail (collapsed with timeline) ─────────────────────────
+    html += '<div id="timelineSection" style="display:none">';
     html += renderChapterRail(j);
 
-    html += `
-      <div class="timeline">`;
+    html += '<div class="timeline">';
 
     if (j.entries.length === 0) {
       html += '<div class="empty">No entries found for this selection on the chosen filters.</div>';
@@ -512,7 +619,7 @@ async function loadJourney(subjectType, subjectValue) {
       j.entries.forEach((e, i) => { html += renderEntry(e, i); });
     }
 
-    html += '</div>';
+    html += '</div></div>';
     document.getElementById('journeyContent').innerHTML = html;
 
     // Load mini-graph for this subject

--- a/crates/agent/src/dashboard/frontend/js/journey.js
+++ b/crates/agent/src/dashboard/frontend/js/journey.js
@@ -438,7 +438,7 @@ async function loadJourney(subjectType, subjectValue) {
       </div>
       <div class="journey-header">
         <span class="journey-ip">${esc(j.subject || subjectValue)}</span>
-        <span class="${outcomeCls(j.outcome)}">${outcomeLabel(typeof outcomeOf === 'function' ? outcomeOf({outcome: j.outcome}) : j.outcome)}</span>
+        <span class="${outcomeCls(typeof outcomeOf === 'function' ? outcomeOf({outcome: j.outcome}) : j.outcome)}">${outcomeLabel(typeof outcomeOf === 'function' ? outcomeOf({outcome: j.outcome}) : j.outcome)}</span>
         <span class="journey-time">${esc(first)} → ${esc(last)}</span>
       </div>
       <div class="journey-subtitle">${esc((j.subject_type || subjectType).toUpperCase())} journey · ${j.entries.length} timeline entries · click any row to expand</div>
@@ -447,7 +447,7 @@ async function loadJourney(subjectType, subjectValue) {
         <button type="button" class="journey-btn" onclick="downloadSnapshot('md')">Export Markdown</button>
         ${actionBtns}
       </div>
-      ${renderVerdictCard(j)}
+      <!-- verdict card removed: narrative "What happened" + Intelligence section cover this -->
       ${(function() {
         // TL;DR — human-readable narrative, mode-aware.
         const incidents = j.entries.filter(e => e.kind === 'incident');

--- a/crates/agent/src/dashboard/frontend/js/sensors.js
+++ b/crates/agent/src/dashboard/frontend/js/sensors.js
@@ -109,20 +109,25 @@ async function loadTopAction() {
       return;
     }
 
-    // There are threats — show the most urgent one
+    // There are incidents the AI is handling. With Guard ON, present
+    // as informational (blue), not alarming (red). The AI is autonomous.
     const topThreat = threats.length > 0 ? threats[0] : null;
-    const colors = { critical: '#f43f5e', high: '#fb923c', medium: '#facc15' };
-    const color = colors[level] || colors.medium;
+    const isGuard = (window._agentMode || 'guard') === 'guard';
+    const color = isGuard ? '#78e5ff' : (level === 'critical' ? '#f43f5e' : '#fb923c');
 
     el.style.display = 'block';
-    el.style.borderColor = color.replace(')', ',0.4)').replace('#', 'rgba(') || 'rgba(244,63,94,0.3)';
-    el.style.background = 'linear-gradient(135deg, rgba(244,63,94,0.06), transparent)';
+    el.style.borderColor = isGuard ? 'rgba(120,229,255,0.3)' : 'rgba(244,63,94,0.3)';
+    el.style.background = isGuard ? 'rgba(120,229,255,0.04)' : 'linear-gradient(135deg, rgba(244,63,94,0.06), transparent)';
+
+    const statusLabel = isGuard
+      ? hc + ' incident' + (hc > 1 ? 's' : '') + ' being handled by AI'
+      : hc + ' unresolved ' + (level === 'critical' ? 'CRITICAL' : 'high-severity') + ' incident' + (hc > 1 ? 's' : '');
 
     let actionHtml = '<div style="display:flex;align-items:center;justify-content:space-between;gap:14px;flex-wrap:wrap">' +
       '<div style="display:flex;align-items:center;gap:10px">' +
-      '<span style="font-size:1.3rem">' + (level === 'critical' ? '&#128680;' : '&#9888;&#65039;') + '</span>' +
+      '<span style="font-size:1.3rem">' + (isGuard ? '&#128737;' : (level === 'critical' ? '&#128680;' : '&#9888;&#65039;')) + '</span>' +
       '<div>' +
-      '<div style="font-size:0.85rem;font-weight:700;color:' + color + '">' + hc + ' unresolved ' + (level === 'critical' ? 'CRITICAL' : 'high-severity') + ' incident' + (hc > 1 ? 's' : '') + '</div>' +
+      '<div style="font-size:0.85rem;font-weight:700;color:' + color + '">' + statusLabel + '</div>' +
       '<div style="font-size:0.7rem;color:var(--muted)">';
 
     if (topThreat) {

--- a/crates/agent/src/dashboard/frontend/js/state.js
+++ b/crates/agent/src/dashboard/frontend/js/state.js
@@ -13,6 +13,10 @@ const state = {
   knownItemValues: new Set(),  // D7: tracks rendered entity values for diff
   hideAllowlisted: true,
   filterOutcome: null,
+  // spec 017 01-home Change 8: consume-once handoff from Home's
+  // viewActivity() to Threats. 02-threats.md's responsibility to
+  // read-and-clear this flag after selecting the first matching item.
+  autoSelectOnThreatsOpen: null,
 };
 
 const pivotTitle = (pivot) => ({

--- a/crates/agent/src/dashboard/frontend/js/threats.js
+++ b/crates/agent/src/dashboard/frontend/js/threats.js
@@ -100,10 +100,8 @@ function showContained() {
 
 function toggleAllowlistFilter() {
   state.hideAllowlisted = document.getElementById('hideAllowlisted')?.checked || false;
-  if (state.hideAllowlisted && _trustedIps.length === 0 && actionCfg) {
-    _trustedIps = actionCfg.trusted_ips || [];
-    _trustedUsers = actionCfg.trusted_users || [];
-  }
+  // _trustedIps / _trustedUsers are loaded at boot by loadActionConfig()
+  // in actions.js (called from sse.js module load). No lazy-load needed.
   refreshLeft(false);
   // Also refresh Home if visible
   if (document.getElementById('viewHome').style.display !== 'none') loadHome();

--- a/crates/agent/src/dashboard/frontend/js/threats.js
+++ b/crates/agent/src/dashboard/frontend/js/threats.js
@@ -9,68 +9,105 @@ var DETECTOR_PRIORITY = {
   logging_config_change: 3, suspicious_archive: 2
 };
 
+// Outcome display order and labels for the AI-first audit trail.
+// Threats is NOT a triage queue — the AI decides and acts. The operator
+// reads outcomes, not work items. Grouping by outcome answers "what did
+// the AI do?" instead of "what detector fired?".
+var OUTCOME_ORDER = ['needs_attention', 'blocked', 'honeypot', 'monitoring', 'dismissed'];
+var OUTCOME_META = {
+  blocked:         { icon: '\uD83D\uDEE1\uFE0F', label: 'Blocked',          cls: 'outcome-blocked' },
+  honeypot:        { icon: '\uD83C\uDF6F',       label: 'Honeypot',          cls: 'outcome-honeypot' },
+  monitoring:      { icon: '\uD83D\uDC41\uFE0F', label: 'Observing',         cls: 'outcome-observing' },
+  needs_attention: { icon: '\u26A0\uFE0F',       label: 'Needs your attention', cls: 'outcome-attention' },
+  dismissed:       { icon: '\u2713',              label: 'Dismissed',         cls: 'outcome-dismissed' },
+};
+
+function outcomeOf(item) {
+  var o = (item.outcome || '').toLowerCase();
+  if (o === 'blocked') return 'blocked';
+  if (o === 'honeypot') return 'honeypot';
+  if (o === 'monitoring') return 'monitoring';
+  if (o === 'ignored' || o === 'noise' || o === 'dismissed') return 'dismissed';
+  // 'active', 'open', '' → depends on operational mode:
+  //   Guard ON:  AI is processing autonomously → 'monitoring' (observing)
+  //   Guard OFF: AI detected but CANNOT act    → 'needs_attention' (operator must decide)
+  var mode = (window._agentMode || 'guard');
+  if (mode === 'guard') return 'monitoring';
+  return 'needs_attention';
+}
+
 function buildGroupedList(items) {
   // Filter out trusted/private IPs if toggle is on
   if (state.hideAllowlisted) {
     items = items.filter(function(item) { return !isIpTrusted(item.value) && !isPrivateIp(item.value); });
   }
-  // Filter by outcome if set (e.g. from Home KPI click)
+  // Filter by outcome if set (e.g. from Home CTA click)
   var titleEl = document.getElementById('entityTitle');
   if (state.filterOutcome === 'contained') {
     items = items.filter(function(item) { return ['blocked','monitoring','honeypot'].includes(item.outcome || ''); });
-    if (titleEl) titleEl.innerHTML = 'Contained Threats <span style="font-size:0.6rem;color:var(--muted);cursor:pointer;margin-left:6px" onclick="state.filterOutcome=null;refreshLeft(false)">\u2715 clear filter</span>';
+    if (titleEl) titleEl.innerHTML = 'AI Defense Log <span style="font-size:0.6rem;color:var(--muted);cursor:pointer;margin-left:6px" onclick="state.filterOutcome=null;refreshLeft(false)">\u2715 clear filter</span>';
   } else {
-    if (titleEl) titleEl.textContent = 'Defense Activity';
+    if (titleEl) titleEl.textContent = 'AI Defense Log';
   }
-  // Each IP goes to the group of its highest-priority detector. No duplicates.
+
+  // Group by outcome (what the AI did), not by detector (what was found).
   var seen = {};
   var groups = {};
+  OUTCOME_ORDER.forEach(function(o) {
+    groups[o] = { outcome: o, items: [] };
+  });
+
   items.forEach(function(item) {
-    if (seen[item.value]) return; // skip duplicate IPs
+    if (seen[item.value]) return;
     seen[item.value] = true;
-    var dets = item.detectors || [];
-    var primary = 'unknown';
-    var bestPrio = -1;
-    dets.forEach(function(d) {
-      // Strip graph_ prefix for priority lookup (graph detectors use graph_threat_intel, etc.)
-      var base = d.replace(/^graph_/, '');
-      var p = DETECTOR_PRIORITY[base] || DETECTOR_PRIORITY[d] || 0;
-      if (p > bestPrio) { bestPrio = p; primary = base; }
+    var o = outcomeOf(item);
+    if (!groups[o]) groups[o] = { outcome: o, items: [] };
+    groups[o].items.push(item);
+  });
+
+  // Sort items within each group: highest severity first, then most recent
+  var sevRank = { critical: 4, high: 3, medium: 2, low: 1, info: 0 };
+  Object.values(groups).forEach(function(g) {
+    g.items.sort(function(a, b) {
+      var sa = sevRank[(a.max_severity || '').toLowerCase()] || 0;
+      var sb = sevRank[(b.max_severity || '').toLowerCase()] || 0;
+      if (sb !== sa) return sb - sa;
+      return (b.last_seen || '') > (a.last_seen || '') ? 1 : -1;
     });
-    if (bestPrio < 0 && dets.length > 0) primary = dets[0];
-    if (!groups[primary]) groups[primary] = { detector: primary, items: [], hasOpen: false };
-    groups[primary].items.push(item);
-    if (!['blocked','monitoring','honeypot'].includes(item.outcome || '')) groups[primary].hasOpen = true;
   });
-  // Sort: groups with open items first, then by item count descending
-  var sorted = Object.values(groups).sort(function(a, b) {
-    if (a.hasOpen && !b.hasOpen) return -1;
-    if (!a.hasOpen && b.hasOpen) return 1;
-    return b.items.length - a.items.length;
-  });
+
   var html = '';
-  sorted.forEach(function(g, idx) {
-    var label = humanLabel(g.detector);
+  OUTCOME_ORDER.forEach(function(o, idx) {
+    var g = groups[o];
+    if (!g) return;
+    var meta = OUTCOME_META[o] || { icon: '', label: o, cls: '' };
     var count = g.items.length;
-    var contained = g.items.filter(function(i) { return ['blocked','monitoring','honeypot'].includes(i.outcome || ''); }).length;
-    var open = count - contained;
-    var statusHtml = '';
-    if (open > 0) {
-      statusHtml = '<span class="badge-unresolved">' + open + ' open</span>';
-    } else {
-      statusHtml = '<span class="badge-contained">\u2705 All contained</span>';
-    }
-    var groupClass = open > 0 ? 'threat-group threat-group-needs-action' : 'threat-group';
-    var startOpen = open > 0 || idx === 0;
-    html += '<div class="' + groupClass + '">' +
+
+    // Always show "Needs your attention" group (even at 0 — reassuring).
+    // Hide empty groups for other outcomes.
+    if (count === 0 && o !== 'needs_attention') return;
+
+    var startOpen = count > 0 && (o === 'needs_attention' || o === 'blocked' || idx === 0);
+    var countLabel = o === 'needs_attention' && count === 0
+      ? '<span style="color:var(--ok);font-weight:700">0</span>'
+      : count + '';
+
+    html += '<div class="threat-group ' + meta.cls + '">' +
       '<div class="threat-group-header" onclick="toggleThreatGroup(this)">' +
       '<span class="threat-group-chevron' + (startOpen ? ' open' : '') + '">\u25B8</span>' +
-      '<span class="threat-group-label">' + label + '</span>' +
-      '<span class="threat-group-meta">' + count + ' IP' + (count > 1 ? 's' : '') + '</span>' +
-      statusHtml +
+      '<span class="threat-group-label">' + meta.icon + ' ' + meta.label + '</span>' +
+      '<span class="threat-group-meta">' + countLabel + '</span>' +
       '</div>' +
       '<div class="threat-group-body' + (startOpen ? ' open' : '') + '">' +
-      g.items.map(function(item) { return renderCard(item); }).join('') +
+      (count === 0
+        ? '<div class="empty" style="padding:12px 16px;color:var(--ok);font-size:0.75rem">' +
+          (o === 'needs_attention'
+            ? ((window._agentMode || 'guard') === 'guard'
+                ? 'Nothing here. The AI is handling everything.'
+                : 'Enable Guard mode for automatic threat response.')
+            : 'None today.') +
+          '</div>'
+        : g.items.map(function(item) { return renderCard(item); }).join('')) +
       '</div></div>';
   });
   return html;
@@ -122,11 +159,17 @@ function renderCard(item) {
   const outcome = item.outcome || 'unknown';
   const dets = (item.detectors || []).map(function(d) { return humanLabel(d); }).join(', ') || '-';
 
-  // Build badges
+  // Build badges — outcome-first, no "OPEN" status exists in the AI-first model.
   let badges = '';
-  const outMap = { blocked:'badge-blocked', active:'badge-active', monitoring:'badge-monitor', honeypot:'badge-honeypot' };
-  const outBadge = outMap[outcome] || '';
-  if (outBadge) badges += `<span class="card-badge ${outBadge}">${outcomeLabel(outcome)}</span>`;
+  const mappedOutcome = outcomeOf(item);
+  const outBadgeMap = {
+    blocked: 'badge-blocked', honeypot: 'badge-honeypot',
+    monitoring: 'badge-monitor', dismissed: 'badge-noise',
+    needs_attention: 'badge-unresolved'
+  };
+  const outBadgeCls = outBadgeMap[mappedOutcome] || 'badge-monitor';
+  const outBadgeLabel = (OUTCOME_META[mappedOutcome] || {}).label || 'Observing';
+  badges += `<span class="card-badge ${outBadgeCls}">${outBadgeLabel}</span>`;
 
   const ago = (ts) => {
     if (!ts) return '';
@@ -228,29 +271,48 @@ function updateStatusHero(incidents, decisions) {
   const sub = document.getElementById('heroSub');
   if (!hero || !icon || !title || !sub) return;
 
-  // Use AI-confirmed threats, not raw incident count.
   const ov = window._lastOverview || {};
-  const confirmedThreats = ov.ai_confirmed || 0;
-  const responded = ov.ai_responded || 0;
+  const blocked = ov.ai_responded || 0;
   const noise = ov.ai_ignored || 0;
-  const rawTotal = (incidents || []).length;
-  const blockedCount = (decisions || []).filter(d => ['block_ip','suspend_user_sudo','kill_process','block_container'].includes(d.action_type)).length;
 
-  if (confirmedThreats > 5) {
+  // Count items by outcome from the current entity list
+  var items = (window._lastEntityItems || []);
+  var needsAttention = 0, observing = 0, totalBlocked = 0, totalHoneypot = 0;
+  items.forEach(function(item) {
+    var o = outcomeOf(item);
+    if (o === 'needs_attention') needsAttention++;
+    else if (o === 'monitoring') observing++;
+    else if (o === 'blocked') totalBlocked++;
+    else if (o === 'honeypot') totalHoneypot++;
+  });
+
+  var isGuard = (window._agentMode || 'guard') === 'guard';
+
+  if (!isGuard) {
+    // Detection-only mode (watch / read_only): AI sees threats but cannot act.
+    // Everything unresolved is the operator's responsibility.
+    var detected = needsAttention + observing;
+    hero.className = detected > 0 ? 'status-hero danger' : 'status-hero safe';
+    icon.textContent = '\uD83D\uDC41\uFE0F';
+    title.textContent = 'Detection Mode';
+    sub.textContent = detected > 0
+      ? detected + ' threat' + (detected > 1 ? 's' : '') + ' detected. AI is monitoring only \u2014 enable Guard mode for automatic response.'
+      : 'No threats detected. AI is monitoring only.';
+  } else if (needsAttention > 0) {
     hero.className = 'status-hero danger';
-    icon.textContent = '🛡️';
-    title.textContent = 'Active Defense — ' + confirmedThreats + ' threats';
-    sub.textContent = responded + ' contained · ' + blockedCount + ' IPs blocked · ' + noise + ' noise filtered';
-  } else if (confirmedThreats > 0) {
+    icon.textContent = '\u26A0\uFE0F';
+    title.textContent = needsAttention + ' item' + (needsAttention > 1 ? 's need' : ' needs') + ' your attention';
+    sub.textContent = 'The AI could not resolve ' + (needsAttention > 1 ? 'these' : 'this') + ' automatically. Review below.';
+  } else if (observing > 0) {
     hero.className = 'status-hero safe';
-    icon.textContent = '🛡️';
-    title.textContent = 'Server Protected';
-    sub.textContent = confirmedThreats + ' threats detected · ' + responded + ' contained · ' + noise + ' noise filtered';
+    icon.textContent = '\uD83D\uDEE1\uFE0F';
+    title.textContent = 'AI Protection Active';
+    sub.textContent = totalBlocked + ' blocked \u00B7 ' + totalHoneypot + ' honeypot \u00B7 ' + observing + ' observing \u00B7 ' + noise + ' dismissed';
   } else {
     hero.className = 'status-hero safe';
-    icon.textContent = '✅';
-    title.textContent = 'All Clear';
-    sub.textContent = 'No confirmed threats · ' + rawTotal + ' events analyzed · defense active';
+    icon.textContent = '\u2705';
+    title.textContent = 'All Handled';
+    sub.textContent = totalBlocked + ' blocked \u00B7 ' + totalHoneypot + ' honeypot \u00B7 ' + noise + ' dismissed. Nothing requires attention.';
   }
 }
 
@@ -355,17 +417,23 @@ async function refreshLeftLive() {
 
     const items = entityData.items || [];
 
-    window._lastOverview = ov; // Store for threat level gauge
+    window._lastOverview = ov;
+    window._lastEntityItems = items;
+
+    // Outcome-first KPIs (same logic as refreshLeft)
+    var kpiBlocked = 0, kpiObserving = 0, kpiAttention = 0;
+    items.forEach(function(item) {
+      var o = outcomeOf(item);
+      if (o === 'blocked' || o === 'honeypot') kpiBlocked++;
+      else if (o === 'needs_attention') kpiAttention++;
+      else if (o === 'monitoring') kpiObserving++;
+    });
+    updateKpi('kpi-confirmed', kpiBlocked);
+    updateKpi('kpi-responded', kpiObserving);
+    updateKpi('kpi-noise',     kpiAttention);
     updateKpi('kpi-events',    ov.events_count);
-    updateKpi('kpi-confirmed', ov.ai_confirmed || 0);
-    updateKpi('kpi-responded', ov.ai_responded || 0);
-    updateKpi('kpi-noise',     ov.ai_ignored || 0);
     updateKpi('kpi-incidents', ov.incidents_count);
     updateKpi('kpi-attackers', items.length);
-    // Contextual KPI colors (confidence system)
-    var u = getUnresolved();
-    var confEl = document.getElementById('kpi-confirmed');
-    if (confEl) confEl.style.color = u.unresolved > 0 ? 'var(--danger)' : u.total > 0 ? 'var(--ok)' : 'var(--accent)';
 
     const list = document.getElementById('attackerList');
     const newItems = items.filter(it => !state.knownItemValues.has(it.value));
@@ -409,7 +477,7 @@ async function refreshLeft(forceRefreshJourney = false) {
       window_seconds: state.filters.window_seconds,
     });
 
-    const [ov, entityData, clusterData] = await Promise.all([
+    const [ov, entityData, clusterData, statusData] = await Promise.all([
       loadJson('/api/overview' + (overviewQs ? '?' + overviewQs : '')),
       state.pivot === 'ip'
         ? loadJson('/api/entities?' + entityQs).then((r) => ({
@@ -421,16 +489,31 @@ async function refreshLeft(forceRefreshJourney = false) {
           }))
         : loadJson('/api/pivots?' + entityQs),
       loadJson('/api/clusters?' + clusterQs),
+      loadJson('/api/status').catch(() => ({ mode: 'guard' })),
     ]);
+
+    // Store agent mode globally so outcomeOf() can adapt.
+    // guard = AI blocks autonomously, watch/read_only = AI detects only.
+    window._agentMode = statusData.mode || 'guard';
 
     const items = entityData.items || [];
     state.clusters = clusterData.items || [];
 
     window._lastOverview = ov;
+    window._lastEntityItems = items;
+
+    // Outcome-first KPIs: Blocked / Observing / Needs attention
+    var kpiBlocked = 0, kpiObserving = 0, kpiAttention = 0;
+    items.forEach(function(item) {
+      var o = outcomeOf(item);
+      if (o === 'blocked' || o === 'honeypot') kpiBlocked++;
+      else if (o === 'needs_attention') kpiAttention++;
+      else if (o === 'monitoring') kpiObserving++;
+    });
+    document.getElementById('kpi-confirmed').textContent = kpiBlocked;
+    document.getElementById('kpi-responded').textContent = kpiObserving;
+    document.getElementById('kpi-noise').textContent     = kpiAttention;
     document.getElementById('kpi-events').textContent    = ov.events_count;
-    document.getElementById('kpi-confirmed').textContent = ov.ai_confirmed || 0;
-    document.getElementById('kpi-responded').textContent = ov.ai_responded || 0;
-    document.getElementById('kpi-noise').textContent     = ov.ai_ignored || 0;
     document.getElementById('kpi-incidents').textContent = ov.incidents_count;
     const kpiAtt = document.getElementById('kpi-attackers');
     if (kpiAtt) kpiAtt.textContent = items.length;

--- a/crates/agent/src/dashboard/frontend/js/threats.js
+++ b/crates/agent/src/dashboard/frontend/js/threats.js
@@ -44,8 +44,11 @@ function buildGroupedList(items) {
   // Filter by outcome if set (e.g. from Home CTA click)
   var titleEl = document.getElementById('entityTitle');
   if (state.filterOutcome === 'contained') {
-    items = items.filter(function(item) { return ['blocked','monitoring','honeypot'].includes(item.outcome || ''); });
-    if (titleEl) titleEl.innerHTML = 'AI Defense Log <span style="font-size:0.6rem;color:var(--muted);cursor:pointer;margin-left:6px" onclick="state.filterOutcome=null;refreshLeft(false)">\u2715 clear filter</span>';
+    items = items.filter(function(item) {
+      var o = (item.outcome || '').toLowerCase();
+      return o === 'blocked' || o === 'honeypot';
+    });
+    if (titleEl) titleEl.innerHTML = 'Blocked threats <span style="font-size:0.6rem;color:var(--muted);cursor:pointer;margin-left:6px" onclick="state.filterOutcome=null;refreshLeft(false)">\u2715 show all</span>';
   } else {
     if (titleEl) titleEl.textContent = 'AI Defense Log';
   }

--- a/crates/agent/src/dashboard/investigation.rs
+++ b/crates/agent/src/dashboard/investigation.rs
@@ -391,6 +391,18 @@ pub(super) fn build_pivots_from_graph(
         std::collections::HashMap::new();
 
     for inc_id in graph.nodes_of_type(NodeType::Incident) {
+        // Skip research_only incidents — same filter as api_incidents
+        // and api_overview. Without this, self-traffic IPs like
+        // 149.154.166.110 (Telegram Bot API) appear in the Threats tab
+        // entity list with 198 incidents, even though every one of them
+        // is research_only. The operator sees a "threat" that is actually
+        // the agent's own notification traffic and is one click away from
+        // blocking their own Telegram integration.
+        if let Some(Node::Incident { research_only, .. }) = graph.get_node(inc_id) {
+            if *research_only {
+                continue;
+            }
+        }
         for edge in graph.outgoing_edges(inc_id) {
             if edge.relation != Relation::TriggeredBy {
                 continue;
@@ -400,6 +412,14 @@ pub(super) fn build_pivots_from_graph(
                     let label = node.label();
                     // Skip internal IPs — they're the server, not the attacker
                     if node_type == NodeType::Ip && internal_ips.contains(&label) {
+                        continue;
+                    }
+                    // Skip self-traffic IPs (cloud providers, agent
+                    // service endpoints, local interfaces) — these are
+                    // infrastructure, not attackers.
+                    if node_type == NodeType::Ip
+                        && crate::cloud_safelist::is_self_traffic_ip(&label)
+                    {
                         continue;
                     }
                     pivot_data
@@ -994,7 +1014,7 @@ pub(super) fn build_journey_from_graph(
         .unwrap_or(if has_incident { "active" } else { "unknown" })
         .to_string();
 
-    let summary = build_journey_summary(
+    let mut summary = build_journey_summary(
         &entries,
         &outcome,
         subject_type,
@@ -1003,6 +1023,128 @@ pub(super) fn build_journey_from_graph(
         &related_users,
         &related_detectors,
     );
+
+    // ── Intelligence enrichment from knowledge graph ────────────────
+    // Replace generic hints with context from real data: connection
+    // count, severity distribution, GeoIP, threat feeds, risk
+    // assessment. This is what makes the operator understand what
+    // happened without technical knowledge.
+    if subject_type == PivotKind::Ip {
+        summary.hints.clear();
+
+        // Connection count
+        let conn_count = graph
+            .all_edges(center_id)
+            .iter()
+            .filter(|e| matches!(e.relation, Relation::ConnectedTo | Relation::AcceptedFrom))
+            .count();
+
+        // Incident severity distribution
+        let mut sev_counts: std::collections::HashMap<String, usize> =
+            std::collections::HashMap::new();
+        let mut blocked = false;
+        let mut has_threat_intel = false;
+        for edge in graph.incoming_edges(center_id) {
+            if edge.relation != Relation::TriggeredBy {
+                continue;
+            }
+            if let Some(Node::Incident {
+                severity,
+                detector,
+                decision,
+                research_only,
+                ..
+            }) = graph.get_node(edge.from)
+            {
+                if *research_only {
+                    continue;
+                }
+                *sev_counts.entry(severity.to_lowercase()).or_insert(0) += 1;
+                if detector == "threat_intel" || detector == "graph_threat_intel" {
+                    has_threat_intel = true;
+                }
+                if decision.as_deref() == Some("block_ip") {
+                    blocked = true;
+                }
+            }
+        }
+
+        // GeoIP from edge properties (if available)
+        let geo = graph
+            .all_edges(center_id)
+            .iter()
+            .find_map(|e| {
+                e.properties
+                    .get("country")
+                    .and_then(|v| v.as_str())
+                    .map(|c| c.to_string())
+            });
+
+        // Build human-readable intelligence hints
+        let total_incidents: usize = sev_counts.values().sum();
+        let critical = sev_counts.get("critical").copied().unwrap_or(0);
+        let high = sev_counts.get("high").copied().unwrap_or(0);
+
+        // Origin
+        if let Some(country) = &geo {
+            summary.hints.push(format!("Origin: {country}."));
+        }
+
+        // Threat intelligence
+        if has_threat_intel {
+            summary
+                .hints
+                .push("This IP is in a known malicious threat intelligence feed.".to_string());
+        }
+
+        // Activity summary
+        if conn_count > 0 {
+            summary.hints.push(format!(
+                "{} connection attempt{} observed today.",
+                conn_count,
+                if conn_count > 1 { "s" } else { "" }
+            ));
+        }
+
+        // Severity assessment
+        if critical > 0 {
+            summary.hints.push(format!(
+                "{} critical and {} high severity incident{}. Investigate immediately.",
+                critical,
+                high,
+                if total_incidents > 1 { "s" } else { "" }
+            ));
+        } else if high > 0 && has_threat_intel {
+            summary.hints.push(format!(
+                "Known malicious IP with {} incident{}. AI should handle automatically.",
+                total_incidents,
+                if total_incidents > 1 { "s" } else { "" }
+            ));
+        } else if total_incidents <= 2 && !has_threat_intel {
+            summary.hints.push(
+                "Low activity — likely a routine internet scanner. Not dangerous.".to_string(),
+            );
+        }
+
+        // Outcome
+        if blocked {
+            summary
+                .hints
+                .push("AI has blocked this IP. No further action needed.".to_string());
+        } else if outcome == "active" || outcome == "monitoring" {
+            if total_incidents <= 2 && critical == 0 && high == 0 {
+                summary.hints.push(
+                    "Routine scanner activity. The AI is monitoring but no action is needed."
+                        .to_string(),
+                );
+            } else {
+                summary.hints.push(
+                    "The AI is still evaluating this activity.".to_string(),
+                );
+            }
+        }
+    }
+
     let verdict = derive_verdict(&entries, &outcome);
     let chapters = derive_chapters(&entries);
 

--- a/crates/agent/src/dashboard/mod.rs
+++ b/crates/agent/src/dashboard/mod.rs
@@ -386,6 +386,8 @@ pub async fn serve(
         // AI Intelligence Briefing
         .route("/api/briefing", get(api_briefing))
         .route("/api/briefing/generate", post(api_briefing_generate))
+        // AI Explain — plain-language threat explanation for non-technical operators
+        .route("/api/ai-explain", get(api_ai_explain))
         // Sensors activity
         .route("/api/sensors", get(api_sensors))
         // E6 - system status

--- a/crates/agent/src/dashboard/types.rs
+++ b/crates/agent/src/dashboard/types.rs
@@ -94,6 +94,12 @@ pub(crate) struct JourneyQuery {
 }
 
 #[derive(Debug, Deserialize)]
+pub(crate) struct AiExplainQuery {
+    pub(super) r#type: Option<String>,
+    pub(super) value: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
 #[allow(dead_code)] // severity_min/detector accepted for API forward-compat; graph filters land in spec 016
 pub(crate) struct ClusterQuery {
     pub(super) limit: Option<usize>,

--- a/crates/agent/src/incident_abuseipdb.rs
+++ b/crates/agent/src/incident_abuseipdb.rs
@@ -121,6 +121,27 @@ pub(crate) async fn try_handle_abuseipdb_autoblock(
         );
     }
 
+    // Write decision to knowledge graph so the dashboard shows "Blocked".
+    // Previously this was missing — the IP was blocked at the firewall
+    // but the graph incident had decision=null, so the Threats tab showed
+    // "Observing" instead of "Blocked". Observed 2026-04-12: 3 auto-blocked
+    // IPs (149.56.102.185, 196.196.253.20, 103.189.235.30) appeared as
+    // "Observing" despite being blocked.
+    {
+        let auto_executed = !execution_result.starts_with("skipped")
+            && !execution_result.starts_with("rate-limited");
+        let mut graph = state.knowledge_graph.write().unwrap();
+        graph.ingest_decision(
+            &incident.incident_id,
+            "block_ip",
+            Some(&ip),
+            auto_decision.confidence,
+            &auto_decision.reason,
+            auto_executed,
+            chrono::Utc::now(),
+        );
+    }
+
     if let Some(writer) = &mut state.decision_writer {
         let entry = decisions::build_entry(
             &incident.incident_id,

--- a/crates/agent/src/incident_enrichment.rs
+++ b/crates/agent/src/incident_enrichment.rs
@@ -67,10 +67,15 @@ pub(crate) fn enrich_attacker_identity(
             .crowdsec
             .as_ref()
             .is_some_and(|cs| cs.is_known_threat(ip));
-        if let Some(profile) = state.attacker_profiles.get_mut(ip) {
-            if profile.geo.is_none() || profile.abuseipdb_score.is_none() {
-                attacker_intel::enrich_identity(profile, ip_geo, ip_reputation, crowdsec_listed);
-            }
+        // Ensure profile exists — enrichment may run before the main
+        // attacker_intel pipeline creates the profile. Without this,
+        // GeoIP/AbuseIPDB data was silently discarded for new IPs.
+        let profile = state
+            .attacker_profiles
+            .entry(ip.to_string())
+            .or_insert_with(|| attacker_intel::new_profile(ip, incident.ts));
+        if profile.geo.is_none() || profile.abuseipdb_score.is_none() {
+            attacker_intel::enrich_identity(profile, ip_geo, ip_reputation, crowdsec_listed);
         }
     }
 }

--- a/crates/agent/src/knowledge_graph/detectors.rs
+++ b/crates/agent/src/knowledge_graph/detectors.rs
@@ -911,6 +911,19 @@ fn detect_network_sniffing(
             continue;
         }
 
+        // Fallback: if the ancestor walk couldn't find the parent (eBPF
+        // event arrived with pid=0 or ppid not ingested), check the Process
+        // node's own uid. The agent runs as uid 998 (innerwarden); tcpdump
+        // spawned by pcap_capture inherits this uid. Observed 2026-04-12:
+        // the ancestor walk returns empty when the graph doesn't have the
+        // parent Process node, so the uid check is the safety net.
+        if let Some(Node::Process { uid, .. }) = graph.get_node(pid_id) {
+            if *uid == 998 {
+                // innerwarden UID — this sniffer is our own pcap_capture
+                continue;
+            }
+        }
+
         let key = format!("graph_sniff:{}:{}", comm, pid_id);
         if !state.check_and_set(&key, now, 600) {
             continue;

--- a/crates/agent/src/knowledge_graph/ingestion.rs
+++ b/crates/agent/src/knowledge_graph/ingestion.rs
@@ -62,11 +62,40 @@ fn is_self_traffic_incident(incident: &Incident) -> bool {
         .filter(|e| e.r#type == EntityType::Ip)
         .map(|e| e.value.as_str())
         .collect();
-    if ips.is_empty() {
-        return false;
+    if !ips.is_empty()
+        && ips
+            .iter()
+            .all(|ip| crate::cloud_safelist::is_self_traffic_ip(ip))
+    {
+        return true;
     }
-    ips.iter()
-        .all(|ip| crate::cloud_safelist::is_self_traffic_ip(ip))
+
+    // Rule 3: cross-layer chains whose title references known self-traffic
+    // patterns. CrowdSec CAPI uses rotating AWS ELB IPs that are impossible
+    // to safelist by CIDR. Instead, detect the pattern: "Data Exfiltration
+    // (eBPF Sequence)" chains where the only service entity is a known
+    // agent/infrastructure process (crowdsec, gomon, innerwarden). These
+    // are outbound connections from OUR processes, not attacker exfil.
+    if incident.incident_id.starts_with("cross_layer_chain") {
+        let service_entities: Vec<&str> = incident
+            .entities
+            .iter()
+            .filter(|e| e.r#type == EntityType::Service)
+            .map(|e| e.value.as_str())
+            .collect();
+        let has_self_service = service_entities.iter().any(|s| {
+            crate::cloud_safelist::is_agent_process(s)
+                || s.contains("crowdsec")
+                || s.contains("gomon")
+                || s.contains("snap")
+                || s.contains("oracle-cloud")
+        });
+        if has_self_service {
+            return true;
+        }
+    }
+
+    false
 }
 
 fn detail_u64(event: &Event, key: &str) -> Option<u64> {

--- a/crates/agent/src/main.rs
+++ b/crates/agent/src/main.rs
@@ -2574,6 +2574,20 @@ async fn process_incidents(
 
         incident_advisory::handle_advisory_violation(incident, advisory_cache, state).await;
 
+        // 1b. Enrichment — runs for ALL incidents regardless of severity.
+        // GeoIP + AbuseIPDB + attacker profile update must happen before the
+        // AI gate filters out low-severity incidents, otherwise auto-blocked
+        // and low-severity IPs never get country/abuse_confidence data.
+        let ip_geo_early = incident_enrichment::lookup_incident_geoip(incident, state).await;
+        let ip_rep_early = incident_reputation::lookup_abuseipdb_reputation(incident, state).await;
+        incident_enrichment::enrich_attacker_identity(
+            incident,
+            state,
+            ip_geo_early.as_ref(),
+            ip_rep_early.as_ref(),
+        );
+        incident_enrichment::log_threat_feed_match(incident, state);
+
         // 2. AI analysis - only when AI is enabled and incident passes the gate.
         match incident_flow::evaluate_pre_ai_flow(
             incident,
@@ -2624,7 +2638,9 @@ async fn process_incidents(
             cfg.ai.context_events,
         );
 
-        let ip_reputation = incident_reputation::lookup_abuseipdb_reputation(incident, state).await;
+        // ── Auto-handle decisions (may `continue` to skip AI) ──────────
+        // Enrichment already ran in step 1b. Reuse the results.
+        let ip_reputation = ip_rep_early;
 
         if incident_abuseipdb::try_handle_abuseipdb_autoblock(
             incident,
@@ -2655,8 +2671,6 @@ async fn process_incidents(
             continue;
         }
 
-        incident_enrichment::log_threat_feed_match(incident, state);
-
         if incident_honeypot_router::try_handle_honeypot_routing(
             incident,
             data_dir,
@@ -2669,14 +2683,6 @@ async fn process_incidents(
             handled += 1;
             continue;
         }
-
-        let ip_geo = incident_enrichment::lookup_incident_geoip(incident, state).await;
-        incident_enrichment::enrich_attacker_identity(
-            incident,
-            state,
-            ip_geo.as_ref(),
-            ip_reputation.as_ref(),
-        );
 
         // Build graph context: attack narrative from knowledge graph neighborhood.
         // Phase 015: prefer the Incident node as center (richest context after 014-D
@@ -2710,7 +2716,7 @@ async fn process_incidents(
                 })
                 .collect(),
             ip_reputation: ip_reputation.clone(),
-            ip_geo: ip_geo.clone(),
+            ip_geo: ip_geo_early.clone(),
             graph_context,
         };
 
@@ -2821,7 +2827,7 @@ async fn process_incidents(
             cfg,
             state,
             ip_reputation.as_ref(),
-            ip_geo.as_ref(),
+            ip_geo_early.as_ref(),
         );
 
         handled += 1;

--- a/crates/sensor/src/detectors/allowlists.rs
+++ b/crates/sensor/src/detectors/allowlists.rs
@@ -438,6 +438,7 @@ pub const C2_OUTBOUND_ALLOWED: &[&str] = &[
     "dpkg",
     // Cloud agents
     "oracle-cloud-ag",
+    "gomon",          // Oracle Cloud Agent monitoring plugin (/snap/oracle-cloud-agent/)
     "google_guest_ag",
     "waagent",
     "amazon-ssm-agen",

--- a/crates/sensor/src/detectors/allowlists.rs
+++ b/crates/sensor/src/detectors/allowlists.rs
@@ -438,7 +438,6 @@ pub const C2_OUTBOUND_ALLOWED: &[&str] = &[
     "dpkg",
     // Cloud agents
     "oracle-cloud-ag",
-    "gomon",          // Oracle Cloud Agent monitoring plugin (/snap/oracle-cloud-agent/)
     "google_guest_ag",
     "waagent",
     "amazon-ssm-agen",

--- a/crates/sensor/src/detectors/data_exfil_ebpf.rs
+++ b/crates/sensor/src/detectors/data_exfil_ebpf.rs
@@ -83,6 +83,12 @@ impl DataExfilEbpfDetector {
 
         // Skip processes that legitimately read /etc/passwd for NSS uid→name
         // resolution and then make outbound connections (CrowdSec, web servers).
+        //
+        // This list is for DAEMONS that read /etc/passwd as part of normal
+        // operation (uid lookup for every request, session setup, etc.) and
+        // are always making outbound calls as part of their job. These
+        // cannot meaningfully be distinguished from the exfil pattern, so
+        // they are always allowed.
         const PASSWD_READERS: &[&str] = &[
             "http",
             "https",
@@ -151,6 +157,19 @@ impl DataExfilEbpfDetector {
             let cutoff = now - self.window;
             self.pending_reads.retain(|_, r| r.ts > cutoff);
 
+            // Peek dst_port BEFORE consuming the pending read: port 0 means
+            // eBPF never observed a real TCP handshake (connect error, NSS
+            // probe, AF_UNIX upgrade). Drop the event and keep the pending
+            // read in the map so a later real connect can still correlate.
+            let dst_port = event
+                .details
+                .get("dst_port")
+                .and_then(|v| v.as_u64())
+                .unwrap_or(0) as u16;
+            if dst_port == 0 {
+                return None;
+            }
+
             if let Some(read) = self.pending_reads.remove(&pid) {
                 // Same PID read a sensitive file then made outbound connection
                 let dst_ip = event
@@ -158,11 +177,6 @@ impl DataExfilEbpfDetector {
                     .get("dst_ip")
                     .and_then(|v| v.as_str())
                     .unwrap_or("unknown");
-                let dst_port = event
-                    .details
-                    .get("dst_port")
-                    .and_then(|v| v.as_u64())
-                    .unwrap_or(0) as u16;
                 let comm = event
                     .details
                     .get("comm")
@@ -171,6 +185,55 @@ impl DataExfilEbpfDetector {
 
                 // Skip internal IPs
                 if super::is_internal_ip(dst_ip) {
+                    return None;
+                }
+
+                // Targeted NSS-init suppression.
+                //
+                // Every dynamically linked C program calls `getpwuid_r` /
+                // `getpwnam_r` at startup, which opens `/etc/passwd`. CLI
+                // tools like wget, curl, git, apt that ALSO make outbound
+                // connections trivially trip "read sensitive file →
+                // connect" in the first milliseconds of startup. Observed
+                // 2026-04-11: Critical FP on `wget read /etc/passwd then
+                // connected to 34.244.58.147:0` — 6ms between read and
+                // connect, port 0 (never established) — pure NSS init.
+                //
+                // The suppression is INTENTIONALLY NARROW:
+                //   - file must be exactly "/etc/passwd" (NSS file), AND
+                //   - comm must be a known CLI network tool whose NSS
+                //     lookup is legitimate.
+                //
+                // Reads of `/etc/shadow`, `~/.ssh/*`, `id_rsa`, `.env`,
+                // `/credentials`, `.kube/config` by wget/curl/git/etc. are
+                // NOT NSS init and STILL fire Critical alerts. A real
+                // exfil of shadow hashes or SSH keys by a renamed-to-wget
+                // attacker is caught unchanged.
+                const NSS_INIT_CLI_TOOLS: &[&str] = &[
+                    "wget",
+                    "curl",
+                    "git",
+                    "git-remote",
+                    "apt",
+                    "apt-get",
+                    "apt-check",
+                    "dpkg",
+                    "snap",
+                    "snapd",
+                    "pip",
+                    "pip3",
+                    "npm",
+                    "yarn",
+                    "cargo",
+                    "rustup",
+                    "gem",
+                    "composer",
+                    "mvn",
+                    "gradle",
+                ];
+                let is_nss_init = read.filename == "/etc/passwd"
+                    && NSS_INIT_CLI_TOOLS.iter().any(|p| read.comm.starts_with(p));
+                if is_nss_init {
                     return None;
                 }
 

--- a/crates/sensor/src/detectors/discovery_burst.rs
+++ b/crates/sensor/src/detectors/discovery_burst.rs
@@ -125,6 +125,20 @@ impl DiscoveryBurstDetector {
             .and_then(|v| v.as_u64())
             .unwrap_or(0);
 
+        // Skip events without process context (pid=0, comm="").
+        // These come from kernel-level activity where eBPF couldn't
+        // attribute the syscall to a userspace process — MOTD scripts,
+        // update-notifier health checks, kernel threads, early-boot
+        // init. Observed 2026-04-12: uid=0 pid=0 comm="" firing once
+        // per 30min with `uname -r` and
+        // `find /var/lib/update-notifier/updates-available ...` as the
+        // last command. An attacker with root runs in a real shell
+        // session with pid>0 and comm set — pid=0 is not exploitable
+        // for recon evasion.
+        if pid == 0 && comm.is_empty() {
+            return None;
+        }
+
         // Skip allowed processes (centralized allowlist)
         if allowlists::is_innerwarden_process(uid, comm)
             || allowlists::comm_in_allowlist(comm, allowlists::DISCOVERY_ALLOWED)

--- a/crates/sensor/src/detectors/dns_c2.rs
+++ b/crates/sensor/src/detectors/dns_c2.rs
@@ -49,6 +49,23 @@ const ALLOWED_DOMAINS: &[&str] = &[
     "local",
     "localhost",
     "innerwarden.com",
+    // Cloud providers — OCI instances resolve metadata, API endpoints,
+    // storage, and internal services via these domains. Observed
+    // 2026-04-12: 7 "Possible DNS C2 channel: oraclecloud.com" Medium
+    // FPs per hour from normal OCI metadata/API resolution.
+    "oraclecloud.com",
+    "oracle.com",
+    "oraclecloud.net",
+    "oci.oraclecloud.com",
+    // AWS (EC2 metadata, S3, SSM, etc.)
+    "aws.amazon.com",
+    "awsstatic.com",
+    // GCP
+    "google.internal",
+    "googleusercontent.com",
+    // Hetzner
+    "hetzner.com",
+    "hetzner.cloud",
 ];
 
 pub struct DnsC2Detector {

--- a/crates/sensor/src/detectors/host_drift.rs
+++ b/crates/sensor/src/detectors/host_drift.rs
@@ -166,6 +166,20 @@ impl HostDriftDetector {
         }
         let filename = filename.as_str();
 
+        // Non-absolute path → the sensor couldn't resolve the binary location
+        // for this event. "pgrep" vs "/usr/bin/pgrep" are semantically
+        // different: the latter is a real location we can compare against
+        // TRUSTED_PATHS, the former is a name without context. Firing a
+        // "Host drift: executed from non-standard path" alert for a bare
+        // name is wrong by construction — we don't know WHERE it executed
+        // from. Observed 2026-04-11 as 23,673 Medium "host_drift pgrep pid=0
+        // uid=0 comm=unknown" incidents per day, all from unresolved events.
+        // Real drift (binary in /tmp, /dev/shm, /home/…) has an absolute
+        // path and is unaffected by this guard.
+        if !filename.starts_with('/') {
+            return None;
+        }
+
         let comm = event
             .details
             .get("comm")

--- a/crates/sensor/src/detectors/kernel_module_load.rs
+++ b/crates/sensor/src/detectors/kernel_module_load.rs
@@ -116,9 +116,45 @@ impl KernelModuleLoadDetector {
     }
 
     /// Check if the command is a kernel module operation.
+    ///
+    /// Requires the FIRST whitespace token to be (a path ending in)
+    /// `insmod`, `modprobe`, or `rmmod`. A substring check was previously
+    /// used, which fired on anything that *mentioned* those words in
+    /// arguments — `grep modprobe /var/log/*`, `man insmod`, `bash
+    /// /etc/systemd/modules-load.d/modprobe.conf`, etc. Observed
+    /// 2026-04-11: 73 "Kernel module load detected: unknown" High
+    /// incidents per day, driven entirely by substring matches where
+    /// `extract_module_name` returned None and the detector fell back to
+    /// "unknown". A real insmod/modprobe/rmmod invocation has the tool
+    /// name as the program being executed (after optional shell wrapper
+    /// like `sudo` / `bash -c`), which the first-token heuristic catches
+    /// via the nested shell check.
     fn is_module_command(command: &str) -> bool {
         let lower = command.to_lowercase();
-        lower.contains("insmod") || lower.contains("modprobe") || lower.contains("rmmod")
+        let mut tokens = lower.split_whitespace();
+        let Some(first) = tokens.next() else {
+            return false;
+        };
+        // Strip path prefix: /usr/sbin/modprobe → modprobe
+        let first_base = first.rsplit('/').next().unwrap_or(first);
+        if first_base == "insmod" || first_base == "modprobe" || first_base == "rmmod" {
+            return true;
+        }
+        // Nested shell wrappers: sudo modprobe foo, bash -c 'modprobe foo',
+        // env VAR=x insmod bar, nice -n 10 rmmod baz. Walk one more token
+        // under a known shell/env wrapper so we still catch real usage.
+        const WRAPPERS: &[&str] =
+            &["sudo", "doas", "bash", "sh", "zsh", "dash", "env", "nice", "nohup", "timeout"];
+        if WRAPPERS.contains(&first_base) {
+            for tok in tokens {
+                if tok.starts_with('-') || tok.contains('=') {
+                    continue;
+                }
+                let base = tok.rsplit('/').next().unwrap_or(tok);
+                return base == "insmod" || base == "modprobe" || base == "rmmod";
+            }
+        }
+        false
     }
 
     pub fn process(&mut self, event: &Event) -> Option<Incident> {
@@ -131,7 +167,15 @@ impl KernelModuleLoadDetector {
             return None;
         }
 
-        let module_name = Self::extract_module_name(command).unwrap_or("unknown");
+        // If we can't extract the module name, we don't have enough signal
+        // to fire a High/Critical incident. Previous behavior was to emit
+        // `Kernel module load detected: unknown`, which gives the operator
+        // nothing actionable and is the signature of a substring-match FP
+        // from the old `is_module_command`.
+        let module_name = match Self::extract_module_name(command) {
+            Some(name) => name,
+            None => return None,
+        };
 
         // Skip allowlisted modules
         if Self::is_allowed_module(module_name) {

--- a/crates/sensor/src/detectors/mitre_hunt.rs
+++ b/crates/sensor/src/detectors/mitre_hunt.rs
@@ -923,6 +923,19 @@ impl MitreHuntDetector {
         }
 
         // Skip if spawned by InnerWarden itself (pcap_capture spawns tcpdump).
+        //
+        // Three-layer check because eBPF events sometimes arrive with
+        // incomplete process context (pid=0, parent_comm="", uid=0):
+        //   1. parent_comm starts with "innerwarden"
+        //   2. /proc/{ppid}/comm starts with "innerwarden" (best-effort)
+        //   3. uid == INNERWARDEN_UID (998) — the tcpdump processes spawned
+        //      by pcap_capture.rs inherit the agent's uid. This is the most
+        //      reliable check when eBPF couldn't resolve parent context.
+        //      Observed 2026-04-12: 9 Medium "Network sniffing tool:
+        //      tcpdump (pid=0, user=unknown)" per day, all self-spawned.
+        if super::allowlists::is_innerwarden_process(uid as u64, "") {
+            return None;
+        }
         let ppid = event
             .details
             .get("ppid")
@@ -936,7 +949,6 @@ impl MitreHuntDetector {
         if parent_comm.starts_with("innerwarden") {
             return None;
         }
-        // Also check if parent is the sensor by reading /proc/ppid/comm (best-effort).
         if ppid > 0 {
             if let Ok(pcomm) = std::fs::read_to_string(format!("/proc/{ppid}/comm")) {
                 if pcomm.trim().starts_with("innerwarden") {

--- a/crates/sensor/src/detectors/proto_anomaly.rs
+++ b/crates/sensor/src/detectors/proto_anomaly.rs
@@ -246,7 +246,13 @@ impl ProtoAnomalyDetector {
                 .and_then(|v| v.as_str())
                 .unwrap_or("");
 
-            // Malformed SSH version
+            // Malformed SSH version — remote client sent an invalid protocol
+            // handshake. sshd rejects at TCP level before any auth attempt.
+            // Severity Low: the "attack" failed before it started — no
+            // credentials tested, no shell obtained, no data read.
+            // High/Critical is reserved for threats that got past the
+            // protocol handshake. Observed 2026-04-12: 15/day from random
+            // bots, all showing as "High — needs attention" for a non-event.
             if !client_version.is_empty()
                 && !client_version.starts_with("SSH-2.0-")
                 && !client_version.starts_with("SSH-1.")
@@ -254,9 +260,9 @@ impl ProtoAnomalyDetector {
                 if let Some(inc) = self.emit(
                     AnomalyType::SshVersionAnomaly,
                     "Malformed SSH version string",
-                    &format!("SSH client from {src_ip} sent malformed version: '{client_version}'. This may indicate a custom exploit tool or protocol fuzzer."),
+                    &format!("SSH client from {src_ip} sent malformed version: '{client_version}'. Scanner or exploit tool that failed at protocol level — no authentication attempted."),
                     src_ip, dst_ip, dst_port, now,
-                    Severity::High,
+                    Severity::Low,
                 ) {
                     incidents.push(inc);
                 }

--- a/crates/sensor/src/detectors/reverse_shell.rs
+++ b/crates/sensor/src/detectors/reverse_shell.rs
@@ -49,10 +49,36 @@ impl ReverseShellDetector {
             return Some("bash_dev_tcp");
         }
 
-        // Netcat variants: nc -e, ncat -e, nc -c, netcat -e
-        if (lower.contains("nc ") || lower.contains("ncat ") || lower.contains("netcat "))
-            && (lower.contains(" -e ") || lower.contains(" -c "))
-        {
+        // Netcat variants: nc -e, ncat -e, nc -c, netcat -e.
+        //
+        // Use word-boundary (whitespace-tokenized) matching, not substring.
+        // The naive `contains("nc ")` check matches `rsync ` (which ends in
+        // "nc ") and `contains(" -c ")` matches every `bash -c …` wrapper,
+        // so a plain `bash -c rsync --server` was being classified as a
+        // Critical netcat_shell reverse shell. Observed 2026-04-11 as
+        // dozens of Critical FPs per day from the operator's own deploy
+        // rsync-over-ssh.
+        //
+        // Coverage preserved:
+        //   - OpenBSD netcat: `nc -e /bin/sh attacker 1234`
+        //   - GNU netcat:     `nc -c /bin/sh attacker 1234`
+        //   - Nmap ncat:      `ncat -e /bin/sh …` and `ncat -c '…'`
+        //   - Full binary:    `netcat -e …` / `netcat -c …`
+        //
+        // Because `has_nc_binary` now requires an exact whitespace-token
+        // match for `nc` / `ncat` / `netcat`, the `-c` flag can safely be
+        // matched again — `bash -c rsync` contains no such token and no
+        // longer trips the pattern. Additionally, the eBPF sequence
+        // detector (`check_ebpf_sequence`) catches reverse shells by
+        // behavior (connect + fd_redirect stdin/stdout to socket) even if
+        // the command matcher misses an exotic variant, giving this
+        // detector two independent layers.
+        let tokens: Vec<&str> = lower.split_whitespace().collect();
+        let has_nc_binary = tokens
+            .iter()
+            .any(|&t| t == "nc" || t == "ncat" || t == "netcat");
+        let has_exec_flag = tokens.iter().any(|&t| t == "-e" || t == "-c");
+        if has_nc_binary && has_exec_flag {
             return Some("netcat_shell");
         }
 

--- a/crates/sensor/src/detectors/rootkit.rs
+++ b/crates/sensor/src/detectors/rootkit.rs
@@ -1025,13 +1025,77 @@ impl RootkitDetector {
     fn check_timing_anomaly(&mut self, event: &Event, now: DateTime<Utc>) -> Option<Incident> {
         let kind = &event.kind;
 
-        // Skip event kinds with naturally high latency variance.
-        // network.accept blocks until a connection arrives (seconds to hours).
-        // file.truncate latency depends on filesystem flush (ms to seconds under I/O load).
-        // These produce timing spikes during normal operations (deploys, builds, idle periods).
+        // Skip event kinds that are not suitable for inter-event delta
+        // timing analysis. "Inter-event delta" is the gap between two
+        // consecutive events of the same kind (globally across the host);
+        // it measures system idleness, NOT per-syscall latency. For a
+        // rootkit that hooks a kernel function, the latency is added
+        // inside each individual call (entry→exit), which is only
+        // measurable with proper eBPF fentry/fexit instrumentation — not
+        // by looking at the gap between consecutive events.
+        //
+        // Detection coverage is preserved by OTHER detectors for every
+        // kind listed here; the timing pass is the weakest signal of
+        // several, and it was firing hundreds of FPs per day because
+        // system idleness and agent restarts create large deltas that
+        // look like "anomalies" to this algorithm.
+        //
+        // COVERAGE MAP (what actually catches rootkit hooks on each kind):
+        //
+        // - shell.command_exec → execve hook detection
+        //     • Hidden process detection (pid_exists_fn check below —
+        //       every exec'd pid that eBPF sees but /proc does not show
+        //       raises "Hidden process" High regardless of timing).
+        //     • process_name_spoofing (comm vs binary mismatch).
+        //     • mitre_hunt detector (catches unusual exec patterns).
+        //     • kernel_integrity.rs (syscall table baseline + bpf program
+        //       inventory — rootkit loading its hook triggers that).
+        //
+        // - network.connection, network.outbound_connect → connect hook
+        //     • Kernel eBPF tracepoints bypass userspace hooks — if the
+        //       rootkit hooks connect() to hide a connection, the raw
+        //       tracepoint sees it anyway and emits the event. The
+        //       anomaly is then a baseline/baseline.rs drift ("new
+        //       outbound destination"), not a timing spike.
+        //     • c2_callback.rs detects beaconing regardless of hook state.
+        //     • threat_intel / AbuseIPDB match on dst_ip.
+        //
+        // - tcp_stream.flow → no rootkit signal in inter-event delta;
+        //   flow events are data-plane frequency and restart-sensitive.
+        //   Covered by: outbound_anomaly.rs, packet_flood.rs, proto_anomaly.
+        //
+        // - network.accept / network.listen — blocks until a connection
+        //   arrives (seconds to hours of natural idleness).
+        //
+        // - file.truncate / file.timestomp — filesystem flush latency
+        //   varies ms to seconds under I/O load.
+        //
+        // - process.exit / process.clone — natural process lifecycle is
+        //   bursty; covered by process_tree.rs and privesc.rs.
+        //
+        // What REMAINS active for this detector: file.read_access and
+        // file.write_access. These have the highest natural frequency on
+        // a Linux host, the cleanest Welford baseline, and are the exact
+        // signal for the #1 rootkit technique (getdents64 hooking to
+        // hide files/processes from ls/ps). Observed 2026-04-11 baseline:
+        // ~100µs mean latency, very stable distribution — a real
+        // getdents64 hook adds 10-100µs of overhead and WILL show up
+        // here as a consecutive anomaly burst.
+        //
+        // If/when proper eBPF entry→exit latency instrumentation is added,
+        // the skipped kinds should move to per-syscall latency tracking
+        // (not inter-event delta) and be re-enabled. Tracked as tech debt.
         match kind.as_str() {
-            "network.accept" | "network.listen" | "file.truncate" | "file.timestomp"
-            | "process.exit" | "process.clone" => {
+            "network.accept"
+            | "network.listen"
+            | "network.connection"
+            | "network.outbound_connect"
+            | "file.truncate"
+            | "file.timestomp"
+            | "process.exit"
+            | "process.clone"
+            | "shell.command_exec"
+            | "tcp_stream.flow" => {
                 return None;
             }
             _ => {}
@@ -1963,6 +2027,14 @@ mod tests {
     }
 
     // --- Timing Test 5: Different syscall kinds tracked independently ---
+    //
+    // Note: `shell.command_exec`, `tcp_stream.flow`, `network.connection`,
+    // and `network.outbound_connect` are intentionally excluded from the
+    // timing pipeline (see check_timing_anomaly's skip list). Inter-event
+    // delta on those kinds measures idleness, not syscall latency, and
+    // produced ~832 FP High incidents per day before the skip. This test
+    // uses `file.read_access` and `file.write_access` — both still active
+    // — to verify that separate tracking per kind is working.
     #[test]
     fn timing_different_kinds_tracked_independently() {
         let mut det = timing_detector(5, 4.0, 3);
@@ -1974,33 +2046,33 @@ mod tests {
             det.process(&timing_event("file.read_access", ts));
         }
 
-        // Feed 8 shell.command_exec events at 50ms intervals
+        // Feed 8 file.write_access events at 50ms intervals
         for i in 0..8 {
             let ts = base + Duration::milliseconds(i * 50);
-            det.process(&timing_event("shell.command_exec", ts));
+            det.process(&timing_event("file.write_access", ts));
         }
 
         // Both should be tracked independently
         assert!(det.syscall_timing.contains_key("file.read_access"));
-        assert!(det.syscall_timing.contains_key("shell.command_exec"));
+        assert!(det.syscall_timing.contains_key("file.write_access"));
 
-        let file_stats = &det.syscall_timing["file.read_access"];
-        let exec_stats = &det.syscall_timing["shell.command_exec"];
+        let read_stats = &det.syscall_timing["file.read_access"];
+        let write_stats = &det.syscall_timing["file.write_access"];
 
         // file.read_access mean should be ~1ms
-        assert!(file_stats.trained);
+        assert!(read_stats.trained);
         assert!(
-            file_stats.mean_ns < 5_000_000.0,
-            "file mean={}",
-            file_stats.mean_ns
+            read_stats.mean_ns < 5_000_000.0,
+            "read mean={}",
+            read_stats.mean_ns
         );
 
-        // shell.command_exec mean should be ~50ms
-        assert!(exec_stats.trained);
+        // file.write_access mean should be ~50ms
+        assert!(write_stats.trained);
         assert!(
-            exec_stats.mean_ns > 10_000_000.0,
-            "exec mean={}",
-            exec_stats.mean_ns
+            write_stats.mean_ns > 10_000_000.0,
+            "write mean={}",
+            write_stats.mean_ns
         );
     }
 

--- a/crates/sensor/src/detectors/sandbox_evasion.rs
+++ b/crates/sensor/src/detectors/sandbox_evasion.rs
@@ -101,6 +101,28 @@ impl SandboxEvasionDetector {
             return None;
         }
 
+        // Skip InnerWarden's own processes: the hypervisor audit, SMM audit,
+        // and firmware integrity modules legitimately read
+        // /sys/class/dmi/id/*, /proc/cpuinfo, and run dmidecode/lspci as
+        // part of the own-host security posture check. Without this filter,
+        // `tokio-rt-worker` self-triggers sandbox_evasion every few seconds
+        // (observed on 2026-04-11: 832+ `Sandbox/VM evasion detected:
+        // tokio-rt-worker` High incidents per day, 100% self-detection).
+        let ev_uid = event
+            .details
+            .get("uid")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(u64::MAX);
+        let ev_comm = event
+            .details
+            .get("comm")
+            .or(event.details.get("process"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        if super::allowlists::is_innerwarden_process(ev_uid, ev_comm) {
+            return None;
+        }
+
         let check_type = self.classify_event(event)?;
 
         // Track


### PR DESCRIPTION
## Summary

- **Home tab**: AI-first hero state (Protected/Detection Mode), trust signal (3.4M events monitored), outcome KPIs (Blocked/Incidents/Events Scanned), mode-aware badges (OBSERVING blue, not ACTIVE red)
- **Threats tab**: outcome-first grouping (Blocked/Honeypot/Observing/Needs attention), mode-aware UX (Guard ON vs OFF), narrative-first journey with AI decision reasoning, "Ask AI to explain" endpoint, Intelligence section from knowledge graph
- **16 detector FP fixes**: sandbox_evasion, rootkit timing, reverse_shell netcat, data_exfil NSS, host_drift, kernel_module, discovery_burst, dns_c2, network_sniffing, proto_anomaly severity, CL-014 entity match, cloud safelist (link-local, local IPs, CrowdSec CAPI, Oracle gomon)
- **Enrichment fix**: GeoIP + AbuseIPDB now runs before AI gate for ALL incidents; profile created on first encounter
- **AbuseIPDB auto-block**: decisions now written to knowledge graph (dashboard shows "Blocked")
- **Briefing**: AI-first prompt, filtered context (no self-traffic), correct blocked count
- **3 URGENT docs** saved in `ideias/` for next phase: verified calibration, AI auto-decision, public data enrichment

## Test plan

- [x] 1177 tests passing (579 sensor + 598 agent)
- [x] Deployed and validated on production server (130.162.171.105)
- [x] Home: hero green with Guard ON, trust signal shows 3.4M events
- [x] Threats: 0 "Needs attention" with Guard ON, blocked items visible
- [x] "Ask AI to explain" returns plain-language explanations via LLM
- [x] GeoIP + AbuseIPDB enriching attacker profiles (14+ profiles in 2 min)
- [x] AbuseIPDB auto-block decisions visible in Threats tab as "Blocked"
- [x] Zero self-traffic FPs post-fix (sandbox_evasion, rootkit, rsync, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)