### PR TITLE
fix(ci): correct scorecard-action SHA (imposter commit)

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: ossf/scorecard-action@ea651e62978af7915d09fe2e282747c798bf2dab # v2.4.1
+      - uses: ossf/scorecard-action@f49aabe0b5af0936a0987cfb85d86b75731b0186 # v2.4.1
         with:
           results_file: results.sarif
           results_format: sarif


### PR DESCRIPTION
## Summary
Fix OpenSSF Scorecard workflow failure on main. The pinned SHA was a tag object, not a commit — Scorecard webapp rejects it as "imposter commit".

Dereferenced `v2.4.1` tag → actual commit SHA `f49aabe0...`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)