### PR TITLE
security: enterprise audit — fix 10 findings (SEC-001 to SEC-020)

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -87,7 +87,7 @@ jobs:
           done
 
       - name: Update canary release
-        uses: ncipollo/release-action@v1
+        uses: ncipollo/release-action@440c8c1cb0ed28b9f43f5c0920cbec5b3422c6a2 # v1
         with:
           tag: canary
           commit: ${{ github.sha }}

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Cache cargo binaries
         id: cargo-bin-cache
-        uses: actions/cache@v4
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
         with:
           path: ~/.cargo/bin
           key: ${{ runner.os }}-cargo-bin-tarpaulin-0.31.5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -230,7 +230,7 @@ jobs:
         run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
 
       - name: Build and push agent image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198a989f3d76a3 # v6
         with:
           context: docker
           file: docker/Dockerfile.agent
@@ -244,7 +244,7 @@ jobs:
 
       - name: Build and push agent-openclaw image
         continue-on-error: true  # OpenClaw upstream may break; don't block the release
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198a989f3d76a3 # v6
         with:
           context: docker
           file: docker/Dockerfile.agent-openclaw

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -25,5 +25,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Install and run gitleaks
         run: |
-          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v8.24.0/gitleaks_8.24.0_linux_x64.tar.gz" | tar xz
+          curl -sSfL -o gitleaks.tar.gz "https://github.com/gitleaks/gitleaks/releases/download/v8.24.0/gitleaks_8.24.0_linux_x64.tar.gz"
+          echo "cb49b7de5ee986510fe8666ca0273a6cc15eb82571f2f14832c9e8920751f3a4  gitleaks.tar.gz" | sha256sum -c -
+          tar xzf gitleaks.tar.gz
           ./gitleaks detect --source . --no-git --verbose --redact

--- a/crates/agent/src/ai/mod.rs
+++ b/crates/agent/src/ai/mod.rs
@@ -389,8 +389,9 @@ pub fn build_provider(cfg: &AiConfig) -> Result<Box<dyn AiProvider>> {
             )))
         }
         other => {
-            // Unknown provider name - if base_url is set, treat as OpenAI-compatible.
-            // This lets users connect any compatible API without code changes.
+            // SEC-017: Unknown provider name — require explicit base_url.
+            // If base_url is set, treat as OpenAI-compatible endpoint.
+            // Without base_url, fail closed to prevent accidental data egress.
             if !cfg.base_url.is_empty() {
                 validate_ai_base_url(&cfg.base_url)?;
                 tracing::info!(
@@ -404,14 +405,11 @@ pub fn build_provider(cfg: &AiConfig) -> Result<Box<dyn AiProvider>> {
                     cfg.base_url.clone(),
                 )))
             } else {
-                tracing::warn!(
-                    provider = other,
-                    "unknown AI provider and no base_url - falling back to openai"
+                anyhow::bail!(
+                    "unknown AI provider '{}'. Set provider to 'openai', 'anthropic', \
+                     or 'ollama', or provide a base_url for OpenAI-compatible endpoints.",
+                    other
                 );
-                Ok(Box::new(openai::OpenAiProvider::new(
-                    cfg.resolved_api_key(),
-                    cfg.model.clone(),
-                )))
             }
         }
     }

--- a/crates/agent/src/ai/mod.rs
+++ b/crates/agent/src/ai/mod.rs
@@ -490,4 +490,53 @@ mod tests {
         assert!(matches!(d.action, AiAction::Ignore { .. }));
         assert!(!d.auto_execute);
     }
+
+    // SEC-017: Unknown provider without base_url must fail.
+    #[test]
+    fn build_provider_unknown_no_base_url_fails() {
+        let cfg = crate::config::AiConfig {
+            enabled: true,
+            provider: "nonexistent-provider".into(),
+            base_url: String::new(),
+            ..Default::default()
+        };
+        let result = build_provider(&cfg);
+        assert!(
+            result.is_err(),
+            "should fail for unknown provider without base_url"
+        );
+        let err = format!("{}", result.err().unwrap());
+        assert!(
+            err.contains("unknown AI provider"),
+            "expected 'unknown AI provider' error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn build_provider_unknown_with_base_url_succeeds() {
+        let cfg = crate::config::AiConfig {
+            enabled: true,
+            provider: "custom-llm".into(),
+            base_url: "https://my-llm.example.com".into(),
+            api_key: "test-key".into(),
+            model: "my-model".into(),
+            ..Default::default()
+        };
+        let result = build_provider(&cfg);
+        assert!(
+            result.is_ok(),
+            "should accept unknown provider with base_url"
+        );
+    }
+
+    #[test]
+    fn build_provider_known_provider_succeeds() {
+        let cfg = crate::config::AiConfig {
+            enabled: true,
+            provider: "ollama".into(),
+            ..Default::default()
+        };
+        let result = build_provider(&cfg);
+        assert!(result.is_ok());
+    }
 }

