### PR TITLE
fix(ci): correct codeql-action SHA in scorecard workflow

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -33,6 +33,6 @@ jobs:
           path: results.sarif
           retention-days: 5
 
-      - uses: github/codeql-action/upload-sarif@3b1a19a80ab047f35cbb237b5bd9bdc1e14f166c # v3
+      - uses: github/codeql-action/upload-sarif@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a # v3
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## Summary
Fix last remaining imposter commit error in OpenSSF Scorecard workflow.
Dereference codeql-action v3 tag → actual commit SHA `ce64ddcb...`.

After merge, Scorecard should run green on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)