### PR TITLE
chore(agent,ctl): realign sort pattern with workspace #![allow] convention

### DIFF
--- a/crates/agent/src/attacker_intel.rs
+++ b/crates/agent/src/attacker_intel.rs
@@ -519,7 +519,7 @@ pub fn persist_snapshot(
     store: Option<&innerwarden_store::Store>,
 ) {
     let mut sorted: Vec<&AttackerProfile> = profiles.values().collect();
-    sorted.sort_by_key(|x| std::cmp::Reverse(x.risk_score));
+    sorted.sort_by(|a, b| b.risk_score.cmp(&a.risk_score));
 
     let path = data_dir.join("attacker-profiles.json");
     match serde_json::to_string(&sorted) {

--- a/crates/agent/src/bot_helpers.rs
+++ b/crates/agent/src/bot_helpers.rs
@@ -70,7 +70,7 @@ pub(crate) fn graph_last_incidents(
     }
 
     // Sort by ts descending, take last N
-    items.sort_by_key(|x| std::cmp::Reverse(x.0));
+    items.sort_by(|a, b| b.0.cmp(&a.0));
     items.truncate(n);
 
     let now = chrono::Utc::now();
@@ -144,7 +144,7 @@ pub(crate) fn graph_last_decisions(
         return "\u{2696}\u{fe0f} No decisions yet today - standing by.".to_string();
     }
 
-    items.sort_by_key(|x| std::cmp::Reverse(x.0));
+    items.sort_by(|a, b| b.0.cmp(&a.0));
     items.truncate(n);
 
     let action_icon = |a: &str| {
@@ -210,7 +210,7 @@ pub(crate) fn graph_last_incidents_raw(
         return String::new();
     }
 
-    items.sort_by_key(|x| std::cmp::Reverse(x.0));
+    items.sort_by(|a, b| b.0.cmp(&a.0));
     items.truncate(n);
 
     items

--- a/crates/agent/src/briefing.rs
+++ b/crates/agent/src/briefing.rs
@@ -176,12 +176,12 @@ pub fn build_briefing_context(kg: &Arc<RwLock<KnowledgeGraph>>) -> String {
         }
     }
     let mut top_attackers: Vec<_> = ip_data.into_iter().collect();
-    top_attackers.sort_by_key(|x| std::cmp::Reverse(x.1 .0));
+    top_attackers.sort_by(|a, b| b.1 .0.cmp(&a.1 .0));
     top_attackers.truncate(10);
 
     // Detectors sorted
     let mut sorted_detectors: Vec<_> = by_detector.into_iter().collect();
-    sorted_detectors.sort_by_key(|x| std::cmp::Reverse(x.1));
+    sorted_detectors.sort_by(|a, b| b.1.cmp(&a.1));
     sorted_detectors.truncate(10);
 
     // Threat level — based on UNRESOLVED, not total

--- a/crates/agent/src/dashboard/agent_api.rs
+++ b/crates/agent/src/dashboard/agent_api.rs
@@ -133,7 +133,7 @@ pub(super) async fn api_agent_security_context(
     }
 
     let mut top: Vec<_> = detector_counts.into_iter().collect();
-    top.sort_by_key(|x| std::cmp::Reverse(x.1));
+    top.sort_by(|a, b| b.1.cmp(&a.1));
     let top_threats: Vec<String> = top.iter().take(5).map(|(k, _)| k.clone()).collect();
 
     let threat_level = security_context_level(total_incidents);

--- a/crates/agent/src/dashboard/data_api.rs
+++ b/crates/agent/src/dashboard/data_api.rs
@@ -220,7 +220,7 @@ pub(super) async fn api_incidents(
         })
         .collect();
 
-    incident_views.sort_by_key(|x| std::cmp::Reverse(x.ts));
+    incident_views.sort_by(|a, b| b.ts.cmp(&a.ts));
     let total = incident_views.len();
     let items: Vec<IncidentView> = incident_views.into_iter().take(limit).collect();
 
@@ -273,7 +273,7 @@ pub(super) async fn api_decisions(
         })
         .collect();
 
-    views.sort_by_key(|x| std::cmp::Reverse(x.ts));
+    views.sort_by(|a, b| b.ts.cmp(&a.ts));
     let total = views.len();
     let items: Vec<DecisionView> = views.into_iter().take(limit).collect();
 

--- a/crates/agent/src/dashboard/intelligence.rs
+++ b/crates/agent/src/dashboard/intelligence.rs
@@ -205,7 +205,7 @@ pub(super) async fn api_graph_view(State(state): State<DashboardState>) -> Json<
             _ => None,
         })
         .collect();
