### PR TITLE
ci: add code coverage with Codecov

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -7,13 +7,14 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   coverage:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
@@ -21,8 +22,16 @@ jobs:
       - name: Cache cargo artifacts
         uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
 
+      - name: Cache cargo binaries
+        id: cargo-bin-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/bin
+          key: ${{ runner.os }}-cargo-bin-tarpaulin-0.31.5
+
       - name: Install cargo-tarpaulin
-        run: cargo install cargo-tarpaulin
+        if: steps.cargo-bin-cache.outputs.cache-hit != 'true'
+        run: cargo install cargo-tarpaulin --version 0.31.5 --locked
 
       - name: Run coverage
         run: cargo tarpaulin --workspace --timeout 300 --out xml --skip-clean

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -28,7 +28,7 @@ jobs:
         run: cargo tarpaulin --workspace --timeout 300 --out xml --skip-clean
 
       - name: Upload to Codecov
-        uses: codecov/codecov-action@18283e04ce6e62d37312384ff67ab1f95a6683b5 # v5
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
         with:
           files: cobertura.xml
           fail_ci_if_error: false

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -1,0 +1,34 @@
+name: Code Coverage
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
+
+      - name: Cache cargo artifacts
+        uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
+
+      - name: Install cargo-tarpaulin
+        run: cargo install cargo-tarpaulin
+
+      - name: Run coverage
+        run: cargo tarpaulin --workspace --timeout 300 --out xml --skip-clean
+
+      - name: Upload to Codecov
+        uses: codecov/codecov-action@18283e04ce6e62d37312384ff67ab1f95a6683b5 # v5
+        with:
+          files: cobertura.xml
+          fail_ci_if_error: false

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Installs in 10 seconds. Starts in observe-only mode. Dry-run by default. You dec
 
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/InnerWarden/innerwarden/badge)](https://scorecard.dev/viewer/?uri=github.com/InnerWarden/innerwarden)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/12546/badge)](https://www.bestpractices.dev/projects/12546)
+[![codecov](https://codecov.io/gh/InnerWarden/innerwarden/branch/main/graph/badge.svg)](https://codecov.io/gh/InnerWarden/innerwarden)
 [![CI](https://github.com/InnerWarden/innerwarden/actions/workflows/ci.yml/badge.svg)](https://github.com/InnerWarden/innerwarden/actions/workflows/ci.yml)
 [![Security](https://github.com/InnerWarden/innerwarden/actions/workflows/security.yml/badge.svg)](https://github.com/InnerWarden/innerwarden/actions/workflows/security.yml)
 [![Release](https://img.shields.io/github/v/release/InnerWarden/innerwarden?label=release&color=blue)](https://github.com/InnerWarden/innerwarden/releases/latest)


### PR DESCRIPTION
## Summary
- Add `cargo-tarpaulin` coverage workflow (runs on push to main + PRs)
- Upload results to Codecov
- Add Codecov badge to README

## Setup required
After merge, activate the repo at https://codecov.io/gh/InnerWarden/innerwarden
(free for public repos, no token needed)

## Test plan
- [ ] CI workflow runs successfully
- [ ] Coverage report uploads to Codecov
- [ ] Badge renders in README

🤖 Generated with [Claude Code](https://claude.com/claude-code)