### PR TITLE
fix(readme): correct OpenSSF Best Practices badge ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ curl -fsSL https://innerwarden.com/install | sudo bash
 Installs in 10 seconds. Starts in observe-only mode. Dry-run by default. You decide when to go live.
 
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/InnerWarden/innerwarden/badge)](https://scorecard.dev/viewer/?uri=github.com/InnerWarden/innerwarden)
-[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/10870/badge)](https://www.bestpractices.dev/projects/10870)
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/12546/badge)](https://www.bestpractices.dev/projects/12546)
 [![CI](https://github.com/InnerWarden/innerwarden/actions/workflows/ci.yml/badge.svg)](https://github.com/InnerWarden/innerwarden/actions/workflows/ci.yml)
 [![Security](https://github.com/InnerWarden/innerwarden/actions/workflows/security.yml/badge.svg)](https://github.com/InnerWarden/innerwarden/actions/workflows/security.yml)
 [![Release](https://img.shields.io/github/v/release/InnerWarden/innerwarden?label=release&color=blue)](https://github.com/InnerWarden/innerwarden/releases/latest)


### PR DESCRIPTION
## Summary
- Fix Best Practices badge project ID from 10870 to 12546

🤖 Generated with [Claude Code](https://claude.com/claude-code)