-    incidents.sort_by_key(|x| std::cmp::Reverse(x.1));
+    incidents.sort_by(|a, b| b.1.cmp(&a.1));
     incidents.truncate(20);
     for (id, _) in &incidents {
         keep.insert(*id);
@@ -229,7 +229,7 @@ pub(super) async fn api_graph_view(State(state): State<DashboardState>) -> Json<
             })
             .filter(|(_, degree)| *degree >= 3)
             .collect();
-        scored.sort_by_key(|x| std::cmp::Reverse(x.1));
+        scored.sort_by(|a, b| b.1.cmp(&a.1));
         for (id, _) in scored.into_iter().take(80 - keep.len()) {
             keep.insert(id);
         }

--- a/crates/agent/src/dashboard/investigation.rs
+++ b/crates/agent/src/dashboard/investigation.rs
@@ -135,7 +135,7 @@ pub(super) async fn api_clusters(
         }
     }
 
-    items.sort_by_key(|x| std::cmp::Reverse(x.incident_count));
+    items.sort_by(|a, b| b.incident_count.cmp(&a.incident_count));
     items.truncate(limit);
 
     Json(ClusterResponse {
@@ -381,7 +381,7 @@ pub(super) fn build_pivots_from_graph(
                 }
             })
             .collect();
-        items.sort_by_key(|x| std::cmp::Reverse(x.incident_count));
+        items.sort_by(|a, b| b.incident_count.cmp(&a.incident_count));
         items.truncate(limit);
         return items;
     }
@@ -2221,7 +2221,7 @@ mod tests {
                 data: serde_json::json!({}),
             },
         ];
-        entries.sort_by_key(|x| std::cmp::Reverse(x.ts));
+        entries.sort_by(|a, b| b.ts.cmp(&a.ts));
         assert!(entries[0].ts >= entries[1].ts);
     }
 

--- a/crates/agent/src/dashboard/live_feed.rs
+++ b/crates/agent/src/dashboard/live_feed.rs
@@ -600,7 +600,7 @@ pub(super) async fn api_live_feed_mitre(
                 .into_iter()
                 .map(|((id, name), count)| MitreTechniqueSummary { id, name, count })
                 .collect();
-            techniques.sort_by_key(|x| std::cmp::Reverse(x.count));
+            techniques.sort_by(|a, b| b.count.cmp(&a.count));
             let count = techniques.iter().map(|t| t.count).sum();
             MitreTacticSummary {
                 tactic,

--- a/crates/agent/src/dashboard/sensors.rs
+++ b/crates/agent/src/dashboard/sensors.rs
@@ -46,7 +46,7 @@ pub(super) async fn api_sensors_inner(state: &DashboardState) -> serde_json::Val
             .iter()
             .map(|(s, &c)| (s.clone(), c))
             .collect();
-        s.sort_by_key(|x| std::cmp::Reverse(x.1));
+        s.sort_by(|a, b| b.1.cmp(&a.1));
         (graph.total_events_ingested, s)
     } else {
         // Fallback: read from telemetry snapshot (has events_by_collector)
@@ -59,7 +59,7 @@ pub(super) async fn api_sensors_inner(state: &DashboardState) -> serde_json::Val
                     .into_iter()
                     .map(|(k, v)| (k, v as usize))
                     .collect();
-                s.sort_by_key(|x| std::cmp::Reverse(x.1));
+                s.sort_by(|a, b| b.1.cmp(&a.1));
                 (total, s)
             }
             None => (0, vec![]),
@@ -71,7 +71,7 @@ pub(super) async fn api_sensors_inner(state: &DashboardState) -> serde_json::Val
         .iter()
         .map(|(k, &c)| (k.clone(), c))
         .collect();
-    kinds.sort_by_key(|x| std::cmp::Reverse(x.1));
+    kinds.sort_by(|a, b| b.1.cmp(&a.1));
     kinds.truncate(15);
 
     // Detector counts from Incident nodes
@@ -101,7 +101,7 @@ pub(super) async fn api_sensors_inner(state: &DashboardState) -> serde_json::Val
     }
 
     let mut detectors: Vec<_> = detector_counts.into_iter().collect();
-    detectors.sort_by_key(|x| std::cmp::Reverse(x.1));
+    detectors.sort_by(|a, b| b.1.cmp(&a.1));
 
     // event_timeline may be empty after restart (cursor/snapshot race).
     // Use detector_timeline as fallback — it's rebuilt from persisted Incident nodes.