--- a/crates/agent/src/ai/openai.rs
+++ b/crates/agent/src/ai/openai.rs
@@ -30,6 +30,7 @@ fn uses_new_token_param(model: &str) -> bool {
 }
 
 impl OpenAiProvider {
+    #[allow(dead_code)] // Used when provider = "openai" (matched explicitly in factory)
     pub fn new(api_key: String, model: String) -> Self {
         Self::with_base_url(api_key, model, "https://api.openai.com".to_string())
     }

--- a/crates/agent/src/dashboard/frontend/js/graph.js
+++ b/crates/agent/src/dashboard/frontend/js/graph.js
@@ -38,11 +38,14 @@ async function loadGraph() {
     }
 
     // Load Cytoscape.js from CDN if not loaded (with offline fallback)
+    // SEC-018: Pinned version with SRI integrity hash to prevent CDN tampering.
     if (typeof cytoscape === 'undefined') {
       try {
         await new Promise((resolve, reject) => {
           const s = document.createElement('script');
           s.src = 'https://unpkg.com/cytoscape@3.30.4/dist/cytoscape.min.js';
+          s.integrity = 'sha384-H3uzGzTfGHUAumB8+s4GEdfFwzAceN9wCCndN8AXubWKFIPuBSWKKtWDx7RhSf/z';
+          s.crossOrigin = 'anonymous';
           s.onload = resolve;
           s.onerror = reject;
           s.timeout = 5000;

--- a/crates/agent/src/dashboard/live_feed.rs
+++ b/crates/agent/src/dashboard/live_feed.rs
@@ -435,7 +435,7 @@ pub(super) async fn api_live_feed_geoip(Query(query): Query<GeoIpQuery>) -> Json
     for ip in ips {
         let ip = ip.trim();
         let url = format!(
-            "http://ip-api.com/json/{}?fields=status,lat,lon,country",
+            "https://ip-api.com/json/{}?fields=status,lat,lon,country",
             ip
         );
         if let Ok(resp) = client.get(&url).send().await {

--- a/crates/agent/src/dashboard/mod.rs
+++ b/crates/agent/src/dashboard/mod.rs
@@ -204,12 +204,24 @@ pub async fn serve(
     tls_key: Option<String>,
     insecure_no_tls: bool,
 ) -> Result<()> {
+    // SEC-005: Reject non-loopback bind without authentication.
+    let is_loopback_bind =
+        bind.starts_with("127.0.0.1") || bind.starts_with("[::1]") || bind.starts_with("localhost");
     if auth.is_none() {
-        warn!(
-            "dashboard is running WITHOUT authentication - \
-             set INNERWARDEN_DASHBOARD_USER and INNERWARDEN_DASHBOARD_PASSWORD_HASH \
-             in agent.env to require a login"
-        );
+        if is_loopback_bind {
+            warn!(
+                "dashboard is running WITHOUT authentication (loopback only) - \
+                 set INNERWARDEN_DASHBOARD_USER and INNERWARDEN_DASHBOARD_PASSWORD_HASH \
+                 in agent.env to require a login"
+            );
+        } else {
+            anyhow::bail!(
+                "dashboard bound to non-loopback address {} without authentication. \
+                 Set INNERWARDEN_DASHBOARD_USER and INNERWARDEN_DASHBOARD_PASSWORD_HASH, \
+                 or bind to 127.0.0.1 for unauthenticated local access.",
+                bind
+            );
+        }
     }
 
     // HTTPS warning: credentials sent in plaintext over non-localhost HTTP
@@ -328,9 +340,10 @@ pub async fn serve(
         }
     });
 
-    // Agent API routes - no auth required (localhost service-to-service)
-    // These are used by AI agents (OpenClaw, n8n, etc.) to query security state.
-    let agent_api = Router::new()
+    // SEC-006: Agent API routes — require auth when bound to non-loopback.
+    // On loopback, these remain unauthenticated for local service-to-service use
+    // (OpenClaw, n8n, etc.). On non-loopback, they go through the auth layer.
+    let agent_api_router = Router::new()
         .route(
             "/api/agent/security-context",
             get(api_agent_security_context),
@@ -347,8 +360,14 @@ pub async fn serve(
             "/api/agent-guard/disconnect",
             post(api_agent_guard_disconnect),
         )
-        .route("/api/agent-guard/agents", get(api_agent_guard_list))
-        .with_state(state.clone());
+        .route("/api/agent-guard/agents", get(api_agent_guard_list));
+    let agent_api = if is_loopback_bind {
+        agent_api_router.with_state(state.clone())
+    } else {
+        agent_api_router
+            .layer(auth_layer.clone())
+            .with_state(state.clone())
+    };
 
     // Auth login route - public (no auth required; this IS the auth endpoint)
     let auth_login = Router::new()
@@ -450,18 +469,25 @@ pub async fn serve(
         // Session management endpoints (auth-protected)
         .route("/api/auth/logout", post(api_auth_logout))
         .route("/api/auth/sessions", get(api_auth_sessions))
-        .layer(auth_layer)
+        .layer(auth_layer.clone())
         .with_state(state.clone());
 
-    // Public live-feed routes - CORS-enabled, no auth, read-only
-    let live_api = Router::new()
+    // SEC-007: Live-feed routes require auth on non-loopback binds.
+    // On loopback, they remain public for local integrations.
+    let live_api_router = Router::new()
         .route("/api/live-feed", get(api_live_feed))
         .route("/api/live-feed/stream", get(api_live_feed_stream))
         .route("/api/live-feed/geoip", get(api_live_feed_geoip))
         .route("/api/live-feed/honeypot", get(api_live_feed_honeypot))
-        .route("/api/live-feed/mitre", get(api_live_feed_mitre))
-        .layer(middleware::from_fn(cors_middleware))
-        .with_state(state);
+        .route("/api/live-feed/mitre", get(api_live_feed_mitre));
+    let live_api = if is_loopback_bind {
+        live_api_router
+            .layer(middleware::from_fn(cors_middleware))
+            .with_state(state)
+    } else {
+        // Non-loopback: no wildcard CORS, require auth
+        live_api_router.layer(auth_layer.clone()).with_state(state)
+    };
 
     let app = agent_api
         .merge(auth_login)
@@ -577,8 +603,13 @@ async fn build_tls_config(
             rcgen::DnType::OrganizationName,
             rcgen::DnValue::Utf8String("InnerWarden".to_string()),
         );
-        // Valid for 365 days
-        params.not_after = rcgen::date_time_ymd(2027, 4, 15);
+        // SEC-013: Valid for 365 days from now (not a hardcoded date).
+        let expiry = chrono::Utc::now() + chrono::Duration::days(365);
+        params.not_after = rcgen::date_time_ymd(
+            chrono::Datelike::year(&expiry),
+            chrono::Datelike::month(&expiry) as u8,
+            chrono::Datelike::day(&expiry) as u8,
+        );
         // Add SANs for common access patterns
         params.subject_alt_names = vec![
             rcgen::SanType::DnsName("localhost".try_into()?),

--- a/crates/agent/src/dashboard/mod.rs
+++ b/crates/agent/src/dashboard/mod.rs
@@ -354,12 +354,12 @@ pub async fn serve(
             post(api_agent_guard_disconnect),
         )
         .route("/api/agent-guard/agents", get(api_agent_guard_list));
-    let agent_api = if is_loopback_bind {
-        agent_api_router.with_state(state.clone())
-    } else {
+    let agent_api = if should_require_api_auth(&bind) {
         agent_api_router
             .layer(auth_layer.clone())
             .with_state(state.clone())
+    } else {
+        agent_api_router.with_state(state.clone())
     };
 
     // Auth login route - public (no auth required; this IS the auth endpoint)
@@ -473,13 +473,13 @@ pub async fn serve(
         .route("/api/live-feed/geoip", get(api_live_feed_geoip))
         .route("/api/live-feed/honeypot", get(api_live_feed_honeypot))
         .route("/api/live-feed/mitre", get(api_live_feed_mitre));
-    let live_api = if is_loopback_bind {
+    let live_api = if should_require_api_auth(&bind) {
+        // Non-loopback: no wildcard CORS, require auth
+        live_api_router.layer(auth_layer.clone()).with_state(state)
+    } else {
         live_api_router
             .layer(middleware::from_fn(cors_middleware))
             .with_state(state)
-    } else {
-        // Non-loopback: no wildcard CORS, require auth
-        live_api_router.layer(auth_layer.clone()).with_state(state)
     };
 
     let app = agent_api
@@ -597,12 +597,8 @@ async fn build_tls_config(
             rcgen::DnValue::Utf8String("InnerWarden".to_string()),
         );
         // SEC-013: Valid for 365 days from now (not a hardcoded date).
-        let expiry = chrono::Utc::now() + chrono::Duration::days(365);
-        params.not_after = rcgen::date_time_ymd(
-            chrono::Datelike::year(&expiry),
-            chrono::Datelike::month(&expiry) as u8,
-            chrono::Datelike::day(&expiry) as u8,
-        );
+        let (y, m, d) = cert_expiry_ymd(365);
+        params.not_after = rcgen::date_time_ymd(y, m, d);
         // Add SANs for common access patterns
         params.subject_alt_names = vec![
             rcgen::SanType::DnsName("localhost".try_into()?),
@@ -742,6 +738,22 @@ pub(crate) fn validate_bind_auth(bind: &str, has_auth: bool) -> Result<(), Strin
         ));
     }
     Ok(())
+}
+
+/// SEC-013: Compute TLS certificate expiry date (year, month, day).
+pub(crate) fn cert_expiry_ymd(days_valid: i64) -> (i32, u8, u8) {
+    let expiry = chrono::Utc::now() + chrono::Duration::days(days_valid);
+    (
+        chrono::Datelike::year(&expiry),
+        chrono::Datelike::month(&expiry) as u8,
+        chrono::Datelike::day(&expiry) as u8,
+    )
+}
+
+/// SEC-006/007: Determine if agent API / live-feed should require auth.
+/// Returns true when auth should be enforced (non-loopback bind).
+pub(crate) fn should_require_api_auth(bind: &str) -> bool {
+    !is_loopback_address(bind)
 }
 
 // ---------------------------------------------------------------------------
@@ -1716,5 +1728,46 @@ mod tests {
     #[test]
     fn validate_bind_auth_loopback_with_auth_ok() {
         assert!(validate_bind_auth("127.0.0.1:8787", true).is_ok());
+    }
+
+    // SEC-013: TLS cert expiry date tests.
+    #[test]
+    fn cert_expiry_ymd_365_days() {
+        let (y, m, d) = cert_expiry_ymd(365);
+        let now = chrono::Utc::now();
+        // Year should be this year or next year
+        assert!(y >= chrono::Datelike::year(&now));
+        assert!(y <= chrono::Datelike::year(&now) + 1);
+        assert!((1..=12).contains(&m));
+        assert!((1..=31).contains(&d));
+    }
+
+    #[test]
+    fn cert_expiry_ymd_1_day() {
+        let (y, m, d) = cert_expiry_ymd(1);
+        let tomorrow = chrono::Utc::now() + chrono::Duration::days(1);
+        assert_eq!(y, chrono::Datelike::year(&tomorrow));
+        assert_eq!(m, chrono::Datelike::month(&tomorrow) as u8);
+        assert_eq!(d, chrono::Datelike::day(&tomorrow) as u8);
+    }
+
+    #[test]
+    fn cert_expiry_ymd_zero_days() {
+        let (y, _m, _d) = cert_expiry_ymd(0);
+        assert_eq!(y, chrono::Datelike::year(&chrono::Utc::now()));
+    }
+
+    // SEC-006/007: API auth requirement tests.
+    #[test]
+    fn should_require_api_auth_external() {
+        assert!(should_require_api_auth("0.0.0.0:8787"));
+        assert!(should_require_api_auth("192.168.1.1:8787"));
+    }
+
+    #[test]
+    fn should_not_require_api_auth_loopback() {
+        assert!(!should_require_api_auth("127.0.0.1:8787"));
+        assert!(!should_require_api_auth("[::1]:8787"));
+        assert!(!should_require_api_auth("localhost:8787"));
     }
 }

--- a/crates/agent/src/dashboard/mod.rs
+++ b/crates/agent/src/dashboard/mod.rs
@@ -205,23 +205,16 @@ pub async fn serve(
     insecure_no_tls: bool,
 ) -> Result<()> {
     // SEC-005: Reject non-loopback bind without authentication.
-    let is_loopback_bind =
-        bind.starts_with("127.0.0.1") || bind.starts_with("[::1]") || bind.starts_with("localhost");
-    if auth.is_none() {
-        if is_loopback_bind {
-            warn!(
-                "dashboard is running WITHOUT authentication (loopback only) - \
-                 set INNERWARDEN_DASHBOARD_USER and INNERWARDEN_DASHBOARD_PASSWORD_HASH \
-                 in agent.env to require a login"
-            );
-        } else {
-            anyhow::bail!(
-                "dashboard bound to non-loopback address {} without authentication. \
-                 Set INNERWARDEN_DASHBOARD_USER and INNERWARDEN_DASHBOARD_PASSWORD_HASH, \
-                 or bind to 127.0.0.1 for unauthenticated local access.",
-                bind
-            );
-        }
+    let is_loopback_bind = is_loopback_address(&bind);
+    if let Err(e) = validate_bind_auth(&bind, auth.is_some()) {
+        anyhow::bail!("{}", e);
+    }
+    if auth.is_none() && is_loopback_bind {
+        warn!(
+            "dashboard is running WITHOUT authentication (loopback only) - \
+             set INNERWARDEN_DASHBOARD_USER and INNERWARDEN_DASHBOARD_PASSWORD_HASH \
+             in agent.env to require a login"
+        );
     }
 
     // HTTPS warning: credentials sent in plaintext over non-localhost HTTP
@@ -728,6 +721,29 @@ const JS_SSE: &str = include_str!("frontend/js/sse.js");
 
 // ---------------------------------------------------------------------------
 // Tests
+// ---------------------------------------------------------------------------
+// SEC-005: Pure helpers for bind address validation (testable).
+// ---------------------------------------------------------------------------
+
+/// Check if a bind address is a loopback address.
+pub(crate) fn is_loopback_address(bind: &str) -> bool {
+    bind.starts_with("127.0.0.1") || bind.starts_with("[::1]") || bind.starts_with("localhost")
+}
+
+/// Validate bind address + auth combination.
+/// Returns Err if non-loopback bind has no auth configured.
+pub(crate) fn validate_bind_auth(bind: &str, has_auth: bool) -> Result<(), String> {
+    if !has_auth && !is_loopback_address(bind) {
+        return Err(format!(
+            "dashboard bound to non-loopback address {} without authentication. \
+             Set INNERWARDEN_DASHBOARD_USER and INNERWARDEN_DASHBOARD_PASSWORD_HASH, \
+             or bind to 127.0.0.1 for unauthenticated local access.",
+            bind
+        ));
+    }
+    Ok(())
+}
+
 // ---------------------------------------------------------------------------
 
 #[cfg(test)]
@@ -1661,5 +1677,44 @@ mod tests {
 
         let second: Vec<Event> = read_jsonl(&path);
         assert_eq!(second.len(), 2);
+    }
+
+    // ── SEC-005: bind address validation tests ──────────────────────────
+
+    #[test]
+    fn is_loopback_localhost() {
+        assert!(is_loopback_address("127.0.0.1:8787"));
+        assert!(is_loopback_address("[::1]:8787"));
+        assert!(is_loopback_address("localhost:8787"));
+    }
+
+    #[test]
+    fn is_not_loopback_external() {
+        assert!(!is_loopback_address("0.0.0.0:8787"));
+        assert!(!is_loopback_address("192.168.1.1:8787"));
+        assert!(!is_loopback_address("10.0.0.1:8787"));
+    }
+
+    #[test]
+    fn validate_bind_auth_loopback_no_auth_ok() {
+        assert!(validate_bind_auth("127.0.0.1:8787", false).is_ok());
+        assert!(validate_bind_auth("localhost:8787", false).is_ok());
+    }
+
+    #[test]
+    fn validate_bind_auth_external_no_auth_rejected() {
+        let result = validate_bind_auth("0.0.0.0:8787", false);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("without authentication"));
+    }
+
+    #[test]
+    fn validate_bind_auth_external_with_auth_ok() {
+        assert!(validate_bind_auth("0.0.0.0:8787", true).is_ok());
+    }
+
+    #[test]
+    fn validate_bind_auth_loopback_with_auth_ok() {
+        assert!(validate_bind_auth("127.0.0.1:8787", true).is_ok());
     }
 }

--- a/crates/agent/src/geoip.rs
+++ b/crates/agent/src/geoip.rs
@@ -84,10 +84,11 @@ impl GeoIpClient {
             return None;
         }
 
-        debug!(ip, "querying ip-api.com");
+        // SEC-016: Use HTTPS to avoid leaking queried IPs in transit.
+        debug!(ip, "querying ip-api.com (HTTPS)");
 
         let url = format!(
-            "http://ip-api.com/json/{}?fields=status,country,countryCode,city,isp,org,as",
+            "https://ip-api.com/json/{}?fields=status,country,countryCode,city,isp,org,as",
             ip
         );
 

--- a/crates/ctl/src/commands/module.rs
+++ b/crates/ctl/src/commands/module.rs
@@ -371,7 +371,8 @@ fn run_module_preflight(pf: &module_manifest::ModulePreflightSpec) -> (bool, Str
                 .any(|l| l.split(':').next().is_some_and(|u| u == pf.value));
             (exists, format!("user '{}' does not exist", pf.value))
         }
-        _ => (true, String::new()), // unknown kind = pass (fail-open)
+        // SEC-009: Fail closed on unknown preflight kinds.
+        other => (false, format!("unknown preflight kind '{}'", other)),
     }
 }
 
@@ -630,7 +631,14 @@ pub(crate) fn cmd_module_install(
     use module_manifest::ModuleManifest;
     use module_package::*;
 
-    let is_url = source.starts_with("https://") || source.starts_with("http://");
+    // SEC-008: Reject insecure HTTP transport for module installation.
+    if source.starts_with("http://") {
+        anyhow::bail!(
+            "insecure HTTP transport is not allowed for module installation.\n\
+             Use https:// or a local file path instead."
+        );
+    }
+    let is_url = source.starts_with("https://");
     let is_path =
         source.starts_with('/') || source.starts_with('.') || std::path::Path::new(source).exists();
 

--- a/crates/ctl/src/commands/module.rs
+++ b/crates/ctl/src/commands/module.rs
@@ -620,6 +620,17 @@ pub(crate) fn cmd_module_search(query: Option<&str>) -> Result<()> {
 // Module install / uninstall / publish
 // ---------------------------------------------------------------------------
 
+/// SEC-008: Validate module source rejects insecure HTTP transport.
+fn validate_module_source(source: &str) -> Result<()> {
+    if source.starts_with("http://") {
+        anyhow::bail!(
+            "insecure HTTP transport is not allowed for module installation.\n\
+             Use https:// or a local file path instead."
+        );
+    }
+    Ok(())
+}
+
 pub(crate) fn cmd_module_install(
     cli: &Cli,
     source: &str,
@@ -632,12 +643,7 @@ pub(crate) fn cmd_module_install(
     use module_package::*;
 
     // SEC-008: Reject insecure HTTP transport for module installation.
-    if source.starts_with("http://") {
-        anyhow::bail!(
-            "insecure HTTP transport is not allowed for module installation.\n\
-             Use https:// or a local file path instead."
-        );
-    }
+    validate_module_source(source)?;
     let is_url = source.starts_with("https://");
     let is_path =
         source.starts_with('/') || source.starts_with('.') || std::path::Path::new(source).exists();
@@ -1169,5 +1175,25 @@ mod tests {
         };
         let (passed, _) = run_module_preflight(&pf);
         assert!(!passed);
+    }
+
+    // SEC-008: Module source validation.
+    #[test]
+    fn validate_module_source_rejects_http() {
+        let r = validate_module_source("http://evil.com/module.tar.gz");
+        assert!(r.is_err());
+        assert!(r.unwrap_err().to_string().contains("insecure HTTP"));
+    }
+
+    #[test]
+    fn validate_module_source_allows_https() {
+        assert!(validate_module_source("https://registry.innerwarden.com/mod.tar.gz").is_ok());
+    }
+
+    #[test]
+    fn validate_module_source_allows_local_path() {
+        assert!(validate_module_source("/opt/modules/my-module.tar.gz").is_ok());
+        assert!(validate_module_source("./my-module.tar.gz").is_ok());
+        assert!(validate_module_source("my-module").is_ok());
     }
 }

--- a/crates/ctl/src/commands/module.rs
+++ b/crates/ctl/src/commands/module.rs
@@ -1116,3 +1116,58 @@ pub(crate) fn cmd_module_update_all(
     }
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // SEC-009: Unknown preflight kind fails closed.
+    #[test]
+    fn preflight_unknown_kind_fails() {
+        let pf = module_manifest::ModulePreflightSpec {
+            kind: "magic_check".into(),
+            value: "anything".into(),
+            reason: "test".into(),
+        };
+        let (passed, msg) = run_module_preflight(&pf);
+        assert!(!passed, "unknown preflight kind should fail");
+        assert!(msg.contains("unknown preflight kind"));
+    }
+
+    #[test]
+    fn preflight_binary_exists_known_path() {
+        let pf = module_manifest::ModulePreflightSpec {
+            kind: "binary_exists".into(),
+            value: "/usr/bin/env".into(),
+            reason: "test".into(),
+        };
+        let (passed, _) = run_module_preflight(&pf);
+        // /usr/bin/env exists on all Unix systems
+        if cfg!(unix) {
+            assert!(passed);
+        }
+    }
+
+    #[test]
+    fn preflight_binary_exists_missing() {
+        let pf = module_manifest::ModulePreflightSpec {
+            kind: "binary_exists".into(),
+            value: "/nonexistent/binary/xyz".into(),
+            reason: "test".into(),
+        };
+        let (passed, msg) = run_module_preflight(&pf);
+        assert!(!passed);
+        assert!(msg.contains("not found"));
+    }
+
+    #[test]
+    fn preflight_directory_exists_missing() {
+        let pf = module_manifest::ModulePreflightSpec {
+            kind: "directory_exists".into(),
+            value: "/nonexistent/dir/xyz".into(),
+            reason: "test".into(),
+        };
+        let (passed, _) = run_module_preflight(&pf);
+        assert!(!passed);
+    }
+}

--- a/crates/sensor/src/collectors/ebpf_syscall.rs
+++ b/crates/sensor/src/collectors/ebpf_syscall.rs
@@ -54,8 +54,16 @@ pub fn is_ebpf_available() -> bool {
         return false;
     }
 
-    // eBPF bytecode exists
-    std::path::Path::new(EBPF_OBJ_PATH).exists() || std::path::Path::new(EBPF_OBJ_PATH_DEV).exists()
+    // eBPF bytecode exists: embedded builds always have it, otherwise check disk.
+    #[cfg(feature = "ebpf-embedded")]
+    {
+        true
+    }
+    #[cfg(not(feature = "ebpf-embedded"))]
+    {
+        std::path::Path::new(EBPF_OBJ_PATH).exists()
+            || std::path::Path::new(EBPF_OBJ_PATH_DEV).exists()
+    }
 }
 
 /// Find the eBPF bytecode file.

--- a/crates/sensor/src/collectors/ebpf_syscall.rs
+++ b/crates/sensor/src/collectors/ebpf_syscall.rs
@@ -55,6 +55,12 @@ pub fn is_ebpf_available() -> bool {
     }
 
     // eBPF bytecode exists: embedded builds always have it, otherwise check disk.
+    has_ebpf_bytecode()
+}
+
+/// Check if eBPF bytecode is available (embedded or on disk).
+/// Separated from `is_ebpf_available()` for testability on non-Linux.
+fn has_ebpf_bytecode() -> bool {
     #[cfg(feature = "ebpf-embedded")]
     {
         true
@@ -2758,5 +2764,20 @@ mod tests {
     #[test]
     fn ebpf_obj_paths_are_absolute() {
         assert!(EBPF_OBJ_PATH.starts_with('/'));
+    }
+
+    #[test]
+    fn has_ebpf_bytecode_returns_bool() {
+        // Without the ebpf-embedded feature, checks disk paths which don't
+        // exist in dev/CI — returns false. With embedded, returns true.
+        // Either way, the function must not panic.
+        let result = has_ebpf_bytecode();
+        if cfg!(feature = "ebpf-embedded") {
+            assert!(result);
+        } else {
+            // On dev machines the bytecode files typically don't exist
+            // (they're only built with `cargo +nightly build --target bpfel-unknown-none`)
+            let _ = result; // just verify it doesn't panic
+        }
     }
 }

--- a/crates/sensor/src/collectors/ebpf_syscall.rs
+++ b/crates/sensor/src/collectors/ebpf_syscall.rs
@@ -2745,4 +2745,18 @@ mod tests {
             assert!(resolve_container_id(1).is_none());
         }
     }
+
+    // SEC-001: eBPF availability tests
+    #[test]
+    fn ebpf_availability_non_linux_returns_false() {
+        // On macOS (CI/dev), should always return false
+        if cfg!(not(target_os = "linux")) {
+            assert!(!is_ebpf_available());
+        }
+    }
+
+    #[test]
+    fn ebpf_obj_paths_are_absolute() {
+        assert!(EBPF_OBJ_PATH.starts_with('/'));
+    }
 }

--- a/install.sh
+++ b/install.sh
@@ -407,21 +407,25 @@ download_asset() {
     fail "Downloaded file is empty: ${asset}. The release may be corrupted."
   fi
 
-  if curl -fsSL "${base_url}/${asset}.sha256" | awk '{print $1}' > /tmp/iw-expected-sha256 2>/dev/null; then
+  local sha_tmpfile
+  sha_tmpfile="$(mktemp)" || fail "failed to create secure temporary file"
+  trap 'rm -f "${sha_tmpfile}"' RETURN
+  if curl -fsSL "${base_url}/${asset}.sha256" | awk '{print $1}' > "${sha_tmpfile}" 2>/dev/null; then
     local expected actual
-    expected="$(cat /tmp/iw-expected-sha256)"
+    expected="$(cat "${sha_tmpfile}")"
     # Use shasum on macOS, sha256sum on Linux
     if command -v sha256sum >/dev/null 2>&1; then
       actual="$(sha256sum "${dest}" | awk '{print $1}')"
     else
       actual="$(shasum -a 256 "${dest}" | awk '{print $1}')"
     fi
-    rm -f /tmp/iw-expected-sha256
+    rm -f "${sha_tmpfile}"
     if [[ "${expected}" != "${actual}" ]]; then
       fail "SHA-256 mismatch for ${asset}:\n  expected: ${expected}\n  got:      ${actual}"
     fi
     log "SHA-256 ok"
   else
+    rm -f "${sha_tmpfile}"
     log "warning: no SHA-256 sidecar for ${asset} - skipping integrity check"
   fi
 }
@@ -1020,10 +1024,11 @@ if [[ "${CANARY}" -eq 1 ]] && [[ "${IW_VERSION}" != "canary" ]]; then
   fi
 fi
 
-# Anonymous install ping (no personal data, just version + OS + arch)
-# Helps us understand how many people install InnerWarden.
-# View the source: this sends nothing beyond what's shown here.
-curl -s "https://innerwarden.com/api/ping?v=${IW_VERSION}&os=${OS_TYPE}&arch=${ARCH}" >/dev/null 2>&1 &
+# SEC-019: Install telemetry is opt-in only.
+# Set INNERWARDEN_TELEMETRY=1 to send an anonymous install ping (version + OS + arch).
+if [[ "${INNERWARDEN_TELEMETRY:-0}" == "1" ]]; then
+  curl -s "https://innerwarden.com/api/ping?v=${IW_VERSION}&os=${OS_TYPE}&arch=${ARCH}" >/dev/null 2>&1 &
+fi
 
 # Show welcome, then auto-run setup
 if ! innerwarden welcome 2>/dev/null; then


### PR DESCRIPTION
## Enterprise Security Audit Remediation

Fixes 10 findings from the enterprise security audit report (2026-04-16).

### Critical
- **IW-SEC-001**: eBPF embedded builds skip file existence check — no silent degradation

### High (5 fixes)
- **IW-SEC-005**: Dashboard rejects non-loopback bind without authentication
- **IW-SEC-006**: Agent API/metrics require auth on non-loopback
- **IW-SEC-007**: Live-feed endpoints require auth on non-loopback, CORS restricted
- **IW-SEC-008**: Module install rejects insecure HTTP transport
- **IW-SEC-009**: Unknown preflight kinds fail closed (was fail-open)

### Medium (5 fixes)
- **IW-SEC-004**: Installer uses `mktemp` instead of fixed `/tmp` path
- **IW-SEC-013**: TLS cert validity computed as `now + 365d` (not hardcoded)
- **IW-SEC-016**: GeoIP enrichment uses HTTPS
- **IW-SEC-017**: Unknown AI provider fails with error (not silent fallback)
- **IW-SEC-018**: Cytoscape CDN script pinned with SRI integrity hash
- **IW-SEC-019**: Installer telemetry opt-in only (`INNERWARDEN_TELEMETRY=1`)
- **IW-SEC-020**: All CI actions pinned by SHA, gitleaks download verified

### Not addressed (require architectural decisions)
- IW-SEC-002: systemd unit privilege model (needs production validation)
- IW-SEC-003: Installer signature verification (needs key infra)
- IW-SEC-010/011: Response blast-radius policy engine (Phase F)
- IW-SEC-012: Compliance verifier cross-day verification
- IW-SEC-014: OpenClaw Dockerfile (separate repo)
- IW-SEC-021: Remote audit notarization (architecture)

## Test plan
- [x] `cargo clippy -- -D warnings` passes (sensor + agent + ctl)
- [x] `cargo fmt -- --check` passes
- [x] All tests pass
- [x] Gitleaks SHA-256 verified against actual download

🤖 Generated with [Claude Code](https://claude.com/claude-code)