### PR TITLE
feat(ctl): integrate SMM and hypervisor as system subcommands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1697,6 +1697,8 @@ dependencies = [
  "digest 0.10.7",
  "ed25519-dalek",
  "innerwarden-agent-guard",
+ "innerwarden-hypervisor",
+ "innerwarden-smm",
  "innerwarden_core",
  "p256",
  "rand_core 0.6.4",

--- a/crates/ctl/Cargo.toml
+++ b/crates/ctl/Cargo.toml
@@ -16,6 +16,8 @@ path = "src/main.rs"
 
 [dependencies]
 innerwarden-agent-guard = { path = "../agent-guard" }
+innerwarden-smm = { path = "../smm" }
+innerwarden-hypervisor = { path = "../hypervisor" }
 anyhow = "1"
 clap = { version = "4", features = ["derive"] }
 clap_complete = "4"

--- a/crates/ctl/src/commands/firmware.rs
+++ b/crates/ctl/src/commands/firmware.rs
@@ -1,0 +1,285 @@
+use anyhow::Result;
+
+// ── SMM (Ring -2) ───────────────────────────────────────────────────────────
+
+pub fn cmd_smm(json: bool) -> Result<()> {
+    let report = innerwarden_smm::full_audit();
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&report)?);
+        return Ok(());
+    }
+
+    println!("╔══════════════════════════════════════════════╗");
+    println!("║  InnerWarden SMM — Firmware Security Audit   ║");
+    println!("╚══════════════════════════════════════════════╝");
+    println!();
+    println!("  Architecture: {:?}", report.arch);
+    println!("  Timestamp:    {}", report.ts);
+    println!("  Trust Score:  {}", format_trust(report.trust_score));
+    println!();
+
+    for check in &report.checks {
+        print_check(check.status_icon(), check.id, check.name, check.confidence, &check.detail);
+    }
+
+    // Correlated threats.
+    if !report.correlated_threats.is_empty() {
+        println!("  \x1b[35;1m══ Correlated Threats ══\x1b[0m");
+        println!();
+        for threat in &report.correlated_threats {
+            let color = if threat.confidence >= 0.9 {
+                "\x1b[31;1m"
+            } else if threat.confidence >= 0.7 {
+                "\x1b[31m"
+            } else {
+                "\x1b[33m"
+            };
+            println!(
+                "  {color}⚡ [{id}] {name} ({conf:.0}% confidence)\x1b[0m",
+                id = threat.id,
+                name = threat.name,
+                conf = threat.confidence * 100.0,
+            );
+            println!("    {color}{detail}\x1b[0m", detail = threat.detail);
+            println!("    Evidence:");
+            for e in &threat.evidence {
+                println!("      → {e}");
+            }
+            println!();
+        }
+    }
+
+    // Summary.
+    let secure = report.checks.iter().filter(|c| c.status == innerwarden_smm::CheckStatus::Secure).count();
+    let warnings = report.checks.iter().filter(|c| c.status == innerwarden_smm::CheckStatus::Warning).count();
+    let critical = report.checks.iter().filter(|c| c.status == innerwarden_smm::CheckStatus::Critical).count();
+    let unavailable = report.checks.iter().filter(|c| c.status == innerwarden_smm::CheckStatus::Unavailable).count();
+
+    println!("  ──────────────────────────────────────────");
+    println!(
+        "  \x1b[32m{secure} secure\x1b[0m  \
+         \x1b[33m{warnings} warnings\x1b[0m  \
+         \x1b[31m{critical} critical\x1b[0m  \
+         \x1b[90m{unavailable} unavailable\x1b[0m  \
+         \x1b[35m{corr} correlated\x1b[0m",
+        corr = report.correlated_threats.len(),
+    );
+
+    if critical > 0 || !report.correlated_threats.is_empty() {
+        println!();
+        if report.trust_score < 0.1 {
+            println!("  \x1b[31;1m⚠ FIRMWARE INTEGRITY COMPROMISED — investigate immediately.\x1b[0m");
+        } else if report.trust_score < 0.5 {
+            println!("  \x1b[31m⚠ Firmware trust degraded — review correlated threats above.\x1b[0m");
+        }
+    }
+
+    // Baseline hint.
+    let baseline_path = innerwarden_smm::baseline::FirmwareBaseline::default_path();
+    if !baseline_path.exists() {
+        println!();
+        println!("  \x1b[36mTip: run `innerwarden system smm --baseline` to enable drift detection.\x1b[0m");
+    }
+
+    Ok(())
+}
+
+pub fn cmd_smm_baseline() -> Result<()> {
+    let path = innerwarden_smm::baseline::FirmwareBaseline::default_path();
+    eprintln!("Capturing firmware baseline...");
+    let b = innerwarden_smm::baseline::FirmwareBaseline::capture();
+    if let Err(e) = b.save(&path) {
+        anyhow::bail!("Failed to save baseline: {e}");
+    }
+    eprintln!("  Saved to {}", path.display());
+    eprintln!("  BIOS: {} {}", b.bios.vendor, b.bios.version);
+    eprintln!("  ACPI tables: {}", b.acpi_tables.len());
+    eprintln!("  PCR values: {}", b.pcrs.len());
+    if let Some(smi) = b.smi_count {
+        eprintln!("  SMI count: {smi}");
+    }
+    eprintln!();
+    eprintln!("  Re-run `innerwarden system smm` to audit against this baseline.");
+    Ok(())
+}
+
+pub fn cmd_smm_drift() -> Result<()> {
+    let path = innerwarden_smm::baseline::FirmwareBaseline::default_path();
+    let Ok(b) = innerwarden_smm::baseline::FirmwareBaseline::load(&path) else {
+        anyhow::bail!("No baseline found. Run `innerwarden system smm --baseline` first.");
+    };
+
+    let drift = innerwarden_smm::baseline::detect_drift(&b);
+    println!("Drift report (baseline from {})", drift.baseline_date);
+    println!();
+
+    if drift.drifts.is_empty() {
+        println!("  No changes detected since baseline.");
+        return Ok(());
+    }
+
+    for d in &drift.drifts {
+        let (icon, color) = match d.severity {
+            innerwarden_smm::baseline::DriftSeverity::Info => ("~", "\x1b[36m"),
+            innerwarden_smm::baseline::DriftSeverity::Suspicious => ("?", "\x1b[33m"),
+            innerwarden_smm::baseline::DriftSeverity::Critical => ("!", "\x1b[31m"),
+        };
+        println!("  {color}{icon}\x1b[0m {}: {color}{}\x1b[0m", d.component, d.detail);
+    }
+
+    Ok(())
+}
+
+// ── Hypervisor (Ring -1) ────────────────────────────────────────────────────
+
+pub fn cmd_hypervisor(json: bool) -> Result<()> {
+    let report = innerwarden_hypervisor::full_audit();
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&report)?);
+        return Ok(());
+    }
+
+    println!("╔══════════════════════════════════════════════╗");
+    println!("║  InnerWarden Hypervisor — Ring -1 Audit      ║");
+    println!("╚══════════════════════════════════════════════╝");
+    println!();
+
+    let env_str = match &report.environment {
+        innerwarden_hypervisor::Environment::BareMetal => "\x1b[32mBare Metal\x1b[0m".to_string(),
+        innerwarden_hypervisor::Environment::VirtualMachine { hypervisor } => {
+            format!("\x1b[36mVirtual Machine ({hypervisor})\x1b[0m")
+        }
+        innerwarden_hypervisor::Environment::HypervisorHost { vm_count } => {
+            format!("\x1b[35mKVM Host ({vm_count} VMs)\x1b[0m")
+        }
+        innerwarden_hypervisor::Environment::UnknownHypervisor => {
+            "\x1b[31;1mUNKNOWN HYPERVISOR\x1b[0m".to_string()
+        }
+    };
+    println!("  Environment: {env_str}");
+    println!(
+        "  VM Score:    {}/100 ({} evidence signals)",
+        report.vm_verdict.score, report.vm_verdict.evidence_count
+    );
+    if let Some(ref brand) = report.vm_verdict.brand {
+        println!("  VM Brand:    \x1b[36m{brand}\x1b[0m");
+    }
+    println!("  Trust Score: {}", format_trust(report.trust_score));
+    println!();
+
+    println!("  \x1b[1m── Deep Checks ──\x1b[0m");
+    println!();
+    for check in &report.checks {
+        let (icon, color) = match check.status {
+            innerwarden_hypervisor::CheckStatus::Secure => ("✓", "\x1b[32m"),
+            innerwarden_hypervisor::CheckStatus::Warning => ("⚠", "\x1b[33m"),
+            innerwarden_hypervisor::CheckStatus::Critical => ("✗", "\x1b[31m"),
+            innerwarden_hypervisor::CheckStatus::Unavailable => ("–", "\x1b[90m"),
+        };
+        let conf = if check.confidence > 0.0 {
+            format!(" \x1b[90m({:.0}%)\x1b[0m", check.confidence * 100.0)
+        } else {
+            String::new()
+        };
+        println!(
+            "  {color}{icon}\x1b[0m [{id}] {name}{conf}",
+            id = check.id,
+            name = check.name
+        );
+        println!("    {color}{detail}\x1b[0m", detail = check.detail);
+        println!();
+    }
+
+    // Probe evidence.
+    let positive_probes: Vec<_> = report.probe_results.iter().filter(|p| p.score > 0).collect();
+    if !positive_probes.is_empty() {
+        println!(
+            "  \x1b[1m── VM Evidence ({} signals) ──\x1b[0m",
+            positive_probes.len()
+        );
+        println!();
+        for p in &positive_probes {
+            let color = if p.score >= 80 {
+                "\x1b[36m"
+            } else if p.score >= 50 {
+                "\x1b[33m"
+            } else {
+                "\x1b[90m"
+            };
+            println!(
+                "  {color}[{score:>3}] {id}: {detail}\x1b[0m",
+                score = p.score,
+                id = p.id,
+                detail = p.detail,
+            );
+        }
+        println!();
+    }
+
+    // Summary.
+    let secure = report.checks.iter().filter(|c| c.status == innerwarden_hypervisor::CheckStatus::Secure).count();
+    let warnings = report.checks.iter().filter(|c| c.status == innerwarden_hypervisor::CheckStatus::Warning).count();
+    let critical = report.checks.iter().filter(|c| c.status == innerwarden_hypervisor::CheckStatus::Critical).count();
+    let unavail = report.checks.iter().filter(|c| c.status == innerwarden_hypervisor::CheckStatus::Unavailable).count();
+
+    println!("  ──────────────────────────────────────────");
+    println!(
+        "  \x1b[32m{secure} secure\x1b[0m  \x1b[33m{warnings} warnings\x1b[0m  \
+         \x1b[31m{critical} critical\x1b[0m  \x1b[90m{unavail} unavailable\x1b[0m  \
+         \x1b[36m{probes} probes ({evidence} positive)\x1b[0m",
+        probes = report.probe_results.len(),
+        evidence = report.vm_verdict.evidence_count,
+    );
+
+    Ok(())
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+trait StatusIcon {
+    fn status_icon(&self) -> (&'static str, &'static str);
+}
+
+impl StatusIcon for innerwarden_smm::CheckResult {
+    fn status_icon(&self) -> (&'static str, &'static str) {
+        match self.status {
+            innerwarden_smm::CheckStatus::Secure => ("✓", "\x1b[32m"),
+            innerwarden_smm::CheckStatus::Warning => ("⚠", "\x1b[33m"),
+            innerwarden_smm::CheckStatus::Critical => ("✗", "\x1b[31m"),
+            innerwarden_smm::CheckStatus::Unavailable => ("–", "\x1b[90m"),
+        }
+    }
+}
+
+fn print_check(
+    (icon, color): (&str, &str),
+    id: &str,
+    name: &str,
+    confidence: f64,
+    detail: &str,
+) {
+    let conf = if confidence > 0.0 {
+        format!(" \x1b[90m({:.0}%)\x1b[0m", confidence * 100.0)
+    } else {
+        String::new()
+    };
+    println!("  {color}{icon}\x1b[0m [{id}] {name}{conf}");
+    println!("    {color}{detail}\x1b[0m");
+    println!();
+}
+
+fn format_trust(score: f64) -> String {
+    let pct = (score * 100.0) as u32;
+    let (color, label) = if pct >= 90 {
+        ("\x1b[32m", "TRUSTED")
+    } else if pct >= 60 {
+        ("\x1b[33m", "DEGRADED")
+    } else if pct >= 30 {
+        ("\x1b[31m", "AT RISK")
+    } else {
+        ("\x1b[31;1m", "COMPROMISED")
+    };
+    format!("{color}{pct}% — {label}\x1b[0m")
+}

