### PR TITLE
release: v0.12.1 + v0.12.2 (autonomy + autoencoder + abuseipdb quota fix + CI gitleaks retry)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -25,7 +25,18 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Install and run gitleaks
         run: |
-          curl -sSfL -o gitleaks.tar.gz "https://github.com/gitleaks/gitleaks/releases/download/v8.24.0/gitleaks_8.24.0_linux_x64.tar.gz"
+          # github.com release downloads occasionally return 504 from the
+          # edge; without retry the whole PR check fails on transient
+          # infra issues unrelated to the code. `--retry-all-errors` +
+          # `--retry-connrefused` covers the 5xx and network-reset paths.
+          curl -sSfL \
+               --retry 5 \
+               --retry-delay 5 \
+               --retry-max-time 180 \
+               --retry-all-errors \
+               --retry-connrefused \
+               -o gitleaks.tar.gz \
+               "https://github.com/gitleaks/gitleaks/releases/download/v8.24.0/gitleaks_8.24.0_linux_x64.tar.gz"
           echo "cb49b7de5ee986510fe8666ca0273a6cc15eb82571f2f14832c9e8920751f3a4  gitleaks.tar.gz" | sha256sum -c -
           tar xzf gitleaks.tar.gz
           ./gitleaks detect --source . --no-git --verbose --redact

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,24 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [0.12.1] - 2026-04-18
+
+### Fixed
+- **Autoencoder trained on zero events since spec 016** — `neural_lifecycle::train_nightly` iterated `events-YYYY-MM-DD.jsonl` files, but spec 016 moved every event into `innerwarden.db`. Every nightly trigger returned `"insufficient data"` and left the stale model in place. `baseline_std` drifted to ~0.0018, saturating sigmoid on every live window (`score=1.000` forever, maturity 1.00 on day 30+). Now reads from SQLite first, falls back to JSONL.
+- **Seven high-volume event kinds invisible to the brain** — `http.request` (22K/3d), `tcp_stream.ssh`, `memory.anon_executable`, `network.snapshot`, `memory.deleted_file_mapping`, `file.extracted_from_network`, `kernel.bpf_program_loaded` were not in `kind_index`, so the autoencoder was training on a biased slice. Added at slots 24..30; `NUM_FEATURES` bumped 58 → 65. Models from 0.12.0 auto-invalidate via dimension-mismatch check.
+- **Autonomy cascade blocking Cloudflare** — `correlation:CL-008` (file.read_access → network.outbound_connect within 60s) was matching the platform's own outbound traffic and auto-blocking whatever IP the outbound connection targeted. Production 24h snapshot: 1021 auto block_ip decisions, top 9 all Cloudflare CIDRs, 552 triggered by CL-008 alone + 375 `repeat-offender` compounding. New `check_block_eligibility_with_safelist` refuses any block whose target resolves via `cloud_safelist::identify_provider`, and short-circuits `correlation_response::handle_completed_chain` + repeat-offender before they mutate `ip_reputations`.
+- **Dashboard decisions table stale since legacy migration** — `DecisionWriter` only wrote JSONL; dashboards, `/metrics`, and scenario-qa all query sqlite `decisions`, which was untouched for a month. `DecisionWriter::with_store` now dual-writes: JSONL remains the audit trail of record, sqlite gets mirrored via `insert_decision`. Failure to persist logs a warning but does not reject the write.
+- **`cloud_safelist::identify_provider` mislabelled Cloudflare** — first-octet heuristic classified 104.x as Azure and 172.x as Google Cloud. Now walks `CLOUDFLARE_RANGES` first; heuristic stays as fallback for other providers.
+
+### Added
+- **`innerwarden-agent --retrain-anomaly`** one-shot flag (mirrors the spec 015 cleanup pattern). Reads events from `innerwarden.db`, trains `anomaly-model.bin` in place, prints maturity + cycles + model path, exits. Operator no longer has to wait until 03:00 UTC to recalibrate after a feature-layout bump.
+- `Store::events_for_training(since_ts, limit)` — streams `(kind, Option<src_ip>)` tuples without deserialising full events. RAM-budget friendly; used by the nightly training path.
+
+### Changed
+- Neural feature vector layout encoded in named constants (`KIND_SLOTS`, `BIGRAM_BASE`, `SEQ_BASE`, `GRAPH_BASE`). Future additions bump constants in one place instead of shifting magic slot numbers across the file.
+
+---
+
 ## [0.12.0] - 2026-04-18
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [0.12.2] - 2026-04-18
+
+### Fixed
+- **AbuseIPDB daily report quota exhausted** — operator email 2026-04-18: "You've exhausted your daily limit of 1,000 requests for report endpoint." Direct fallout of the CL-008 cascade that v0.12.1 fixed: ~900 false-positive blocks against Cloudflare CIDRs were queued for community reporting, each consuming one `report` call. The block refusal lands at `execute_block_ip_decision`, which prevents NEW reports from being queued, but entries already sitting in `state.abuseipdb_report_queue` before the fix deployed would still fire on the 5-minute grace flush. The slow-loop flush now consults `cloud_safelist::identify_provider` one more time before calling `client.report`, so any pre-fix queue entries targeting cloud ranges are dropped with a log line instead of polluting the community feed and burning our quota.
+- **CI `Secrets scan` job flaky on transient 504** — `curl -sSfL` fetching the gitleaks release tarball from github.com sometimes hits a 504 at the CDN edge, failing the whole PR check. Added `--retry 5 --retry-delay 5 --retry-all-errors --retry-connrefused --retry-max-time 180` so the download survives transient upstream hiccups.
+
+---
+
 ## [0.12.1] - 2026-04-18
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1936,7 +1936,7 @@ dependencies = [
 
 [[package]]
 name = "innerwarden-agent"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "aes-gcm 0.10.3",
  "anyhow",
@@ -1991,7 +1991,7 @@ dependencies = [
 
 [[package]]
 name = "innerwarden-agent-guard"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2009,7 +2009,7 @@ dependencies = [
 
 [[package]]
 name = "innerwarden-ctl"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "anyhow",
  "base64",
@@ -2037,7 +2037,7 @@ dependencies = [
 
 [[package]]
 name = "innerwarden-dna"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -2057,14 +2057,14 @@ dependencies = [
 
 [[package]]
 name = "innerwarden-ebpf-types"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "innerwarden-hypervisor"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2078,7 +2078,7 @@ dependencies = [
 
 [[package]]
 name = "innerwarden-killchain"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2114,7 +2114,7 @@ dependencies = [
 
 [[package]]
 name = "innerwarden-sensor"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "anyhow",
  "aya",
@@ -2145,7 +2145,7 @@ dependencies = [
 
 [[package]]
 name = "innerwarden-shield"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -2163,7 +2163,7 @@ dependencies = [
 
 [[package]]
 name = "innerwarden-smm"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2178,7 +2178,7 @@ dependencies = [
 
 [[package]]
 name = "innerwarden-store"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2196,7 +2196,7 @@ dependencies = [
 
 [[package]]
 name = "innerwarden_core"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1936,7 +1936,7 @@ dependencies = [
 
 [[package]]
 name = "innerwarden-agent"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "aes-gcm 0.10.3",
  "anyhow",
@@ -1991,7 +1991,7 @@ dependencies = [
 
 [[package]]
 name = "innerwarden-agent-guard"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2009,7 +2009,7 @@ dependencies = [
 
 [[package]]
 name = "innerwarden-ctl"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "anyhow",
  "base64",
@@ -2037,7 +2037,7 @@ dependencies = [
 
 [[package]]
 name = "innerwarden-dna"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "anyhow",
  "axum",
@@ -2057,14 +2057,14 @@ dependencies = [
 
 [[package]]
 name = "innerwarden-ebpf-types"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "innerwarden-hypervisor"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2078,7 +2078,7 @@ dependencies = [
 
 [[package]]
 name = "innerwarden-killchain"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2114,7 +2114,7 @@ dependencies = [
 
 [[package]]
 name = "innerwarden-sensor"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "anyhow",
  "aya",
@@ -2145,7 +2145,7 @@ dependencies = [
 
 [[package]]
 name = "innerwarden-shield"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "anyhow",
  "axum",
@@ -2163,7 +2163,7 @@ dependencies = [
 
 [[package]]
 name = "innerwarden-smm"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2178,7 +2178,7 @@ dependencies = [
 
 [[package]]
 name = "innerwarden-store"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2196,7 +2196,7 @@ dependencies = [
 
 [[package]]
 name = "innerwarden_core"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ exclude = ["crates/sensor-ebpf"]
 resolver = "2"
 
 [workspace.package]
-version = "0.12.0"
+version = "0.12.1"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/InnerWarden/innerwarden"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ exclude = ["crates/sensor-ebpf"]
 resolver = "2"
 
 [workspace.package]
-version = "0.12.1"
+version = "0.12.2"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/InnerWarden/innerwarden"

--- a/crates/agent/src/loops/boot.rs
+++ b/crates/agent/src/loops/boot.rs
@@ -1503,6 +1503,15 @@ pub(crate) async fn run_agent(cli: crate::Cli) -> Result<()> {
                     }
 
                     // ── Safeguard: flush AbuseIPDB delayed report queue ──
+                    // Defense-in-depth: even though `check_block_eligibility_with_safelist`
+                    // refuses blocks on cloud-provider IPs, the queue can carry
+                    // entries queued before the fix deployed. Reporting a
+                    // Cloudflare edge to AbuseIPDB pollutes the public feed
+                    // AND burns our 1k/day report quota — the operator email
+                    // on 2026-04-18 ("You've exhausted your daily limit of
+                    // 1,000 requests for report endpoint") was direct
+                    // fallout of the CL-008 cascade. Filter one more time
+                    // before sending.
                     {
                         let report_cutoff = chrono::Utc::now() - chrono::Duration::seconds(ABUSEIPDB_REPORT_DELAY_SECS);
                         let ready: Vec<_> = state.abuseipdb_report_queue
@@ -1510,11 +1519,28 @@ pub(crate) async fn run_agent(cli: crate::Cli) -> Result<()> {
                             .filter(|(_, _, _, ts)| *ts < report_cutoff)
                             .cloned()
                             .collect();
+                        let mut dropped_cloud = 0usize;
                         if let Some(ref client) = state.abuseipdb {
                             for (ip, comment, categories, _) in &ready {
+                                if let Some(provider) = cloud_safelist::identify_provider(ip) {
+                                    dropped_cloud += 1;
+                                    warn!(
+                                        ip,
+                                        provider,
+                                        "AbuseIPDB report dropped: target is in cloud safelist"
+                                    );
+                                    continue;
+                                }
                                 client.report(ip, categories, comment).await;
                                 info!(ip, "AbuseIPDB report sent (after 5min delay)");
                             }
+                        }
+                        if dropped_cloud > 0 {
+                            info!(
+                                dropped_cloud,
+                                "AbuseIPDB queue flush: dropped {} cloud-provider entries",
+                                dropped_cloud
+                            );
                         }
                         state.abuseipdb_report_queue.retain(|(_, _, _, ts)| *ts >= report_cutoff);
                     }


### PR DESCRIPTION
Patch release bundling PR #170 (autoencoder sqlite training) + PR #171 (autonomy Cloudflare cascade fix). Tag v0.12.1 pushed; release workflow is building binaries. This PR brings Cargo.toml + CHANGELOG onto main.