### PR TITLE
fix(autonomy): stop CL-008+repeat-offender blocking Cloudflare; sync decisions to sqlite

### DIFF
--- a/crates/agent/src/cloud_safelist.rs
+++ b/crates/agent/src/cloud_safelist.rs
@@ -374,12 +374,28 @@ pub fn identify_provider(ip_str: &str) -> Option<&'static str> {
     let Ok(ip) = ip_str.parse::<IpAddr>() else {
         return None;
     };
-    let first_octet = match ip {
-        IpAddr::V4(v4) => v4.octets()[0],
+    let (ip_u32, first_octet) = match ip {
+        IpAddr::V4(v4) => (u32::from(v4), v4.octets()[0]),
         _ => return None,
     };
 
-    // Broad heuristic based on first octet
+    // Authoritative Cloudflare-first check. The first-octet heuristic below
+    // misclassifies large Cloudflare blocks (104.16.0.0/13, 104.24.0.0/14,
+    // 172.64.0.0/13) as Azure / Google because 104 and 172 are shared with
+    // other providers. Operator incident 2026-04-18 showed top auto-blocked
+    // IPs were all Cloudflare ranges (104.26.x, 172.66.x, 172.67.x). Walking
+    // CLOUDFLARE_RANGES keeps the guard correct regardless of heuristic drift.
+    for cidr in CLOUDFLARE_RANGES {
+        if let Some(r) = CidrRange::from_str(cidr) {
+            if r.contains(ip_u32) {
+                return Some("Cloudflare");
+            }
+        }
+    }
+
+    // Broad heuristic based on first octet for the other providers (still
+    // fine-grained enough for operator-facing labels, and any false label
+    // is harmless — the block is refused either way).
     match first_octet {
         34 | 35 | 130 | 142 | 172 | 216 | 209 => Some("Google Cloud"),
         3 | 13 | 15 | 18 | 44 | 52 | 54 | 99 => Some("AWS"),
@@ -418,6 +434,37 @@ mod tests {
         assert!(is_cloud_provider_ip("3.5.1.1"));
         assert!(is_cloud_provider_ip("52.1.1.1"));
         assert!(is_cloud_provider_ip("54.200.1.1"));
+    }
+
+    #[test]
+    fn regression_guard_production_cloudflare_ips_get_identified() {
+        // Operator incident 2026-04-18: correlation:CL-008 +
+        // repeat-offender auto-blocked these IPs in production (top by
+        // block count: 53, 49, 46, 45, 41, ...). All are Cloudflare. If
+        // the safelist ever stops covering any of them the cascade comes
+        // right back — fail loud here before it can leak into a release.
+        init();
+        for cloudflare_ip in [
+            "104.26.12.38",
+            "172.66.0.243",
+            "162.159.140.245",
+            "104.19.192.29",
+            "172.67.70.74",
+            "104.26.13.38",
+            "104.19.192.176",
+            "104.19.192.174",
+            "104.19.193.29",
+        ] {
+            assert!(
+                is_cloud_provider_ip(cloudflare_ip),
+                "{cloudflare_ip} (Cloudflare) must be in the safelist"
+            );
+            assert_eq!(
+                identify_provider(cloudflare_ip),
+                Some("Cloudflare"),
+                "{cloudflare_ip} must resolve to provider=Cloudflare"
+            );
+        }
     }
 
     #[test]

--- a/crates/agent/src/correlation_response.rs
+++ b/crates/agent/src/correlation_response.rs
@@ -85,6 +85,24 @@ async fn handle_completed_chain(
     if crate::incident_auto_rules::is_internal_ip_pub(&ip) {
         return;
     }
+    // Cloud-provider / CDN safelist: prevent correlation chains (CL-008 in
+    // particular — file.read_access → network.outbound_connect within 60s —
+    // matches every normal web server, and would otherwise ban Cloudflare,
+    // AWS, and our own Oracle peer ranges en masse). `execute_block_ip`
+    // already guards at the executor, but short-circuiting here keeps the
+    // ip_reputation counter, cooldown table, and knowledge-graph decision
+    // edge from being polluted in the first place.
+    if let Some(provider) = crate::cloud_safelist::identify_provider(&ip) {
+        info!(
+            chain_id = %chain.chain_id,
+            rule = %chain.rule_id,
+            ip = %ip,
+            provider,
+            "correlation chain targeted a cloud-provider IP — skipping escalation"
+        );
+        state.ip_reputations.remove(&ip);
+        return;
+    }
     if allowlist::is_ip_allowlisted(&ip, &cfg.allowlist.trusted_ips)
         || allowlist::is_ip_allowlisted(&ip, &state.dynamic_trusted_ips)
     {
@@ -320,6 +338,21 @@ async fn check_repeat_offenders(
 
         // Guard checks.
         if crate::incident_auto_rules::is_internal_ip_pub(&ip) {
+            continue;
+        }
+        // Cloud-provider / CDN safelist — drop the reputation entry outright
+        // so the next correlation burst cannot bump this IP back above the
+        // escalation threshold. Production data from 2026-04-18 showed
+        // repeat-offender compounding on Cloudflare CIDRs after CL-008
+        // kept refiring on legitimate outbound traffic.
+        if let Some(provider) = crate::cloud_safelist::identify_provider(&ip) {
+            info!(
+                ip = %ip,
+                provider,
+                total_blocks,
+                "repeat-offender: purging cloud-provider IP from reputation state"
+            );
+            state.ip_reputations.remove(&ip);
             continue;
         }
         if allowlist::is_ip_allowlisted(&ip, &cfg.allowlist.trusted_ips)

--- a/crates/agent/src/decision_block_ip.rs
+++ b/crates/agent/src/decision_block_ip.rs
@@ -24,17 +24,32 @@ pub(crate) async fn execute_block_ip_decision(
         .recent_blocks
         .retain(|ts| *ts > now_utc - chrono::Duration::seconds(60));
 
-    // Safeguard: pure eligibility checks (empty IP, operator session, rate limit).
-    if let Err(reason) = check_block_eligibility(
+    // Safeguard: pure eligibility checks (empty IP, operator session, rate
+    // limit) + cloud-provider / CDN safelist. Operator incident 2026-04-18:
+    // `correlation:CL-008` + `repeat-offender` were auto-blocking Cloudflare
+    // ranges (104.16.0.0/12, 104.26.0.0/15, 172.66.0.0/15, …) as a cascade —
+    // a file read followed by any outbound connect within 60s triggered
+    // CL-008, the response targeted the outbound IP, and the repeat-offender
+    // loop multiplied the damage. The global guard here catches every block
+    // path (correlation, repeat-offender, auto-rule, AbuseIPDB, AI triage,
+    // honeypot) with a single check.
+    if let Err(reason) = check_block_eligibility_with_safelist(
         ip,
         &state.operator_ips,
         state.recent_blocks.len(),
         crate::MAX_BLOCKS_PER_MINUTE,
+        crate::cloud_safelist::identify_provider,
     ) {
         if reason.starts_with("skipped:") {
             info!(ip, "{}", reason);
         } else {
             warn!(ip, "{}", reason);
+        }
+        // Stop the repeat-offender cascade: if we ever bumped this IP's
+        // reputation by mistake (pre-fix production data), wipe it so the
+        // next correlation burst doesn't escalate based on stale counts.
+        if reason.contains("cloud provider safelist") {
+            state.ip_reputations.remove(ip);
         }
         return (reason, false);
     }
@@ -255,12 +270,41 @@ pub(crate) fn is_valid_block_target(s: &str) -> bool {
     }
 }
 
+/// Pure-predicate variant used by the in-tree test suite to exercise
+/// eligibility rules without constructing a cloud-safelist closure. Prod
+/// code routes through `check_block_eligibility_with_safelist`.
+#[allow(dead_code)]
 pub(crate) fn check_block_eligibility(
     ip: &str,
     operator_ips: &std::collections::HashMap<String, std::time::Instant>,
     recent_blocks_len: usize,
     max_blocks_per_min: usize,
 ) -> Result<(), String> {
+    check_block_eligibility_with_safelist(
+        ip,
+        operator_ips,
+        recent_blocks_len,
+        max_blocks_per_min,
+        |_| None,
+    )
+}
+
+/// Variant that also consults a cloud-provider / CDN safelist. The safelist
+/// predicate receives the candidate IP and returns `Some(provider_label)` when
+/// the IP is part of a known CDN / cloud range (Cloudflare, AWS, Oracle, …);
+/// in that case the block is refused outright. Keeps the base eligibility
+/// check pure-testable while every production code path that routes through
+/// `execute_block_ip_decision` inherits the guard.
+pub(crate) fn check_block_eligibility_with_safelist<F>(
+    ip: &str,
+    operator_ips: &std::collections::HashMap<String, std::time::Instant>,
+    recent_blocks_len: usize,
+    max_blocks_per_min: usize,
+    safelist_provider: F,
+) -> Result<(), String>
+where
+    F: Fn(&str) -> Option<&'static str>,
+{
     if ip.is_empty() {
         return Err("skipped: block decision has empty IP".to_string());
     }
@@ -269,6 +313,11 @@ pub(crate) fn check_block_eligibility(
     // "active" entries that can never be reverted.
     if !is_valid_block_target(ip) {
         return Err(format!("skipped: {ip} is not a valid IP address"));
+    }
+    if let Some(provider) = safelist_provider(ip) {
+        return Err(format!(
+            "skipped: {ip} is in cloud provider safelist ({provider})"
+        ));
     }
     if operator_ips.contains_key(ip) {
         return Err(format!("skipped: {ip} is an active operator session"));
@@ -374,6 +423,71 @@ mod tests {
         assert_eq!(
             check_block_eligibility("10.0.0.0/abc", &operator_ips, 0, 20),
             Err("skipped: 10.0.0.0/abc is not a valid IP address".to_string())
+        );
+    }
+
+    #[test]
+    fn check_block_eligibility_with_safelist_refuses_cloud_ranges() {
+        // Regression guard for the operator incident on 2026-04-18:
+        // correlation:CL-008 + repeat-offender kept auto-blocking Cloudflare
+        // CIDRs. With the safelist predicate in play every eligibility check
+        // refuses a matching IP with an explanatory reason before the
+        // firewall skill ever sees it.
+        let operator_ips: HashMap<String, Instant> = HashMap::new();
+        let safelist = |ip: &str| -> Option<&'static str> {
+            if ip.starts_with("104.26.") || ip.starts_with("172.66.") {
+                Some("Cloudflare")
+            } else {
+                None
+            }
+        };
+
+        let err =
+            check_block_eligibility_with_safelist("104.26.12.38", &operator_ips, 0, 20, &safelist)
+                .expect_err("cloudflare IP must be refused");
+        assert!(err.contains("cloud provider safelist"), "got {err}");
+        assert!(err.contains("Cloudflare"), "got {err}");
+
+        // IP outside the safelist still passes (sanity).
+        assert_eq!(
+            check_block_eligibility_with_safelist("198.51.100.7", &operator_ips, 0, 20, &safelist,),
+            Ok(())
+        );
+    }
+
+    #[test]
+    fn check_block_eligibility_with_safelist_wraps_non_safelist_gates() {
+        // The safelist predicate only refuses matches; empty / invalid /
+        // operator / rate-limit checks must keep working exactly like the
+        // pure `check_block_eligibility` variant. Using a never-match
+        // predicate makes the wrapper behaviourally identical.
+        let mut operator_ips: HashMap<String, Instant> = HashMap::new();
+        operator_ips.insert("10.0.0.5".to_string(), Instant::now());
+        let no_match = |_: &str| None;
+
+        assert!(
+            check_block_eligibility_with_safelist("", &operator_ips, 0, 20, &no_match)
+                .unwrap_err()
+                .contains("empty IP")
+        );
+        assert!(
+            check_block_eligibility_with_safelist("bad-ip", &operator_ips, 0, 20, &no_match)
+                .unwrap_err()
+                .contains("not a valid IP")
+        );
+        assert!(
+            check_block_eligibility_with_safelist("10.0.0.5", &operator_ips, 0, 20, &no_match)
+                .unwrap_err()
+                .contains("operator session")
+        );
+        assert!(
+            check_block_eligibility_with_safelist("1.2.3.4", &operator_ips, 20, 20, &no_match)
+                .unwrap_err()
+                .contains("rate-limited")
+        );
+        assert_eq!(
+            check_block_eligibility_with_safelist("8.8.8.8", &operator_ips, 0, 20, &no_match),
+            Ok(())
         );
     }
 

--- a/crates/agent/src/decisions.rs
+++ b/crates/agent/src/decisions.rs
@@ -1,6 +1,7 @@
 use std::fs::{File, OpenOptions};
 use std::io::{BufRead, BufReader, BufWriter, Write};
 use std::path::Path;
+use std::sync::Arc;
 
 use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
@@ -54,10 +55,33 @@ pub struct DecisionWriter {
     writer: BufWriter<File>,
     /// SHA-256 hash of the last written decision entry for hash chaining.
     last_hash: Option<String>,
+    /// Unified SQLite store (spec 016). When present every JSONL write is
+    /// mirrored into the `decisions` table so the dashboard, `/metrics`, and
+    /// the spec-024 drift harness all see the same reality as the audit log.
+    /// Before this dual-write the sqlite copy was only populated by the
+    /// one-shot legacy migration, which left production dashboards reading
+    /// a stale table while the JSONL audit trail kept growing.
+    store: Option<Arc<innerwarden_store::Store>>,
 }
 
 impl DecisionWriter {
+    /// JSONL-only constructor retained for tests and any future callers that
+    /// intentionally want to opt out of the sqlite mirror. Production uses
+    /// [`DecisionWriter::with_store`] to keep the audit file and the
+    /// `decisions` table in lockstep.
+    #[allow(dead_code)]
     pub fn new(data_dir: &Path) -> Result<Self> {
+        Self::with_store(data_dir, None)
+    }
+
+    /// Constructor that also takes an optional SQLite store. Production calls
+    /// this with `Some(state.sqlite_store.clone())` so every decision written
+    /// via `DecisionWriter::write` lands in both the JSONL audit file and
+    /// the `decisions` table.
+    pub fn with_store(
+        data_dir: &Path,
+        store: Option<Arc<innerwarden_store::Store>>,
+    ) -> Result<Self> {
         let today = chrono::Local::now()
             .date_naive()
             .format("%Y-%m-%d")
@@ -69,6 +93,7 @@ impl DecisionWriter {
             current_date: today,
             writer: BufWriter::new(file),
             last_hash,
+            store,
         })
     }
 
@@ -128,6 +153,31 @@ impl DecisionWriter {
         self.writer
             .flush()
             .context("failed to flush decision entry")?;
+
+        // Dual-write to sqlite. Failure to persist the row mirrors up as a
+        // warning rather than an error: the JSONL write already succeeded
+        // (that is the audit trail of record), and a sqlite hiccup must not
+        // silently discard the whole decision.
+        if let Some(ref store) = self.store {
+            let row = innerwarden_store::decisions::DecisionRow {
+                ts: entry.ts.to_rfc3339(),
+                incident_id: entry.incident_id.clone(),
+                action_type: entry.action_type.clone(),
+                target_ip: entry.target_ip.clone(),
+                target_user: entry.target_user.clone(),
+                confidence: entry.confidence as f64,
+                auto_executed: entry.auto_executed,
+                reason: Some(entry.reason.clone()),
+                data: line.clone(),
+            };
+            if let Err(e) = store.insert_decision(&row) {
+                warn!(
+                    incident_id = %entry.incident_id,
+                    error = %e,
+                    "decision written to JSONL but sqlite mirror failed"
+                );
+            }
+        }
         Ok(())
     }
 
@@ -326,6 +376,79 @@ mod tests {
         assert_eq!(entry.target_ip, Some("10.0.0.1".to_string()));
         assert_eq!(entry.skill_id, Some("block-ip-xdp".to_string()));
         assert_eq!(entry.execution_result, "success");
+    }
+
+    #[test]
+    fn decision_writer_dual_writes_to_jsonl_and_sqlite() {
+        // Regression guard: before the spec-016 follow-up the writer only
+        // wrote JSONL, leaving dashboards reading a decisions table that
+        // had not been touched since the legacy migration. The dual-write
+        // must land every entry in both the audit file and the sqlite
+        // mirror so `/metrics` + the spec-024 drift harness see the same
+        // reality as the audit trail of record.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = Arc::new(innerwarden_store::Store::open(dir.path()).expect("store"));
+        let mut writer =
+            DecisionWriter::with_store(dir.path(), Some(store.clone())).expect("writer");
+
+        let entry = DecisionEntry {
+            ts: chrono::Utc::now(),
+            incident_id: "inc-dual-1".into(),
+            host: "h".into(),
+            ai_provider: "test".into(),
+            action_type: "block_ip".into(),
+            target_ip: Some("203.0.113.9".into()),
+            target_user: None,
+            skill_id: Some("block-ip-ufw".into()),
+            confidence: 0.91,
+            auto_executed: true,
+            dry_run: false,
+            reason: "synthetic".into(),
+            estimated_threat: "high".into(),
+            execution_result: "ok".into(),
+            prev_hash: None,
+        };
+        writer.write(&entry).expect("write decision");
+
+        // JSONL side.
+        let today = chrono::Local::now().date_naive().format("%Y-%m-%d");
+        let jsonl_path = dir.path().join(format!("decisions-{today}.jsonl"));
+        let jsonl = std::fs::read_to_string(&jsonl_path).expect("jsonl exists");
+        assert!(jsonl.contains("inc-dual-1"), "jsonl must carry the entry");
+
+        // Sqlite side.
+        let count = store.decisions_count().expect("count");
+        assert_eq!(count, 1, "sqlite decisions table must receive one row");
+    }
+
+    #[test]
+    fn decision_writer_without_store_keeps_jsonl_path_working() {
+        // Back-compat: constructing without a store (tests, pre-016 deploys)
+        // must not require the sqlite path to be available.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut writer = DecisionWriter::new(dir.path()).expect("writer");
+        let entry = DecisionEntry {
+            ts: chrono::Utc::now(),
+            incident_id: "inc-jsonl-only".into(),
+            host: "h".into(),
+            ai_provider: "test".into(),
+            action_type: "ignore".into(),
+            target_ip: None,
+            target_user: None,
+            skill_id: None,
+            confidence: 0.4,
+            auto_executed: false,
+            dry_run: true,
+            reason: "low".into(),
+            estimated_threat: "low".into(),
+            execution_result: "skipped".into(),
+            prev_hash: None,
+        };
+        writer.write(&entry).expect("write without store");
+        let today = chrono::Local::now().date_naive().format("%Y-%m-%d");
+        let jsonl = std::fs::read_to_string(dir.path().join(format!("decisions-{today}.jsonl")))
+            .expect("jsonl written");
+        assert!(jsonl.contains("inc-jsonl-only"));
     }
 
     #[test]

--- a/crates/agent/src/loops/boot.rs
+++ b/crates/agent/src/loops/boot.rs
@@ -667,7 +667,14 @@ pub(crate) async fn run_agent(cli: crate::Cli) -> Result<()> {
         // Decision writer is always created — Layer 1/2 decisions are written
         // even without AI. Previously gated on cfg.ai.enabled which caused
         // zero audit trail when AI was disabled or during agent restarts.
-        decision_writer: match decisions::DecisionWriter::new(&cli.data_dir) {
+        // Pass the sqlite store so every JSONL write is mirrored into the
+        // `decisions` table; dashboards, `/metrics`, and the scenario-qa
+        // drift harness all query sqlite, so without the mirror they were
+        // reading a table untouched since the legacy migration.
+        decision_writer: match decisions::DecisionWriter::with_store(
+            &cli.data_dir,
+            sqlite_store.clone(),
+        ) {
             Ok(w) => Some(w),
             Err(e) => {
                 warn!("failed to create decision writer: {e:#}");


### PR DESCRIPTION
## Summary

Operator baseline captured 2026-04-18 on `130.162.171.105`:

| signal | value |
|---|---|
| incidents (24h) | 675 |
| decisions JSONL (24h) | 1021 auto `block_ip` + 373 auto `dismiss` |
| decisions **sqlite** (24h) | **0** |
| top blocked IPs | 104.26.12.38, 172.66.0.243, 162.159.140.245 (all **Cloudflare**) |
| top providers | `correlation:CL-008` x552, `repeat-offender` x375 |

CL-008 (`file.read_access` → `network.outbound_connect` within 60s) was matching the platform's own outbound traffic and auto-blocking whatever IP it touched — mostly Cloudflare CIDRs. `repeat-offender` then escalated those IPs into 7-day bans. Meanwhile the dashboard read a stale sqlite `decisions` table untouched since the legacy migration.

## Changes

1. **Cloud-safelist guard at `execute_block_ip_decision`** via new `check_block_eligibility_with_safelist`. Every block path (correlation, repeat-offender, auto-rule, AbuseIPDB, AI triage, honeypot) inherits the refusal. On match, purges the IP from `ip_reputations` so the cascade can't feed itself on stale counts.
2. **Correlation + repeat-offender short-circuits** before they build a synthetic incident, keeping `ip_reputations`/cooldown/graph clean.
3. **DecisionWriter dual-writes JSONL + sqlite** via `with_store(data_dir, Arc<Store>)`. JSONL remains the audit trail of record; sqlite mirror lands in `insert_decision` so `/metrics` + dashboard + scenario-qa reflect reality.
4. **`identify_provider` walks `CLOUDFLARE_RANGES` first** so 104.x.x.x and 172.x.x.x stop being mislabelled as Azure / Google by the first-octet heuristic.

## Test plan

- [x] `cargo test --workspace` → 3702 passed.
- [x] `make check` — clippy + fmt clean.
- [x] Regression guard over 9 Cloudflare IPs that topped the 24h block list.
- [x] Dual-write test asserts both JSONL + sqlite receive the entry.
- [ ] Post-merge: deploy, verify decisions table grows + no Cloudflare IPs appear.