### PR TITLE
feat(guard): auto-dismiss low-severity noise

### DIFF
--- a/crates/agent/src/ai/mod.rs
+++ b/crates/agent/src/ai/mod.rs
@@ -223,6 +223,22 @@ pub fn should_invoke_ai(
     true
 }
 
+/// Check if incident severity is strictly below the configured min_severity threshold.
+/// Extracted so `incident_flow` can distinguish "below severity" from other skip reasons.
+pub fn is_below_severity_threshold(
+    severity: &innerwarden_core::event::Severity,
+    min_severity: &innerwarden_core::event::Severity,
+) -> bool {
+    use innerwarden_core::event::Severity;
+    match min_severity {
+        Severity::Low => matches!(severity, Severity::Debug | Severity::Info),
+        Severity::Medium => matches!(severity, Severity::Debug | Severity::Info | Severity::Low),
+        Severity::High => !matches!(severity, Severity::High | Severity::Critical),
+        Severity::Critical => !matches!(severity, Severity::Critical),
+        _ => true,
+    }
+}
+
 fn is_private_or_loopback(addr: IpAddr) -> bool {
     match addr {
         IpAddr::V4(v4) => {

--- a/crates/agent/src/dashboard/helpers.rs
+++ b/crates/agent/src/dashboard/helpers.rs
@@ -148,13 +148,15 @@ pub(super) fn determine_outcome_for_ips(
 ) -> String {
     let mut has_monitoring = false;
     let mut has_honeypot = false;
-    let mut has_active = has_incident;
+    let mut has_dismissed = false;
+    let mut has_active = false;
 
     for ip in ips {
         match determine_outcome(decisions, ip, has_incident).as_str() {
             "blocked" => return "blocked".to_string(),
             "honeypot" => has_honeypot = true,
             "monitoring" => has_monitoring = true,
+            "dismissed" => has_dismissed = true,
             "active" => has_active = true,
             _ => {}
         }
@@ -167,6 +169,12 @@ pub(super) fn determine_outcome_for_ips(
         return "monitoring".to_string();
     }
     if has_active {
+        return "active".to_string();
+    }
+    if has_dismissed {
+        return "dismissed".to_string();
+    }
+    if has_incident {
         return "active".to_string();
     }
     "unknown".to_string()
@@ -201,6 +209,11 @@ pub(super) fn determine_outcome(
     for d in &ip_decisions {
         if d.action_type == "honeypot" && d.auto_executed && !d.dry_run {
             return "honeypot".to_string();
+        }
+    }
+    for d in &ip_decisions {
+        if (d.action_type == "dismiss" || d.action_type == "ignore") && d.auto_executed {
+            return "dismissed".to_string();
         }
     }
     if has_incident {

--- a/crates/agent/src/incident_autodismiss.rs
+++ b/crates/agent/src/incident_autodismiss.rs
@@ -1,0 +1,87 @@
+use tracing::info;
+
+use crate::{config, decisions, AgentState};
+
+/// Auto-dismiss gate for low-severity noise when Guard mode is ON.
+///
+/// Called when `evaluate_pre_ai_flow` returns `SkipBelowSeverity` — the
+/// incident's severity is below the AI threshold, so no AI call will be made.
+/// Instead of leaving the incident without a decision (which shows as
+/// "needs attention" / "monitoring" in the dashboard), write a rule-based
+/// dismiss decision so every incident has a clear outcome.
+///
+/// Returns true when the incident was handled (dismiss decision written).
+pub(crate) fn try_autodismiss_noise(
+    incident: &innerwarden_core::incident::Incident,
+    cfg: &config::AgentConfig,
+    state: &mut AgentState,
+) -> bool {
+    // Only auto-dismiss when the responder is active (Guard mode ON).
+    // In Watch/DryRun mode the operator wants to see everything.
+    if !cfg.responder.enabled || cfg.responder.dry_run {
+        return false;
+    }
+
+    let detector = incident.incident_id.split(':').next().unwrap_or("");
+
+    let reason = format!(
+        "Auto-dismissed: {detector} below AI severity threshold (severity {:?})",
+        incident.severity,
+    );
+
+    info!(
+        incident_id = %incident.incident_id,
+        detector,
+        severity = ?incident.severity,
+        "noise gate: auto-dismissing low-severity incident"
+    );
+
+    // Write decision entry to audit trail
+    let primary_ip = incident
+        .entities
+        .iter()
+        .find(|e| e.r#type == innerwarden_core::entities::EntityType::Ip)
+        .map(|e| e.value.clone());
+
+    let entry = decisions::DecisionEntry {
+        ts: chrono::Utc::now(),
+        incident_id: incident.incident_id.clone(),
+        host: incident.host.clone(),
+        ai_provider: "noise-gate".to_string(),
+        action_type: "dismiss".to_string(),
+        target_ip: primary_ip,
+        target_user: None,
+        skill_id: None,
+        confidence: 1.0,
+        auto_executed: true,
+        dry_run: false,
+        reason: reason.clone(),
+        estimated_threat: "none".to_string(),
+        execution_result: "dismissed".to_string(),
+        prev_hash: None,
+    };
+    if let Some(writer) = &mut state.decision_writer {
+        if let Err(e) = writer.write(&entry) {
+            tracing::warn!("failed to write noise-gate decision: {e:#}");
+        }
+    }
+
+    // Feed into knowledge graph so dashboard picks it up
+    {
+        let mut graph = state.knowledge_graph.write().unwrap();
+        graph.ingest_decision(
+            &incident.incident_id,
+            "dismiss",
+            None,
+            1.0,
+            &reason,
+            true,
+            chrono::Utc::now(),
+        );
+    }
+
+    true
+}
+
+// Integration tests for autodismiss live in main.rs test harness where
+// AgentState can be constructed via triage_test_state().

--- a/crates/agent/src/incident_flow.rs
+++ b/crates/agent/src/incident_flow.rs
@@ -10,6 +10,9 @@ pub(crate) enum PreAiFlowDecision {
     /// Entity is in allowlist — skip AI but mark in graph.
     SkipAllowlisted,
     PipelineTestHandled,
+    /// Incident severity is below the configured AI min_severity threshold.
+    /// Eligible for rule-based auto-dismiss (noise gate) when Guard mode is ON.
+    SkipBelowSeverity,
 }
 
 /// Evaluate all pre-AI gates for one incident.
@@ -103,10 +106,24 @@ pub(crate) fn evaluate_pre_ai_flow(
     }
 
     if !ai::should_invoke_ai(incident, blocked_set, &cfg.ai.parsed_min_severity()) {
+        // Distinguish "below severity threshold" from other skip reasons so
+        // the caller can route low-severity noise to the auto-dismiss gate.
+        let dominated_by_min = ai::is_below_severity_threshold(
+            &incident.severity,
+            &cfg.ai.parsed_min_severity(),
+        );
+        if dominated_by_min {
+            info!(
+                incident_id = %incident.incident_id,
+                severity = ?incident.severity,
+                "AI gate: skipping (below min_severity threshold)"
+            );
+            return PreAiFlowDecision::SkipBelowSeverity;
+        }
         info!(
             incident_id = %incident.incident_id,
             severity = ?incident.severity,
-            "AI gate: skipping (low severity / private IP / already blocked)"
+            "AI gate: skipping (private IP / already blocked)"
         );
         return PreAiFlowDecision::SkipHandled;
     }

--- a/crates/agent/src/incident_obvious.rs
+++ b/crates/agent/src/incident_obvious.rs
@@ -20,7 +20,11 @@ pub(crate) async fn try_handle_obvious_incident(
     let detector = incident_detector(&incident.incident_id);
     let is_obvious_detector = matches!(
         detector,
-        "ssh_bruteforce" | "credential_stuffing" | "packet_flood" | "port_scan"
+        "ssh_bruteforce"
+            | "credential_stuffing"
+            | "packet_flood"
+            | "port_scan"
+            | "threat_intel"
     );
     let is_high_or_critical = matches!(
         incident.severity,

--- a/crates/agent/src/main.rs
+++ b/crates/agent/src/main.rs
@@ -44,6 +44,7 @@ mod incident_action_report;
 mod incident_advisory;
 mod incident_ai_context;
 mod incident_ai_failure;
+mod incident_autodismiss;
 mod incident_attacker_profile;
 mod incident_audit_write;
 mod incident_crowdsec;
@@ -2603,6 +2604,15 @@ async fn process_incidents(
                 let mut graph = state.knowledge_graph.write().unwrap();
                 graph.set_allowlisted(&incident.incident_id, true);
                 drop(graph);
+                handled += 1;
+                continue;
+            }
+            incident_flow::PreAiFlowDecision::SkipBelowSeverity => {
+                // Low-severity noise: write auto-dismiss decision so the
+                // dashboard shows a clear outcome instead of "needs attention".
+                if incident_autodismiss::try_autodismiss_noise(incident, cfg, state) {
+                    state.grouping_engine.mark_auto_resolved(incident);
+                }
                 handled += 1;
                 continue;
             }


### PR DESCRIPTION
## Summary
- New `incident_autodismiss` module: writes rule-based "dismiss" decisions for incidents below AI severity threshold when Guard mode is ON — zero extra API calls
- Add `threat_intel` to obvious detector gate (auto-block without AI call, reducing API usage)
- Dashboard `determine_outcome` now handles dismiss/ignore → "dismissed" outcome
- New `SkipBelowSeverity` variant in PreAiFlowDecision to distinguish noise from other skip reasons

Fixes: Guard mode leaving 33 IPs as permanent "needs attention" / "monitoring" with no decision. Now every incident gets a decision — Guard ON + normal noise = 0 unresolved items.

## Test plan
- [x] `cargo test` — 2499 tests passing, 0 failures
- [x] Deployed to production server, agent running healthy
- [ ] Monitor dashboard for noise IPs showing as "Dismissed" instead of "Needs attention"
- [ ] Verify `noise-gate` entries in agent logs on next SSH scanner wave

🤖 Generated with [Claude Code](https://claude.com/claude-code)