### PR TITLE
test(agent): cover incident enrichment adapters (#148)

### DIFF
--- a/crates/agent/src/crowdsec.rs
+++ b/crates/agent/src/crowdsec.rs
@@ -203,6 +203,14 @@ impl CrowdSecState {
     }
 }
 
+#[cfg(test)]
+impl CrowdSecState {
+    /// Test-only helper to seed known threats without network sync.
+    pub(crate) fn insert_known_threat_for_test(&mut self, ip: &str) {
+        self.threat_list.insert(ip.to_string());
+    }
+}
+
 /// Update the threat list from CrowdSec LAPI (delta stream).
 /// Called from the agent's slow loop. Returns (added, removed) counts.
 pub async fn sync_threat_list(cs: &mut CrowdSecState) -> (usize, usize) {

--- a/crates/agent/src/incident_advisory.rs
+++ b/crates/agent/src/incident_advisory.rs
@@ -97,3 +97,79 @@ fn check_advisory_match(
         .find(|e| e.command_hash == command_hash)
         .cloned()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+
+    fn advisory_entry(id: &str, command: &str) -> AdvisoryEntry {
+        AdvisoryEntry {
+            advisory_id: id.to_string(),
+            command_hash: innerwarden_core::audit::sha256_hex(&command.to_lowercase()),
+            command_preview: command.to_string(),
+            risk_score: 87,
+            recommendation: "blocked".to_string(),
+            signals: vec!["dangerous-command".to_string()],
+            ts: Utc::now(),
+        }
+    }
+
+    #[tokio::test]
+    async fn handle_advisory_violation_consumes_matching_advisory_entry() {
+        // Invariant: a matching advisory must be consumed exactly once after a tagged incident.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let state = crate::tests::triage_test_state(dir.path());
+        let command = "rm -rf /tmp/suspicious";
+        let cache = Arc::new(RwLock::new(VecDeque::from([advisory_entry(
+            "adv-1", command,
+        )])));
+        let mut incident = crate::tests::test_incident("203.0.113.21");
+        incident.tags = vec!["execution".to_string()];
+        incident.evidence = serde_json::json!([{ "command": command }]);
+
+        handle_advisory_violation(&incident, &cache, &state).await;
+
+        let remaining = cache.read().expect("cache read lock");
+        assert!(remaining.is_empty());
+    }
+
+    #[tokio::test]
+    async fn handle_advisory_violation_skips_when_trigger_tags_are_absent() {
+        // Invariant: incidents without `execution`/`suspicious` tags must not touch advisory cache.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let state = crate::tests::triage_test_state(dir.path());
+        let cache = Arc::new(RwLock::new(VecDeque::from([advisory_entry(
+            "adv-2",
+            "cat /etc/shadow",
+        )])));
+        let mut incident = crate::tests::test_incident("203.0.113.22");
+        incident.tags = vec!["ssh".to_string()];
+        incident.evidence = serde_json::json!([{ "command": "cat /etc/shadow" }]);
+
+        handle_advisory_violation(&incident, &cache, &state).await;
+
+        let remaining = cache.read().expect("cache read lock");
+        assert_eq!(remaining.len(), 1);
+        assert_eq!(remaining[0].advisory_id, "adv-2");
+    }
+
+    #[tokio::test]
+    async fn handle_advisory_violation_keeps_cache_when_no_advisory_match_exists() {
+        // Invariant: upstream `None` matches must be a no-op and leave advisory entries intact.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let state = crate::tests::triage_test_state(dir.path());
+        let cache = Arc::new(RwLock::new(VecDeque::from([advisory_entry(
+            "adv-3", "whoami",
+        )])));
+        let mut incident = crate::tests::test_incident("203.0.113.23");
+        incident.tags = vec!["execution".to_string()];
+        incident.evidence = serde_json::json!([{ "command": "ls -la /tmp" }]);
+
+        handle_advisory_violation(&incident, &cache, &state).await;
+
+        let remaining = cache.read().expect("cache read lock");
+        assert_eq!(remaining.len(), 1);
+        assert_eq!(remaining[0].advisory_id, "adv-3");
+    }
+}

--- a/crates/agent/src/incident_attacker_profile.rs
+++ b/crates/agent/src/incident_attacker_profile.rs
@@ -22,3 +22,46 @@ pub(crate) fn update_incident_ip_profiles(
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use innerwarden_core::entities::EntityRef;
+
+    #[test]
+    fn update_incident_ip_profiles_updates_reputation_and_profile_for_ip_entities() {
+        // Invariant: every IP entity increments local reputation and attacker profile counters.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut state = crate::tests::triage_test_state(dir.path());
+        let incident = crate::tests::test_incident("203.0.113.10");
+
+        update_incident_ip_profiles(&incident, &mut state);
+        update_incident_ip_profiles(&incident, &mut state);
+
+        let rep = state
+            .ip_reputations
+            .get("203.0.113.10")
+            .expect("IP reputation should be created");
+        assert_eq!(rep.total_incidents, 2);
+
+        let profile = state
+            .attacker_profiles
+            .get("203.0.113.10")
+            .expect("attacker profile should be created");
+        assert_eq!(profile.total_incidents, 2);
+    }
+
+    #[test]
+    fn update_incident_ip_profiles_skips_non_ip_entities() {
+        // Invariant: non-IP entities must not mutate IP reputation or attacker profile maps.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut state = crate::tests::triage_test_state(dir.path());
+        let mut incident = crate::tests::test_incident("203.0.113.11");
+        incident.entities = vec![EntityRef::user("root")];
+
+        update_incident_ip_profiles(&incident, &mut state);
+
+        assert!(state.ip_reputations.is_empty());
+        assert!(state.attacker_profiles.is_empty());
+    }
+}

--- a/crates/agent/src/incident_crowdsec.rs
+++ b/crates/agent/src/incident_crowdsec.rs
@@ -118,3 +118,111 @@ pub(crate) async fn try_handle_crowdsec_autoblock(
 
     true
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn try_handle_crowdsec_autoblock_auto_blocks_known_threat_ips() {
+        // Invariant: CrowdSec-known threat IPs should bypass AI and be auto-blocked once.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut state = crate::tests::triage_test_state(dir.path());
+        let cfg = crate::config::AgentConfig::default();
+        let ip = "203.0.113.41";
+        let incident = crate::tests::test_incident(ip);
+        let mut crowdsec = crate::crowdsec::CrowdSecState::new(&cfg.crowdsec);
+        crowdsec.insert_known_threat_for_test(ip);
+        state.crowdsec = Some(crowdsec);
+        state.attacker_profiles.insert(
+            ip.to_string(),
+            crate::attacker_intel::new_profile(ip, incident.ts),
+        );
+        let mut blocked_set = HashSet::new();
+
+        let handled = try_handle_crowdsec_autoblock(
+            &incident,
+            dir.path(),
+            &cfg,
+            &mut state,
+            &mut blocked_set,
+        )
+        .await;
+
+        assert!(handled);
+        assert!(blocked_set.contains(ip));
+        assert!(state.blocklist.contains(ip));
+
+        let profile = state
+            .attacker_profiles
+            .get(ip)
+            .expect("attacker profile should exist");
+        assert_eq!(profile.total_decisions, 1);
+        assert_eq!(profile.total_blocks, 1);
+
+        let skill_id = format!("block-ip-{}", cfg.responder.block_backend);
+        let decision = crate::ai::AiDecision {
+            action: crate::ai::AiAction::BlockIp {
+                ip: ip.to_string(),
+                skill_id,
+            },
+            confidence: 1.0,
+            auto_execute: true,
+            reason: "CrowdSec community threat list match".to_string(),
+            alternatives: vec![],
+            estimated_threat: "high".to_string(),
+        };
+        let key = crate::decision_cooldown_key_for_decision(&incident, &decision)
+            .expect("block decision should produce cooldown key");
+        assert!(state
+            .store
+            .has_cooldown(crate::state_store::CooldownTable::Decision, &key));
+    }
+
+    #[tokio::test]
+    async fn try_handle_crowdsec_autoblock_returns_false_when_feature_is_disabled() {
+        // Invariant: when CrowdSec state is disabled (`None`), auto-block must never trigger.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut state = crate::tests::triage_test_state(dir.path());
+        let cfg = crate::config::AgentConfig::default();
+        let incident = crate::tests::test_incident("203.0.113.42");
+        let mut blocked_set = HashSet::new();
+
+        let handled = try_handle_crowdsec_autoblock(
+            &incident,
+            dir.path(),
+            &cfg,
+            &mut state,
+            &mut blocked_set,
+        )
+        .await;
+
+        assert!(!handled);
+        assert!(blocked_set.is_empty());
+        assert!(!state.blocklist.contains("203.0.113.42"));
+    }
+
+    #[tokio::test]
+    async fn try_handle_crowdsec_autoblock_returns_false_when_upstream_has_no_threat_match() {
+        // Invariant: an enabled CrowdSec adapter with no threat hit must return `false` and avoid mutations.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut state = crate::tests::triage_test_state(dir.path());
+        let cfg = crate::config::AgentConfig::default();
+        state.crowdsec = Some(crate::crowdsec::CrowdSecState::new(&cfg.crowdsec));
+        let incident = crate::tests::test_incident("203.0.113.43");
+        let mut blocked_set = HashSet::new();
+
+        let handled = try_handle_crowdsec_autoblock(
+            &incident,
+            dir.path(),
+            &cfg,
+            &mut state,
+            &mut blocked_set,
+        )
+        .await;
+
+        assert!(!handled);
+        assert!(blocked_set.is_empty());
+        assert!(!state.blocklist.contains("203.0.113.43"));
+    }
+}

--- a/crates/agent/src/incident_forensics.rs
+++ b/crates/agent/src/incident_forensics.rs
@@ -2,11 +2,13 @@ use tracing::info;
 
 use crate::AgentState;
 
-/// Best-effort forensics capture for high-severity incidents.
-/// Captures /proc state by PID and selective pcap by primary attacker IP.
-pub(crate) fn maybe_capture_incident_forensics(
+fn capture_incident_forensics_with<
+    F: FnMut(u32, &str) -> Option<crate::forensics::ForensicsReport>,
+    P: FnMut(&str, &str) -> Option<crate::pcap_capture::CaptureResult>,
+>(
     incident: &innerwarden_core::incident::Incident,
-    state: &mut AgentState,
+    mut capture_forensics: F,
+    mut capture_pcap: P,
 ) {
     if !matches!(
         incident.severity,
@@ -17,7 +19,7 @@ pub(crate) fn maybe_capture_incident_forensics(
 
     if let Some(pid) = incident.evidence.get("pid").and_then(|v| v.as_u64()) {
         let pid = pid as u32;
-        if let Some(report) = state.forensics.try_capture(pid, &incident.incident_id) {
+        if let Some(report) = capture_forensics(pid, &incident.incident_id) {
             info!(
                 pid = report.pid,
                 incident_id = %incident.incident_id,
@@ -34,7 +36,7 @@ pub(crate) fn maybe_capture_incident_forensics(
         .find(|e| e.r#type == innerwarden_core::entities::EntityType::Ip)
         .map(|e| e.value.as_str());
     if let Some(ip) = primary_ip {
-        if let Some(result) = state.pcap_capture.try_capture(ip, &incident.incident_id) {
+        if let Some(result) = capture_pcap(ip, &incident.incident_id) {
             info!(
                 ip = %result.ip,
                 pcap = %result.pcap_path.display(),
@@ -42,5 +44,139 @@ pub(crate) fn maybe_capture_incident_forensics(
                 "pcap: capture initiated for incident"
             );
         }
+    }
+}
+
+/// Best-effort forensics capture for high-severity incidents.
+/// Captures /proc state by PID and selective pcap by primary attacker IP.
+pub(crate) fn maybe_capture_incident_forensics(
+    incident: &innerwarden_core::incident::Incident,
+    state: &mut AgentState,
+) {
+    let forensics = &mut state.forensics;
+    let pcap_capture = &mut state.pcap_capture;
+    capture_incident_forensics_with(
+        incident,
+        |pid, incident_id| forensics.try_capture(pid, incident_id),
+        |ip, incident_id| pcap_capture.try_capture(ip, incident_id),
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+    use std::cell::Cell;
+    use std::path::PathBuf;
+
+    fn forensics_report(pid: u32, incident_id: &str) -> crate::forensics::ForensicsReport {
+        crate::forensics::ForensicsReport {
+            pid,
+            incident_id: incident_id.to_string(),
+            timestamp: Utc::now(),
+            cmdline: Some("cmd".to_string()),
+            exe: Some("/bin/echo".to_string()),
+            cwd: Some("/tmp".to_string()),
+            status: Some("Running".to_string()),
+            open_fds: vec![],
+            network_connections: vec![],
+            memory_maps: vec![],
+            env_redacted: vec![],
+        }
+    }
+
+    fn pcap_result(ip: &str) -> crate::pcap_capture::CaptureResult {
+        crate::pcap_capture::CaptureResult {
+            pcap_path: PathBuf::from("/tmp/mock.pcap"),
+            ip: ip.to_string(),
+            duration_secs: 60,
+        }
+    }
+
+    #[test]
+    fn capture_incident_forensics_with_invokes_both_captures_on_high_severity() {
+        // Invariant: high-severity incidents with PID and IP must trigger both capture adapters.
+        let mut incident = crate::tests::test_incident("203.0.113.31");
+        incident.evidence = serde_json::json!({ "pid": 42 });
+        let forensics_calls = Cell::new(0u32);
+        let pcap_calls = Cell::new(0u32);
+
+        capture_incident_forensics_with(
+            &incident,
+            |pid, incident_id| {
+                forensics_calls.set(forensics_calls.get() + 1);
+                assert_eq!(pid, 42);
+                Some(forensics_report(pid, incident_id))
+            },
+            |ip, _incident_id| {
+                pcap_calls.set(pcap_calls.get() + 1);
+                assert_eq!(ip, "203.0.113.31");
+                Some(pcap_result(ip))
+            },
+        );
+
+        assert_eq!(forensics_calls.get(), 1);
+        assert_eq!(pcap_calls.get(), 1);
+    }
+
+    #[test]
+    fn capture_incident_forensics_with_skips_when_severity_below_high() {
+        // Invariant: medium/low incidents must never call forensics or pcap capture backends.
+        let mut incident = crate::tests::test_incident("203.0.113.32");
+        incident.severity = innerwarden_core::event::Severity::Low;
+        incident.evidence = serde_json::json!({ "pid": 7 });
+        let forensics_calls = Cell::new(0u32);
+        let pcap_calls = Cell::new(0u32);
+
+        capture_incident_forensics_with(
+            &incident,
+            |_pid, _incident_id| {
+                forensics_calls.set(forensics_calls.get() + 1);
+                Some(forensics_report(7, "unused"))
+            },
+            |_ip, _incident_id| {
+                pcap_calls.set(pcap_calls.get() + 1);
+                Some(pcap_result("203.0.113.32"))
+            },
+        );
+
+        assert_eq!(forensics_calls.get(), 0);
+        assert_eq!(pcap_calls.get(), 0);
+    }
+
+    #[test]
+    fn capture_incident_forensics_with_tolerates_upstream_none_results() {
+        // Invariant: upstream capture adapters returning `None` must not panic and keep flow alive.
+        let mut incident = crate::tests::test_incident("203.0.113.33");
+        incident.evidence = serde_json::json!({ "pid": 99999 });
+        let forensics_calls = Cell::new(0u32);
+        let pcap_calls = Cell::new(0u32);
+
+        capture_incident_forensics_with(
+            &incident,
+            |_pid, _incident_id| {
+                forensics_calls.set(forensics_calls.get() + 1);
+                None
+            },
+            |_ip, _incident_id| {
+                pcap_calls.set(pcap_calls.get() + 1);
+                None
+            },
+        );
+
+        assert_eq!(forensics_calls.get(), 1);
+        assert_eq!(pcap_calls.get(), 1);
+    }
+
+    #[test]
+    fn maybe_capture_incident_forensics_returns_early_for_low_severity_incidents() {
+        // Invariant: runtime adapter wrapper should no-op when incident severity is below High.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut state = crate::tests::triage_test_state(dir.path());
+        let mut incident = crate::tests::test_incident("203.0.113.34");
+        incident.severity = innerwarden_core::event::Severity::Low;
+        incident.evidence = serde_json::json!({ "pid": std::process::id() });
+
+        maybe_capture_incident_forensics(&incident, &mut state);
     }
 }

--- a/crates/agent/src/incident_playbook.rs
+++ b/crates/agent/src/incident_playbook.rs
@@ -42,3 +42,88 @@ pub(crate) fn maybe_evaluate_and_persist_playbook(
         let _ = std::fs::write(&log_path, json_str);
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write_playbook_rule(
+        rules_dir: &std::path::Path,
+        playbook_id: &str,
+        detector: &str,
+        min_severity: &str,
+    ) {
+        let playbooks_dir = rules_dir.join("playbooks");
+        std::fs::create_dir_all(&playbooks_dir).expect("playbooks dir");
+        let content = format!(
+            r#"[playbook.{playbook_id}]
+name = "Unit Test Playbook"
+trigger = {{ detector = "{detector}", min_severity = "{min_severity}" }}
+steps = [{{ action = "notify" }}]
+"#
+        );
+        std::fs::write(playbooks_dir.join("unit.toml"), content).expect("write rule");
+    }
+
+    #[test]
+    fn maybe_evaluate_and_persist_playbook_persists_log_and_sqlite_blob_on_match() {
+        // Invariant: matching playbooks must be persisted to both JSON log and SQLite blob.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let rules_dir = dir.path().join("rules-enabled");
+        write_playbook_rule(&rules_dir, "pb-unit", "ssh_bruteforce", "high");
+        let mut state = crate::tests::triage_test_state(dir.path());
+        state.playbook_engine = crate::playbook::PlaybookEngine::new(&rules_dir);
+        let store = crate::tests::test_sqlite_store(dir.path());
+        state.sqlite_store = Some(store.clone());
+        let incident = crate::tests::test_incident("203.0.113.51");
+
+        maybe_evaluate_and_persist_playbook(&incident, dir.path(), &mut state);
+
+        let log_path = dir.path().join("playbook-log.json");
+        let raw = std::fs::read_to_string(&log_path).expect("playbook log");
+        let entries: Vec<serde_json::Value> = serde_json::from_str(&raw).expect("valid json log");
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0]["playbook_id"], "pb-unit");
+
+        let blob = store
+            .get_blob("playbook_log")
+            .expect("blob read")
+            .expect("blob value");
+        assert!(blob.contains("\"playbook_id\":\"pb-unit\""));
+    }
+
+    #[test]
+    fn maybe_evaluate_and_persist_playbook_skips_when_no_playbook_matches() {
+        // Invariant: when playbook evaluation returns `None`, no persistence side effects should occur.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let rules_dir = dir.path().join("rules-disabled");
+        write_playbook_rule(&rules_dir, "pb-never", "never_match", "critical");
+        let mut state = crate::tests::triage_test_state(dir.path());
+        state.playbook_engine = crate::playbook::PlaybookEngine::new(&rules_dir);
+        let incident = crate::tests::test_incident("203.0.113.52");
+
+        maybe_evaluate_and_persist_playbook(&incident, dir.path(), &mut state);
+
+        assert!(!dir.path().join("playbook-log.json").exists());
+    }
+
+    #[test]
+    fn maybe_evaluate_and_persist_playbook_recovers_from_corrupted_existing_log() {
+        // Invariant: malformed on-disk playbook log must be treated as empty and replaced with valid JSON.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let rules_dir = dir.path().join("rules-recovery");
+        write_playbook_rule(&rules_dir, "pb-recover", "ssh_bruteforce", "high");
+        let mut state = crate::tests::triage_test_state(dir.path());
+        state.playbook_engine = crate::playbook::PlaybookEngine::new(&rules_dir);
+        let incident = crate::tests::test_incident("203.0.113.53");
+        let log_path = dir.path().join("playbook-log.json");
+        std::fs::write(&log_path, "{not-valid-json").expect("seed corrupted log");
+
+        maybe_evaluate_and_persist_playbook(&incident, dir.path(), &mut state);
+
+        let raw = std::fs::read_to_string(&log_path).expect("playbook log");
+        let entries: Vec<serde_json::Value> = serde_json::from_str(&raw).expect("valid json log");
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0]["playbook_id"], "pb-recover");
+    }
+}


### PR DESCRIPTION
Closes #148.

| Adapter | What was missing | What is now covered |
| --- | --- | --- |
| `attacker_profile` | No direct unit tests for IP-entity mutation behavior. | `update_incident_ip_profiles` now guards IP happy path (reputation/profile increments) and non-IP skip branch. |
| `advisory` | No coverage for advisory cache consume gate paths. | `handle_advisory_violation` now covers tagged-match consume path, feature-disabled tag gate, and no-match (`None`) branch. |
| `forensics` | No deterministic coverage of capture decision matrix around severity and adapter returns. | `maybe_capture_incident_forensics` now covers high-severity happy path via extracted adapter helper, low-severity disabled branch, and upstream `None` capture branch. |
| `crowdsec` | No tests for auto-block gate behavior and state mutations. | `try_handle_crowdsec_autoblock` now covers known-threat happy path with blocklist/cooldown/profile mutation, disabled `crowdsec=None` branch, and enabled-but-no-hit branch. |
| `playbook` | No coverage for playbook evaluation persistence branches. | `maybe_evaluate_and_persist_playbook` now covers matched persistence path (JSON + SQLite), no-match disabled branch, and corrupted-log recovery/error branch. |

Notes:
- Test-only helper added to CrowdSec state seeding (`#[cfg(test)]`) to avoid network calls.
- Tests use in-tree harness + `tempdir()` and do not perform external network I/O.
- This PR is tests-only (`docs/tests/CI only`).
