### PR TITLE
feat: centered terminal setup and welcome screens

### DIFF
--- a/crates/ctl/src/welcome.rs
+++ b/crates/ctl/src/welcome.rs
@@ -1,70 +1,134 @@
 //! Welcome screen — displayed after installation.
 
-use std::io::{self, Write};
+use std::env;
+use std::io::{self, IsTerminal, Write};
+use std::process::Command;
 
-/// Crossed swords logo.
-const SWORDS: &[&str] = &[
-    "               ░░░░▒                                                    ░░░░░",
-    "              ░░░░░░▒▒                                                ░░░░░░░░",
-    "              ░░░░░░░░▒▒                                            ░░░░░░░░░▒",
-    "                ░░░░░░░▒▒▒                                        ░░░░░░░░░▒",
-    "                 ░░░░░░░░▒▒                                      ░░░░░░░░▒▒",
-    "                   ░░░░░░░░▒▒                                  ░░░░░░░░▒▒",
-    "                     ░░░░░░░▒▒▒                              ░░░░░░░▒▒▒",
-    "                       ░░░░░░░▒▒▒                          ░░░░░░░░▒▒",
-    "                         ░░░░░░▒▒▒▒      ▓▓▓▓  ▓▓▓▓      ░░░░░░░▒▒▒",
-    "                           ░░░░░░▒▒▒   ▓▓▓▓▓▓▓▓▓▓▓▓▓▓   ░░░░░░▒▒▒",
-    "                            ░░░░░░░▒▒▒▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓░░░░░░▒▒▒▒",
-    "                              ░░░░░░▒▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▒░░▒▒▒▒",
-    "                                ░░▒▓▓▓▓▓▓▓▓▓    ▓▓▓▓▓▓▓▓▓▒▒▒",
-    "                                ▓▓▓▓▓▓▓▓▓▒▒▒    ░░▒▓▓▓▓▓▓▓▓▓",
-    "                              ▓▓▓▓▓▓▓▓▓▒▓▓▒▒▒▒░░░▒▓▓▒▓▓▓▓▓▓▓▓▓",
-    "                             ▓▓▓▓▓▓▓▓▓░░▒▓▓▓▒░░▒▓▓▓▒▒▒▓▓▓▓▓▓▓▓▓",
-    "                             ▓▓▓▓▓▓▓▓  ░░░▒▒░▒▓▓▓▓▒▒▒  ▓▓▓▓▓▓▓▓",
-    "                               ▓▓▓▓      ░░▒▓▓▓▓▒▒▒      ▓▓▓▓",
-    "                                       ░░▒▓▓▓▓▒▒▓▓▒▒▒",
-    "                                     ░░▒▒▓▓▓▒▒▒▒▓▓▓▓▒▒▒",
-    "                                    ░░▒▓▓▓▒▒▒▒░░░▒▓▓▓▒▒▒",
-    "                                  ░░░▒▓▓▓▒▒▒    ░░▒▓▓▓▒▒▒▒",
-    "                                ░░░▒▒▒▒▒▒▒        ░░▒▒▒▒▒▒▒▒",
-    "                              ░░░▒▒▒▒▒▒▒            ░░░▒▒▒▒▒▒▒",
-    "                            ░░░▒▒▒▒▒▒▒                ░░░▒▒▒▒▒▒▒",
-    "                           ░░▒▒▒▒▒▒▒                    ░░░▒▒▒▒▒▒",
-    "                         ░░▒▒▒▒▒▒▒▒                      ░░░▒▒▒▒▒▒▒",
-    "                       ░░▒▒▒▒▒▒▒▒                          ░░░▒▒▒▒▒▒▒",
-    "                     ░░▒▒▒▒▒▒▒▒                              ░░▒▒▒▒▒▒▒▒",
-    "                   ░░▒▒▒▒▒▒▒▒                                  ░░▒▒▒▒▒▒▒▒",
-    "                 ░░▒▒▒▒▒▒▒▒                                      ░▒▒▒▒▒▒▒▒▒",
-    "                ░▒▒▒▒▒▒▒▒▒                                        ░░▒▒▒▒▒▒▒▒",
-    "              ▒▒▒▒▒▒▒▒▒▒                                            ░░▒▒▒▒▒▒▒▒",
-    "              ▒▒▒▒▒▒▒▒                                                ░▒▒▒▒▒▒▒",
-    "               ▒▒▒▒▒                                                    ░▒▒▒▒",
+/// Wide ASCII logo for larger terminals.
+const LOGO_WIDE: &[&str] = &[
+    "  _____ _   _ _   _ _____ ____  __        ___    ____  ____  _____ _   _ ",
+    " |_   _| \\ | | \\ | | ____|  _ \\ \\ \\      / / \\  |  _ \\|  _ \\| ____| \\ | |",
+    "   | | |  \\| |  \\| |  _| | |_) | \\ \\ /\\ / / _ \\ | |_) | | | |  _| |  \\| |",
+    "   | | | |\\  | |\\  | |___|  _ <   \\ V  V / ___ \\|  _ <| |_| | |___| |\\  |",
+    "   |_| |_| \\_|_| \\_|_____|_| \\_\\   \\_/\\_/_/   \\_\\_| \\_\\____/|_____|_| \\_|",
 ];
 
-/// Block font title.
-const TITLE: &[&str] = &[
-    "██ ███    ██ ███    ██ ███████ ██████      ██     ██  █████  ██████  ██████  ███████ ███    ██",
-    "██ ████   ██ ████   ██ ██      ██   ██     ██     ██ ██   ██ ██   ██ ██   ██ ██      ████   ██",
-    "██ ██ ██  ██ ██ ██  ██ █████   ██████      ██  █  ██ ███████ ██████  ██   ██ █████   ██ ██  ██",
-    "██ ██  ██ ██ ██  ██ ██ ██      ██   ██     ██ ███ ██ ██   ██ ██   ██ ██   ██ ██      ██  ██ ██",
-    "██ ██   ████ ██   ████ ███████ ██   ██      ███ ███  ██   ██ ██   ██ ██████  ███████ ██   ████",
-];
+fn parse_env_size(key: &str) -> Option<usize> {
+    env::var(key)
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .filter(|value| *value > 0)
+}
 
-/// Show welcome screen. No animation, no colors. Just the logo.
-pub fn run_welcome(_ebpf_hooks: u32) {
+fn terminal_size(is_tty: bool) -> (usize, usize) {
+    if let (Some(cols), Some(rows)) = (parse_env_size("COLUMNS"), parse_env_size("LINES")) {
+        return (cols, rows);
+    }
+
+    if is_tty {
+        if let Ok(output) = Command::new("stty").arg("size").output() {
+            if output.status.success() {
+                let size_text = String::from_utf8_lossy(&output.stdout);
+                let mut parts = size_text.split_whitespace();
+                if let (Some(rows), Some(cols)) = (parts.next(), parts.next()) {
+                    if let (Ok(rows), Ok(cols)) = (rows.parse::<usize>(), cols.parse::<usize>()) {
+                        if cols > 0 && rows > 0 {
+                            return (cols, rows);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    (80, 24)
+}
+
+fn centered_line(line: &str, cols: usize) -> String {
+    let width = line.chars().count();
+    let pad = cols.saturating_sub(width) / 2;
+    format!("{}{}", " ".repeat(pad), line)
+}
+
+fn box_lines(lines: Vec<String>, cols: usize) -> Vec<String> {
+    let inner_width = lines
+        .iter()
+        .map(|line| line.chars().count())
+        .max()
+        .unwrap_or(0);
+    let boxed_width = inner_width + 4;
+
+    if boxed_width > cols {
+        return lines;
+    }
+
+    let border = format!("+{}+", "-".repeat(inner_width + 2));
+    let mut out = Vec::with_capacity(lines.len() + 2);
+    out.push(border.clone());
+    for line in lines {
+        out.push(format!("| {:<width$} |", line, width = inner_width));
+    }
+    out.push(border);
+    out
+}
+
+fn build_screen(cols: usize, ebpf_hooks: u32) -> Vec<String> {
+    let mut lines = Vec::new();
+
+    let logo_width = LOGO_WIDE
+        .iter()
+        .map(|line| line.chars().count())
+        .max()
+        .unwrap_or(0);
+    if cols >= logo_width + 4 {
+        lines.extend(LOGO_WIDE.iter().map(|line| (*line).to_string()));
+    } else {
+        lines.push("INNERWARDEN".to_string());
+    }
+
+    lines.push(String::new());
+
+    let hook_line = if ebpf_hooks > 0 {
+        format!("Kernel hooks active: {ebpf_hooks}")
+    } else {
+        "Kernel hooks: initializing".to_string()
+    };
+
+    lines.extend(box_lines(
+        vec![
+            "Installed successfully".to_string(),
+            "Observe-only mode is ON by default".to_string(),
+            "Run: innerwarden setup".to_string(),
+            hook_line,
+        ],
+        cols,
+    ));
+
+    lines
+}
+
+/// Show centered welcome screen in the active terminal.
+pub fn run_welcome(ebpf_hooks: u32) {
     let mut out = io::stdout();
+    let is_tty = out.is_terminal();
 
-    let sword_width = SWORDS.iter().map(|l| l.chars().count()).max().unwrap_or(80);
-    let title_width = TITLE[0].chars().count();
+    if !is_tty {
+        println!("InnerWarden installed");
+        let _ = out.flush();
+        return;
+    }
 
-    // Swords + block title saved for future use (too wide for some terminals)
-    let _ = (SWORDS, TITLE, sword_width, title_width);
+    let (cols, rows) = terminal_size(is_tty);
+    let lines = build_screen(cols, ebpf_hooks);
+    let top_padding = rows.saturating_sub(lines.len() + 1) / 2;
 
-    println!();
-    println!("  🛡️  InnerWarden installed");
-    println!();
-
-    println!();
-
-    out.flush().unwrap();
+    let _ = write!(out, "\x1b[2J\x1b[H");
+    for _ in 0..top_padding {
+        let _ = writeln!(out);
+    }
+    for line in lines {
+        let _ = writeln!(out, "{}", centered_line(&line, cols));
+    }
+    let _ = writeln!(out);
+    let _ = out.flush();
 }

--- a/install.sh
+++ b/install.sh
@@ -139,15 +139,87 @@ prompt_yes_no() {
   [[ "${normalized}" == "true" ]]
 }
 
+term_cols() {
+  local cols=""
+  if command -v tput >/dev/null 2>&1; then
+    cols="$(tput cols 2>/dev/null || true)"
+  fi
+  if [[ -z "${cols}" || ! "${cols}" =~ ^[0-9]+$ || "${cols}" -lt 20 ]]; then
+    cols="${COLUMNS:-80}"
+  fi
+  if [[ ! "${cols}" =~ ^[0-9]+$ || "${cols}" -lt 20 ]]; then
+    cols=80
+  fi
+  echo "${cols}"
+}
+
+term_rows() {
+  local rows=""
+  if command -v tput >/dev/null 2>&1; then
+    rows="$(tput lines 2>/dev/null || true)"
+  fi
+  if [[ -z "${rows}" || ! "${rows}" =~ ^[0-9]+$ || "${rows}" -lt 10 ]]; then
+    rows="${LINES:-24}"
+  fi
+  if [[ ! "${rows}" =~ ^[0-9]+$ || "${rows}" -lt 10 ]]; then
+    rows=24
+  fi
+  echo "${rows}"
+}
+
+print_centered_line() {
+  local cols="$1"
+  local line="$2"
+  local width="${#line}"
+  local pad=0
+  if (( cols > width )); then
+    pad=$(( (cols - width) / 2 ))
+  fi
+  printf "%*s%s\n" "${pad}" "" "${line}"
+}
+
+print_install_banner() {
+  local cols rows top_pad i
+  cols="$(term_cols)"
+  rows="$(term_rows)"
+
+  local platform_line
+  platform_line="$(printf "%s %s | kernel %s%s" "${OS_TYPE,,}" "${ARCH}" "${KERNEL}" "${DISTRO:+ | ${DISTRO}}")"
+
+  local banner_lines=(
+"  _____ _   _ _   _ _____ ____  __        ___    ____  ____  _____ _   _ "
+" |_   _| \\ | | \\ | | ____|  _ \\ \\ \\      / / \\  |  _ \\|  _ \\| ____| \\ | |"
+"   | | |  \\| |  \\| |  _| | |_) | \\ \\ /\\ / / _ \\ | |_) | | | |  _| |  \\| |"
+"   | | | |\\  | |\\  | |___|  _ <   \\ V  V / ___ \\|  _ <| |_| | |___| |\\  |"
+"   |_| |_| \\_|_| \\_|_____|_| \\_\\   \\_/\\_/_/   \\_\\_| \\_\\____/|_____|_| \\_|"
+""
+"+---------------------------------------------------------------+"
+"| Your server's immune system installer                         |"
+"+---------------------------------------------------------------+"
+"${platform_line}"
+  )
+
+  if [[ -t 1 ]]; then
+    printf '\033[2J\033[H'
+  fi
+
+  top_pad=1
+  if (( rows > ${#banner_lines[@]} + 2 )); then
+    top_pad=$(( (rows - ${#banner_lines[@]}) / 2 ))
+  fi
+
+  for ((i = 0; i < top_pad; i++)); do
+    echo ""
+  done
+
+  for line in "${banner_lines[@]}"; do
+    print_centered_line "${cols}" "${line}"
+  done
+  echo ""
+}
+
 # ── Banner (only after sudo, so it shows once) ──────────────────────────
-echo ""
-echo "  ┌──────────────────────────────────┐"
-echo "  │  🛡️  InnerWarden                  │"
-echo "  │  Your server's immune system.    │"
-echo "  └──────────────────────────────────┘"
-echo ""
-echo "  ▸ ${OS_TYPE,,} ${ARCH} · kernel ${KERNEL}${DISTRO:+ · $DISTRO}"
-echo ""
+print_install_banner
 
 if [[ "$OS_TYPE" != "Linux" && "$OS_TYPE" != "Darwin" ]]; then
   fail "this installer supports Linux and macOS (Darwin) hosts only"


### PR DESCRIPTION
## Summary
- center the installer banner in terminal width/height instead of hardcoded left padding
- replace the minimal `innerwarden welcome` output with a centered screen that adapts to terminal size
- add TTY-safe fallbacks for non-interactive environments

## Validation
- `make check`
- `make test`
- `make spec-check`

All commands passed locally on this branch.