--- a/crates/ctl/src/commands/firmware.rs
+++ b/crates/ctl/src/commands/firmware.rs
@@ -20,7 +20,13 @@ pub fn cmd_smm(json: bool) -> Result<()> {
     println!();
 
     for check in &report.checks {
-        print_check(check.status_icon(), check.id, check.name, check.confidence, &check.detail);
+        print_check(
+            check.status_icon(),
+            check.id,
+            check.name,
+            check.confidence,
+            &check.detail,
+        );
     }
 
     // Correlated threats.
@@ -51,10 +57,26 @@ pub fn cmd_smm(json: bool) -> Result<()> {
     }
 
     // Summary.
-    let secure = report.checks.iter().filter(|c| c.status == innerwarden_smm::CheckStatus::Secure).count();
-    let warnings = report.checks.iter().filter(|c| c.status == innerwarden_smm::CheckStatus::Warning).count();
-    let critical = report.checks.iter().filter(|c| c.status == innerwarden_smm::CheckStatus::Critical).count();
-    let unavailable = report.checks.iter().filter(|c| c.status == innerwarden_smm::CheckStatus::Unavailable).count();
+    let secure = report
+        .checks
+        .iter()
+        .filter(|c| c.status == innerwarden_smm::CheckStatus::Secure)
+        .count();
+    let warnings = report
+        .checks
+        .iter()
+        .filter(|c| c.status == innerwarden_smm::CheckStatus::Warning)
+        .count();
+    let critical = report
+        .checks
+        .iter()
+        .filter(|c| c.status == innerwarden_smm::CheckStatus::Critical)
+        .count();
+    let unavailable = report
+        .checks
+        .iter()
+        .filter(|c| c.status == innerwarden_smm::CheckStatus::Unavailable)
+        .count();
 
     println!("  ──────────────────────────────────────────");
     println!(
@@ -69,9 +91,13 @@ pub fn cmd_smm(json: bool) -> Result<()> {
     if critical > 0 || !report.correlated_threats.is_empty() {
         println!();
         if report.trust_score < 0.1 {
-            println!("  \x1b[31;1m⚠ FIRMWARE INTEGRITY COMPROMISED — investigate immediately.\x1b[0m");
+            println!(
+                "  \x1b[31;1m⚠ FIRMWARE INTEGRITY COMPROMISED — investigate immediately.\x1b[0m"
+            );
         } else if report.trust_score < 0.5 {
-            println!("  \x1b[31m⚠ Firmware trust degraded — review correlated threats above.\x1b[0m");
+            println!(
+                "  \x1b[31m⚠ Firmware trust degraded — review correlated threats above.\x1b[0m"
+            );
         }
     }
 
@@ -125,7 +151,10 @@ pub fn cmd_smm_drift() -> Result<()> {
             innerwarden_smm::baseline::DriftSeverity::Suspicious => ("?", "\x1b[33m"),
             innerwarden_smm::baseline::DriftSeverity::Critical => ("!", "\x1b[31m"),
         };
-        println!("  {color}{icon}\x1b[0m {}: {color}{}\x1b[0m", d.component, d.detail);
+        println!(
+            "  {color}{icon}\x1b[0m {}: {color}{}\x1b[0m",
+            d.component, d.detail
+        );
     }
 
     Ok(())
@@ -193,7 +222,11 @@ pub fn cmd_hypervisor(json: bool) -> Result<()> {
     }
 
     // Probe evidence.
-    let positive_probes: Vec<_> = report.probe_results.iter().filter(|p| p.score > 0).collect();
+    let positive_probes: Vec<_> = report
+        .probe_results
+        .iter()
+        .filter(|p| p.score > 0)
+        .collect();
     if !positive_probes.is_empty() {
         println!(
             "  \x1b[1m── VM Evidence ({} signals) ──\x1b[0m",
@@ -219,10 +252,26 @@ pub fn cmd_hypervisor(json: bool) -> Result<()> {
     }
 
     // Summary.
-    let secure = report.checks.iter().filter(|c| c.status == innerwarden_hypervisor::CheckStatus::Secure).count();
-    let warnings = report.checks.iter().filter(|c| c.status == innerwarden_hypervisor::CheckStatus::Warning).count();
-    let critical = report.checks.iter().filter(|c| c.status == innerwarden_hypervisor::CheckStatus::Critical).count();
-    let unavail = report.checks.iter().filter(|c| c.status == innerwarden_hypervisor::CheckStatus::Unavailable).count();
+    let secure = report
+        .checks
+        .iter()
+        .filter(|c| c.status == innerwarden_hypervisor::CheckStatus::Secure)
+        .count();
+    let warnings = report
+        .checks
+        .iter()
+        .filter(|c| c.status == innerwarden_hypervisor::CheckStatus::Warning)
+        .count();
+    let critical = report
+        .checks
+        .iter()
+        .filter(|c| c.status == innerwarden_hypervisor::CheckStatus::Critical)
+        .count();
+    let unavail = report
+        .checks
+        .iter()
+        .filter(|c| c.status == innerwarden_hypervisor::CheckStatus::Unavailable)
+        .count();
 
     println!("  ──────────────────────────────────────────");
     println!(
@@ -253,13 +302,7 @@ impl StatusIcon for innerwarden_smm::CheckResult {
     }
 }
 
-fn print_check(
-    (icon, color): (&str, &str),
-    id: &str,
-    name: &str,
-    confidence: f64,
-    detail: &str,
-) {
+fn print_check((icon, color): (&str, &str), id: &str, name: &str, confidence: f64, detail: &str) {
     let conf = if confidence > 0.0 {
         format!(" \x1b[90m({:.0}%)\x1b[0m", confidence * 100.0)
     } else {

--- a/crates/ctl/src/commands/mod.rs
+++ b/crates/ctl/src/commands/mod.rs
@@ -1,6 +1,7 @@
 pub(crate) mod agent;
 pub(crate) mod ai;
 pub(crate) mod capability;
+pub(crate) mod firmware;
 pub(crate) mod core;
 pub(crate) mod history;
 pub(crate) mod integrations;

--- a/crates/ctl/src/commands/mod.rs
+++ b/crates/ctl/src/commands/mod.rs
@@ -1,8 +1,8 @@
 pub(crate) mod agent;
 pub(crate) mod ai;
 pub(crate) mod capability;
-pub(crate) mod firmware;
 pub(crate) mod core;
+pub(crate) mod firmware;
 pub(crate) mod history;
 pub(crate) mod integrations;
 pub(crate) mod mesh;

--- a/crates/ctl/src/main.rs
+++ b/crates/ctl/src/main.rs
@@ -1635,6 +1635,38 @@ enum SystemCommand {
         #[arg(short, long)]
         output: Option<String>,
     },
+
+    /// Audit Ring -2 firmware security (SMM, MSR, UEFI, TPM, ACPI, SPI).
+    ///
+    /// Examples:
+    ///   innerwarden system smm
+    ///   innerwarden system smm --json
+    ///   innerwarden system smm --baseline
+    ///   innerwarden system smm --drift
+    Smm {
+        /// Output as JSON instead of human-readable format.
+        #[arg(long)]
+        json: bool,
+
+        /// Capture firmware baseline for drift detection.
+        #[arg(long)]
+        baseline: bool,
+
+        /// Show what changed since the last baseline.
+        #[arg(long)]
+        drift: bool,
+    },
+
+    /// Audit Ring -1 hypervisor integrity (VM detection, KVM monitoring).
+    ///
+    /// Examples:
+    ///   innerwarden system hypervisor
+    ///   innerwarden system hypervisor --json
+    Hypervisor {
+        /// Output as JSON instead of human-readable format.
+        #[arg(long)]
+        json: bool,
+    },
 }
 
 // ---------------------------------------------------------------------------
@@ -2017,6 +2049,20 @@ fn main() -> Result<()> {
             SystemCommand::Navigator { ref output } => {
                 commands::status::cmd_navigator(output.as_deref())
             }
+            SystemCommand::Smm {
+                json,
+                baseline,
+                drift,
+            } => {
+                if *baseline {
+                    commands::firmware::cmd_smm_baseline()
+                } else if *drift {
+                    commands::firmware::cmd_smm_drift()
+                } else {
+                    commands::firmware::cmd_smm(*json)
+                }
+            }
+            SystemCommand::Hypervisor { json } => commands::firmware::cmd_hypervisor(*json),
         },
 
         // ===================================================================

--- a/crates/sensor/src/main.rs
+++ b/crates/sensor/src/main.rs
@@ -387,7 +387,10 @@ async fn main() -> Result<()> {
         distributed_ssh: distributed_ssh_detector,
         suspicious_login: cfg.detectors.ssh_bruteforce.enabled.then(|| {
             let anomaly_hours = cfg.detectors.suspicious_login.anomaly_hours_enabled;
-            info!(anomaly_hours_enabled = anomaly_hours, "suspicious_login detector enabled");
+            info!(
+                anomaly_hours_enabled = anomaly_hours,
+                "suspicious_login detector enabled"
+            );
             SuspiciousLoginDetector::new(&cfg.agent.host_id, 300, anomaly_hours)
         }),
         c2_callback: Some({


### PR DESCRIPTION
## Summary

- Wire Ring -2 (SMM) and Ring -1 (hypervisor) audits into the CTL as `innerwarden system smm` and `innerwarden system hypervisor`
- SMM supports `--json`, `--baseline` (capture), and `--drift` (compare) flags
- Hypervisor supports `--json` flag
- No more standalone `innerwarden-smm` / `innerwarden-hypervisor` binaries needed

## Test plan

- [x] `cargo build -p innerwarden-ctl` compiles
- [x] `cargo test -p innerwarden-ctl` — 208 tests pass
- [x] `innerwarden system --help` shows `smm` and `hypervisor` subcommands
- [x] `innerwarden system smm --help` shows all flags
- [x] `innerwarden system hypervisor --help` shows all flags
- [ ] Run `sudo innerwarden system smm` on x86_64 lab machine
- [ ] Run `sudo innerwarden system hypervisor` on x86_64 lab machine

🤖 Generated with [Claude Code](https://claude.com/claude-code)