### PR TITLE
release: v0.12.0

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,6 +12,7 @@
 
 - [ ] `make check`
 - [ ] `make test`
+- [ ] `make scenario-qa` — if this PR touches anything that could change incident / telegram / block volumes
 
 ## Risk
 
@@ -19,6 +20,13 @@
 - [ ] Includes config or schema changes
 - [ ] Includes responder or privileged behavior changes
 - [ ] Includes dashboard or investigation UX changes
+
+## Spec 024 regression gate
+
+If this PR changes a gate threshold, cooldown, responder behaviour, notification policy, or any code on the incident → decision → notification → block path, it can silently drift the volumes asserted in `testdata/scenarios/`. Before merging:
+
+- [ ] I ran `make scenario-qa` locally; all 7 scenarios still pass (or I updated the matching `expected.json` envelope and explained why in the PR body)
+- [ ] OR this PR is docs / tests / CI only and cannot affect scenario volumes (tick this and skip the one above)
 
 ## Documentation
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -230,7 +230,7 @@ jobs:
         run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
 
       - name: Build and push agent image
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198a989f3d76a3 # v6
+        uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109a75 # v6.9.0
         with:
           context: docker
           file: docker/Dockerfile.agent
@@ -244,7 +244,7 @@ jobs:
 
       - name: Build and push agent-openclaw image
         continue-on-error: true  # OpenClaw upstream may break; don't block the release
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198a989f3d76a3 # v6
+        uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109a75 # v6.9.0
         with:
           context: docker
           file: docker/Dockerfile.agent-openclaw

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,39 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [0.12.0] - 2026-04-18
+
+### Added
+- **Regression safety net (spec 024)** — `make scenario-qa` with 7 deterministic canonical scenarios (SSH brute single/coordinated, honeypot known-bad/unknown, port scan, DDoS SYN flood, grouped campaign) gated in CI via envelope assertions; 18 contract tests across the 5 boundary subsystems; `/metrics` now exposes all 10 drift metrics; `docs/prometheus-alerts.yaml` with 10/h warn + 50/h crit thresholds post spec 005 grouping; dashboard "Health → Metrics drift" tab.
+- **Intelligent notifications (spec 005)** — incident grouping, channel filter, daily briefing digest, bootstrap environment profile, periodic census, operator feedback loop, AI batch triage (opt-in). Agent now sends ≤ 1 grouped Telegram instead of one-per-incident.
+- **Structured subgraph in LLM prompts (spec 025)** — JSON graph context replaces prose narrative (qwen2.5:3b bench: 53% → 73% action accuracy, hallucinated target 47% → 7%).
+- **Zero-trust MDR (spec 020)** — continuous trust scoring engine, AI SOC daily checks with 11 system parsers, graduated enforcement state machine (Phase F-partial).
+- **Observation verification (spec 021)** — behavioural score engine, AI batch verification for ambiguous observations, dashboard score display.
+- **CTL** — new `innerwarden replay` command for E2E validation.
+- **Scenario seed mechanism** — `scripts/scenario_seed.py` pre-populates `innerwarden.db` and KV cache so scenarios that require eBPF / root / packet generators still run headless in CI.
+- **Auto-response coverage (spec 018 Phases A-D)** — correlation-driven escalation + trusted_processes filter.
+- **Graph full connectivity (spec 014)** — 8 → 18 active relations, edges 12K → 33K, Process nodes 411 → 4,470.
+- **Graph signal quality audit (spec 015)** — caught 3,954 false-positive `graph_user_creation` incidents from a single presence-scan detector.
+
+### Changed
+- **Unified SQLite store (spec 016)** — single `innerwarden.db` replaces 15 storage artifacts; redb removed, JSONL removed, 14 maintenance tasks consolidated.
+- **AbuseIPDB per-incident lookup** — now consults SQLite cache before hitting the live API. Removes redundant HTTP on every incident and closes the "no API key → always None" gap.
+- **Telegram mock outbox** — new `INNERWARDEN_MOCK_TELEGRAM=1` mode for deterministic scenario testing without touching api.telegram.org.
+- **GeoIP** — switched ip-api.com to HTTP (free tier rejects HTTPS).
+- **Coverage scaffolding** — 11 coverage batches from spec 023 + 3 decomposition phases from spec 026 (agent crate +10.98pp). 1426 agent tests passing, patch coverage 72% on 7,300 changed lines.
+
+### Fixed
+- **Invalid-IP zombie ufw rules** — `response_lifecycle.register()` now rejects invalid targets before hydration; 8 previously-orphaned rules no longer recur.
+- **Self-triggered DATA_EXFIL** — killchain now skips the agent's own threads (was producing 40+ self-incidents/day).
+- **Kill chain persistence** — incidents now land in sqlite alongside jsonl; honeypot activity accepted as kill chain input.
+- **Dashboard threat pivot** — unhidden pivot tabs, detector-pivot drill-down in `/api/journey`, entity population on sigma + crypto_miner incidents, live-feed `/api/live-feed/geoip` returns empty list on missing params instead of 400.
+- **Telemetry monotonicity** — `gate_suppressed_total` + `telegram_sent_count` never decrement; `serde(default)` on new counters for backward compat.
+- **Replay test expectation** — matches detector dedup reality.
+- **Sensor host_drift** — test allowlist synced with detector.
+- **Dependency** — `rand` 0.9.2 → 0.9.4 (GHSA unsoundness fix).
+
+---
+
 ## [0.11.1] - 2026-04-14
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1936,7 +1936,7 @@ dependencies = [
 
 [[package]]
 name = "innerwarden-agent"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "aes-gcm 0.10.3",
  "anyhow",
@@ -1991,7 +1991,7 @@ dependencies = [
 
 [[package]]
 name = "innerwarden-agent-guard"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2009,7 +2009,7 @@ dependencies = [
 
 [[package]]
 name = "innerwarden-ctl"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -2037,7 +2037,7 @@ dependencies = [
 
 [[package]]
 name = "innerwarden-dna"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -2057,14 +2057,14 @@ dependencies = [
 
 [[package]]
 name = "innerwarden-ebpf-types"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "innerwarden-hypervisor"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2078,7 +2078,7 @@ dependencies = [
 
 [[package]]
 name = "innerwarden-killchain"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2114,7 +2114,7 @@ dependencies = [
 
 [[package]]
 name = "innerwarden-sensor"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "aya",
@@ -2145,7 +2145,7 @@ dependencies = [
 
 [[package]]
 name = "innerwarden-shield"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -2163,7 +2163,7 @@ dependencies = [
 
 [[package]]
 name = "innerwarden-smm"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2178,7 +2178,7 @@ dependencies = [
 
 [[package]]
 name = "innerwarden-store"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2196,7 +2196,7 @@ dependencies = [
 
 [[package]]
 name = "innerwarden_core"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ exclude = ["crates/sensor-ebpf"]
 resolver = "2"
 
 [workspace.package]
-version = "0.11.1"
+version = "0.12.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/InnerWarden/innerwarden"

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Installs in 10 seconds. Starts in observe-only mode. Dry-run by default. You dec
 ![eBPF Hooks](https://img.shields.io/badge/eBPF%20hooks-40-blueviolet)
 ![Detectors](https://img.shields.io/badge/detectors-49-blue)
 ![Correlation Rules](https://img.shields.io/badge/correlation%20rules-47-purple)
-![Tests](https://img.shields.io/badge/tests-2556-brightgreen)
+![Tests](https://img.shields.io/badge/tests-3689-brightgreen)
 ![MITRE Coverage](https://img.shields.io/badge/MITRE%20ATT%26CK-65%20mappings-red)
 ![Sigma Rules](https://img.shields.io/badge/Sigma%20rules-208-blueviolet)
 ![Memory](https://img.shields.io/badge/memory-~250MB%20(full%20stack)-green)
@@ -47,7 +47,7 @@ Installs in 10 seconds. Starts in observe-only mode. Dry-run by default. You dec
 
 Inner Warden is a self-contained runtime defense stack: kernel-level telemetry, native network visibility, AI triage, and autonomous response in one system. Single SQLite database for all state — no scattered log files, no external database. No SIEM bundle, no external IDS/HIDS dependency, and no cloud control plane required.
 
-40 eBPF kernel hooks. 49 detectors. 22 collectors. 47 cross-layer correlation rules. 65 MITRE ATT&CK techniques (40% validated via Caldera). 208 Sigma community rules. Autoencoder anomaly detection. Behavioral DNA attacker fingerprinting. JA3/JA4 TLS fingerprinting. YARA + Sigma rule engines. 20 automated playbooks. Monthly threat reports. Mesh collaborative defense. No cloud. No dependencies. Just two Rust daemons and a CLI.
+40 eBPF kernel hooks. 49 detectors. 22 collectors. 47 cross-layer correlation rules. 65 MITRE ATT&CK techniques (40% validated via Caldera). 208 Sigma community rules. Autoencoder anomaly detection. Behavioral DNA attacker fingerprinting. JA3/JA4 TLS fingerprinting. YARA + Sigma rule engines. 20 automated playbooks. Monthly threat reports. Mesh collaborative defense. **Unified SQLite store** for every artifact (incidents, decisions, KV cache, graph snapshots, attacker profiles). **Intelligent notifications** — incidents group into a single Telegram message per IP instead of one-per-event. **Zero-trust MDR** — continuous trust scoring + AI SOC daily checks + graduated enforcement. **Regression safety net** — `make scenario-qa` gates every PR against drift for 7 canonical attack scenarios. No cloud. No dependencies. Just two Rust daemons and a CLI.
 
 <h3 align="center">
   <a href="https://innerwarden.com/live">See it responding to real attacks right now</a>
@@ -181,10 +181,19 @@ Solo developer. Apache-2.0. If this project helps protect your servers, [give it
 │   ┌───────────────────────────────────────────────────────────┐   │
 │   │ Dashboard: HUD, threats, investigation, attacker intel,   │   │
 │   │ MITRE ATT&CK map, monthly reports, baseline learning,     │   │
-│   │ ISO 27001 compliance, hash chain, live SSE, audit trail   │   │
+│   │ ISO 27001 compliance, hash chain, live SSE, audit trail,  │   │
+│   │ drift metrics (spec 024), trust scores (spec 020)         │   │
 │   └───────────────────────────────────────────────────────────┘   │
 └───────────────────────────────────────────────────────────────────┘
 ```
+
+**Runtime layers added in v0.12.0** (sit between the AI Triage and the notification channels above):
+
+- **Notification gate** (spec 005) — every channel (Telegram, Slack, Webhook, Push) goes through a single policy that returns `SendNow` / `DailyBriefingOnly` / `Drop`. Burst summary collapses 50+/h auto-blocks into one "all handled" message.
+- **Graduated enforcement** (spec 020) — state machine promotes a responder from `Observe` → `Warn` → `Contain` → `Enforce` based on continuous trust scoring and AI SOC daily checks (11 system parsers).
+- **Observation verification** (spec 021) — behavioural score engine + AI batch verification clears active false positives instead of leaving them to rot.
+- **Regression safety net** (spec 024) — `make scenario-qa` asserts volume envelopes for 7 canonical scenarios; 10 drift metrics exported on `/metrics`; `docs/prometheus-alerts.yaml` consumes them.
+- **Structured subgraph prompt** (spec 025, opt-in) — when `ai.use_structured_subgraph = true`, the LLM receives the graph context as JSON nodes/edges instead of prose (measured +20pp action accuracy on qwen2.5:3b).
 
 ---
 


### PR DESCRIPTION
## Summary

- Bumps workspace version 0.11.1 → 0.12.0 and snapshots the post-0.11.1 history into `CHANGELOG.md`.
- The `v0.12.0` tag is already pushed and the release workflow is building binaries from the tagged commit. This PR exists only to advance the `main` branch ref to match.

## What landed between 0.11.1 and 0.12.0 (highlights)

- Spec 024 regression safety net — 7 canonical scenarios, 18 contract tests, /metrics drift, dashboard drift tab.
- Spec 005 intelligent notifications — grouping, digest, batch triage.
- Spec 025 structured subgraph LLM prompt — qwen2.5:3b 53% → 73% accuracy.
- Spec 020 zero-trust MDR — trust scoring, AI SOC, graduated enforcement.
- Spec 021 observation verification — score engine + AI batch verification.
- Spec 016 unified SQLite store — single `innerwarden.db`.
- AbuseIPDB per-incident cache-first lookup.
- 11 coverage batches from spec 023 + 3 decomposition phases from spec 026.

Full notes in `CHANGELOG.md`.

## Test plan

- [x] `cargo check --workspace` clean at 0.12.0
- [x] Release workflow publishes x86_64 + aarch64 binaries
- [x] Docker images pushed