### PR TITLE
docs: re-add spec 024 — starting execution

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,6 +122,7 @@ Ordenado por numero. ✅ merged, 🚧 in-progress, 📝 draft/planned, ⏸ defer
 | 021 | Observation Verification | ✅ Phases A-D. Score engine + integracao no agent loop + AI batch verification + dashboard score display. Active FP clearing funcional. |
 | 022 | Dashboard Test Coverage | ✅ 6 batches merged + 2 expansoes. Cobertura do dashboard de 0% pra ~30%+. HTML escape, auth, investigation, sensors, actions — tudo testado. |
 | 023 | Coverage Closeout (project-wide) | **In progress** — Batches 1..11 done, awaiting codecov refresh |
+| 024 | Regression Safety Net | 🚧 P0. Scenario volume tests (`make scenario-qa`) + `/metrics` drift + contract tests. Motivation: coverage alone doesn't prevent "fix A → break B" whack-a-mole. Phases A+B planned, C blocks on spec 005. |
 | 025 | Structured AI Prompt | 📝 Draft P1. Bench mostrou qwen2.5:3b: 53%→73% accuracy (prose→JSON subgraph). Implementacao: 2 AI sessions. Bench em `innerwarden-test/ai-grounding/`. |
 | 026 | Decomposition for Testability | ✅ Phases A-C. main.rs split, honeypot split, telegram split. Agent crate +10.98pp coverage. replay-qa diff zero. |
 


### PR DESCRIPTION
Spec 024 (regression safety net) is moving into execution. Operator's stated goal for coverage work is "don't break X when I add Y" — that's a composition-level guarantee that unit test coverage alone cannot provide. Spec 024's scenario tests + contract tests + drift metrics are the structural answer.

Re-adds 024 to the Features table as 🚧 (in progress). Spec file itself unchanged.

Codex prompt for executing Phase A + B lives in PR comment + in the spec's "Prompt for the executing AI" section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)