--- a/crates/agent/src/mitre.rs
+++ b/crates/agent/src/mitre.rs
@@ -557,7 +557,7 @@ pub fn coverage_by_tactic(
     }
 
     // Sort recommendations by impact (most techniques first)
-    recs.sort_by_key(|x| std::cmp::Reverse(x.techniques_gained));
+    recs.sort_by(|a, b| b.techniques_gained.cmp(&a.techniques_gained));
     recs.truncate(10); // Top 10 recommendations
 
     (tactics, recs)

--- a/crates/agent/src/narrative.rs
+++ b/crates/agent/src/narrative.rs
@@ -102,7 +102,8 @@ pub fn generate_with_responder(
 
         // Sort groups by highest severity (descending)
         let mut sorted_groups: Vec<&IncidentGroup> = groups.values().collect();
-        sorted_groups.sort_by_key(|b| std::cmp::Reverse(severity_rank(&b.max_severity)));
+        sorted_groups
+            .sort_by(|a, b| severity_rank(&b.max_severity).cmp(&severity_rank(&a.max_severity)));
 
         for group in &sorted_groups {
             let icon = severity_icon(&group.max_severity);
@@ -196,7 +197,7 @@ pub fn generate_with_responder(
             *by_kind.entry(ev.kind.as_str()).or_insert(0) += 1;
         }
         let mut kinds: Vec<(&&str, &usize)> = by_kind.iter().collect();
-        kinds.sort_by_key(|x| std::cmp::Reverse(*x.1));
+        kinds.sort_by(|a, b| b.1.cmp(a.1));
         for (kind, count) in &kinds {
             out.push_str(&format!("| {} | {count} |\n", human_event_kind(kind)));
         }

--- a/crates/agent/src/narrative_daily_summary.rs
+++ b/crates/agent/src/narrative_daily_summary.rs
@@ -104,7 +104,7 @@ pub(crate) async fn maybe_write_daily_summary_and_digest(
                             // Drain deferred incidents for digest breakdown.
                             let mut deferred: Vec<(String, u32)> =
                                 state.telegram_deferred.drain().collect();
-                            deferred.sort_by_key(|x| std::cmp::Reverse(x.1));
+                            deferred.sort_by(|a, b| b.1.cmp(&a.1));
                             let text = telegram::format_daily_digest_enriched(
                                 incidents_today,
                                 blocks_today,

--- a/crates/agent/src/threat_report.rs
+++ b/crates/agent/src/threat_report.rs
@@ -402,7 +402,7 @@ pub fn generate_monthly(
         .values()
         .filter(|p| p.visit_dates.iter().any(|d| d.starts_with(month)))
         .collect();
-    month_profiles.sort_by_key(|x| std::cmp::Reverse(x.risk_score));
+    month_profiles.sort_by(|a, b| b.risk_score.cmp(&a.risk_score));
 
     let top_attackers: Vec<AttackerSummaryCompact> = month_profiles
         .iter()
@@ -728,7 +728,7 @@ fn build_mitre_coverage(
             attacker_count: attackers.len() as u64,
         })
         .collect();
-    seen.sort_by_key(|x| std::cmp::Reverse(x.incident_count));
+    seen.sort_by(|a, b| b.incident_count.cmp(&a.incident_count));
 
     let total = seen.len();
     MitreCoverage {
@@ -762,7 +762,7 @@ fn build_geo_distribution(profiles: &[&AttackerProfile]) -> GeoDistribution {
             incident_count: incidents,
         })
         .collect();
-    stats.sort_by_key(|x| std::cmp::Reverse(x.attacker_count));
+    stats.sort_by(|a, b| b.attacker_count.cmp(&a.attacker_count));
 
     GeoDistribution { by_country: stats }
 }
@@ -795,11 +795,11 @@ fn build_honeypot_intel(profiles: &[&AttackerProfile]) -> HoneypotIntel {
         .into_iter()
         .map(|((u, p), c)| (u, p, c))
         .collect();
-    top_credentials.sort_by_key(|x| std::cmp::Reverse(x.2));
+    top_credentials.sort_by(|a, b| b.2.cmp(&a.2));
     top_credentials.truncate(15);
 
     let mut top_commands: Vec<(String, u64)> = cmd_counts.into_iter().collect();
-    top_commands.sort_by_key(|x| std::cmp::Reverse(x.1));
+    top_commands.sort_by(|a, b| b.1.cmp(&a.1));
     top_commands.truncate(15);
 
     HoneypotIntel {

--- a/crates/ctl/src/commands/status.rs
+++ b/crates/ctl/src/commands/status.rs
@@ -395,7 +395,7 @@ pub(crate) fn cmd_sensor_status(cli: &Cli, data_dir: &Path) -> Result<()> {
                 .iter()
                 .map(|(k, v)| (k, v.as_u64().unwrap_or(0)))
                 .collect();
-            pairs.sort_by_key(|x| std::cmp::Reverse(x.1));
+            pairs.sort_by(|a, b| b.1.cmp(&a.1));
             for (source, count) in &pairs {
                 println!("  ● {:<30} {:>6} events", source, count);
             }
@@ -412,7 +412,7 @@ pub(crate) fn cmd_sensor_status(cli: &Cli, data_dir: &Path) -> Result<()> {
                 .iter()
                 .map(|(k, v)| (k, v.as_u64().unwrap_or(0)))
                 .collect();
-            pairs.sort_by_key(|x| std::cmp::Reverse(x.1));
+            pairs.sort_by(|a, b| b.1.cmp(&a.1));
             for (detector, count) in &pairs {
                 println!("  ⚠  {:<30} {:>6} incidents", detector, count);
             }
@@ -602,7 +602,7 @@ pub(crate) fn cmd_metrics(cli: &Cli, data_dir: &Path) -> Result<()> {
                     (k, c)
                 })
                 .collect();
-            pairs.sort_by_key(|x| std::cmp::Reverse(x.1));
+            pairs.sort_by(|a, b| b.1.cmp(&a.1));
             for (source, count) in &pairs {
                 println!("  {:<30} {:>6}", source, count);
             }
@@ -625,7 +625,7 @@ pub(crate) fn cmd_metrics(cli: &Cli, data_dir: &Path) -> Result<()> {
                     (k, c)
                 })
                 .collect();
-            pairs.sort_by_key(|x| std::cmp::Reverse(x.1));
+            pairs.sort_by(|a, b| b.1.cmp(&a.1));
             for (detector, count) in &pairs {
                 println!("  {:<30} {:>6}", detector, count);
             }
@@ -648,7 +648,7 @@ pub(crate) fn cmd_metrics(cli: &Cli, data_dir: &Path) -> Result<()> {
                     (k, c)
                 })
                 .collect();
-            pairs.sort_by_key(|x| std::cmp::Reverse(x.1));
+            pairs.sort_by(|a, b| b.1.cmp(&a.1));
             for (action, count) in &pairs {
                 println!("  {:<30} {:>6}", action, count);
             }


### PR DESCRIPTION
Style-only cleanup on top of @nandanadileep's replay CLI (#87, #135). Preserves her feature commits intact — this branch only touches pre-existing files where her clippy-driven \`sort_by_key(|x| Reverse(x.x))\` edits departed from the team's documented preference for the explicit \`sort_by(|a, b| b.x.cmp(&a.x))\` form.

### Background

\`crates/agent/src/main.rs\` carries a deliberate \`#![allow(clippy::unnecessary_sort_by)]\`:

> Clippy 1.95 promotes \`unnecessary_sort_by\` to a default-deny lint, but \`sort_by_key(|x| Reverse(...))\` is less readable than the explicit \`sort_by(|a, b| b.x.cmp(&a.x))\` pattern used throughout the agent for reverse-sort leaderboards (threat report, attacker intel, MITRE heatmap). Keep the existing style workspace-wide for this crate.

#87 was opened before that allow landed, and the contributor converted 18 sites to silence the lint. Four of those were resolved back to the \`sort_by\` form during the main → dev sync (#143). This commit closes the remaining 14 that did not conflict and therefore slipped through.

### Files touched (style only)
\`attacker_intel\`, \`bot_helpers\`, \`briefing\`, \`dashboard/{agent_api, data_api, intelligence, investigation, live_feed, sensors}\`, \`mitre\`, \`narrative\`, \`narrative_daily_summary\`, \`threat_report\`, \`ctl/commands/status\`.

Zero behaviour change — both forms produce identical sorted output.

### Impact on #144 (dev → main)

After this merges to \`development\`, PR #144 auto-updates to include her replay CLI + her test fix + this style cleanup. The resulting diff on main will show her two feature commits at their original authorship plus this style commit.

### Test plan
- [x] \`cargo fmt --all --check\` clean
- [x] \`cargo clippy --workspace -- -D warnings\` clean
- [x] \`cargo test --workspace\` — 3599 passed, 0 failed