### PR TITLE
test(agent): cover slow_loop guard orchestration (#151)

### DIFF
--- a/crates/agent/src/incident_flow.rs
+++ b/crates/agent/src/incident_flow.rs
@@ -15,6 +15,69 @@ pub(crate) enum PreAiFlowDecision {
     SkipBelowSeverity,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum PreAiGuardDecision {
+    Proceed,
+    PipelineTestHandled,
+    SkipAdvisoryDetector,
+    SkipAiDisabled,
+    SkipAllowlisted,
+    SkipBelowSeverity,
+    SkipPrivateOrBlocked,
+    SkipDecisionCooldown,
+    SkipAiCallBudget,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct PreAiGuardInputs {
+    pub is_pipeline_test: bool,
+    pub is_advisory_detector: bool,
+    pub ai_enabled: bool,
+    pub is_allowlisted: bool,
+    pub passes_ai_gate: bool,
+    pub below_severity_threshold: bool,
+    pub in_decision_cooldown: bool,
+    pub ai_calls_this_tick: usize,
+    pub max_ai_calls_per_tick: usize,
+}
+
+pub(super) fn decide_pre_ai_guard(inputs: PreAiGuardInputs) -> PreAiGuardDecision {
+    if inputs.is_pipeline_test {
+        return PreAiGuardDecision::PipelineTestHandled;
+    }
+
+    // Neural model detectors remain advisory-only and never go through AI.
+    if inputs.is_advisory_detector {
+        return PreAiGuardDecision::SkipAdvisoryDetector;
+    }
+
+    if !inputs.ai_enabled {
+        return PreAiGuardDecision::SkipAiDisabled;
+    }
+
+    if inputs.is_allowlisted {
+        return PreAiGuardDecision::SkipAllowlisted;
+    }
+
+    if !inputs.passes_ai_gate {
+        if inputs.below_severity_threshold {
+            return PreAiGuardDecision::SkipBelowSeverity;
+        }
+        return PreAiGuardDecision::SkipPrivateOrBlocked;
+    }
+
+    if inputs.in_decision_cooldown {
+        return PreAiGuardDecision::SkipDecisionCooldown;
+    }
+
+    if inputs.max_ai_calls_per_tick > 0 && inputs.ai_calls_this_tick >= inputs.max_ai_calls_per_tick
+    {
+        return PreAiGuardDecision::SkipAiCallBudget;
+    }
+
+    PreAiGuardDecision::Proceed
+}
+
 /// Evaluate all pre-AI gates for one incident.
 /// This keeps `process_incidents` focused on orchestration and leaves
 /// eligibility logic in one cohesive place.
@@ -26,59 +89,22 @@ pub(crate) fn evaluate_pre_ai_flow(
     blocked_set: &HashSet<String>,
     ai_calls_this_tick: usize,
 ) -> PreAiFlowDecision {
-    // Pipeline test: recognise `innerwarden test` incidents by tag and
-    // write an acknowledgement decision without calling the AI provider.
-    if incident.tags.contains(&"pipeline-test".to_string()) {
-        info!(
-            incident_id = %incident.incident_id,
-            "pipeline test incident detected - writing acknowledgement decision"
-        );
-        let test_ip = incident
-            .entities
-            .iter()
-            .find(|e| e.r#type == innerwarden_core::entities::EntityType::Ip)
-            .map(|e| e.value.clone());
-        let entry = crate::decisions::DecisionEntry {
-            ts: chrono::Utc::now(),
-            incident_id: incident.incident_id.clone(),
-            host: incident.host.clone(),
-            ai_provider: "pipeline-test".to_string(),
-            action_type: "monitor".to_string(),
-            target_ip: test_ip,
-            target_user: None,
-            skill_id: None,
-            confidence: 1.0,
-            auto_executed: false,
-            dry_run: true,
-            reason: "Pipeline test acknowledged - sensor → agent → decision path is working"
-                .to_string(),
-            estimated_threat: "none".to_string(),
-            execution_result: "test-ok".to_string(),
-            prev_hash: None,
-        };
-        if let Some(writer) = &mut state.decision_writer {
-            if let Err(e) = writer.write(&entry) {
-                warn!("failed to write pipeline-test decision: {e:#}");
-            }
-        }
-        return PreAiFlowDecision::PipelineTestHandled;
-    }
-
-    // Neural model is advisory only — observes and logs but never triggers
-    // blocks or notifications. The brain records its suggestion in brain-log.json
-    // for operator review; actual blocking is left to rule-based detectors.
     let detector = incident.incident_id.split(':').next().unwrap_or("");
-    if detector == "neural_anomaly" || detector == "host_drift" {
-        return PreAiFlowDecision::SkipHandled;
-    }
+    let mut guard_inputs = PreAiGuardInputs {
+        is_pipeline_test: incident.tags.iter().any(|tag| tag == "pipeline-test"),
+        is_advisory_detector: detector == "neural_anomaly" || detector == "host_drift",
+        ai_enabled,
+        is_allowlisted: false,
+        passes_ai_gate: true,
+        below_severity_threshold: false,
+        in_decision_cooldown: false,
+        ai_calls_this_tick,
+        max_ai_calls_per_tick: cfg.ai.max_ai_calls_per_tick,
+    };
 
-    if !ai_enabled {
-        return PreAiFlowDecision::SkipHandled;
-    }
-
-    // Allowlist gate - skip AI for explicitly trusted IPs and users.
-    // Merges static config allowlist with dynamic allowlist.toml (hot-reloaded every 30s).
-    {
+    if ai_enabled {
+        // Allowlist gate - skip AI for explicitly trusted IPs and users.
+        // Merges static config allowlist with dynamic allowlist.toml (hot-reloaded every 30s).
         use innerwarden_core::entities::EntityType;
         let ip_allowlisted = incident
             .entities
@@ -96,66 +122,252 @@ pub(crate) fn evaluate_pre_ai_flow(
                 allowlist::is_user_allowlisted(&e.value, &cfg.allowlist.trusted_users)
                     || allowlist::is_user_allowlisted(&e.value, &state.dynamic_trusted_users)
             });
-        if ip_allowlisted || user_allowlisted {
+        guard_inputs.is_allowlisted = ip_allowlisted || user_allowlisted;
+
+        if !guard_inputs.is_allowlisted {
+            let min_severity = cfg.ai.parsed_min_severity();
+            guard_inputs.passes_ai_gate =
+                ai::should_invoke_ai(incident, blocked_set, &min_severity);
+            guard_inputs.below_severity_threshold =
+                ai::is_below_severity_threshold(&incident.severity, &min_severity);
+
+            if guard_inputs.passes_ai_gate {
+                // Decision cooldown - suppress repeated AI decisions for the same
+                // action:detector:entity scope within a 1-hour window.
+                let cooldown_cutoff =
+                    chrono::Utc::now() - chrono::Duration::seconds(crate::DECISION_COOLDOWN_SECS);
+                let candidates = crate::decision_cooldown_candidates(incident);
+                guard_inputs.in_decision_cooldown = candidates.iter().any(|k| {
+                    state
+                        .store
+                        .get_cooldown(state_store::CooldownTable::Decision, k)
+                        .is_some_and(|ts| ts > cooldown_cutoff)
+                });
+            }
+        }
+    }
+
+    match decide_pre_ai_guard(guard_inputs) {
+        PreAiGuardDecision::PipelineTestHandled => {
+            // Pipeline test: recognise `innerwarden test` incidents by tag and
+            // write an acknowledgement decision without calling the AI provider.
+            info!(
+                incident_id = %incident.incident_id,
+                "pipeline test incident detected - writing acknowledgement decision"
+            );
+            let test_ip = incident
+                .entities
+                .iter()
+                .find(|e| e.r#type == innerwarden_core::entities::EntityType::Ip)
+                .map(|e| e.value.clone());
+            let entry = crate::decisions::DecisionEntry {
+                ts: chrono::Utc::now(),
+                incident_id: incident.incident_id.clone(),
+                host: incident.host.clone(),
+                ai_provider: "pipeline-test".to_string(),
+                action_type: "monitor".to_string(),
+                target_ip: test_ip,
+                target_user: None,
+                skill_id: None,
+                confidence: 1.0,
+                auto_executed: false,
+                dry_run: true,
+                reason: "Pipeline test acknowledged - sensor → agent → decision path is working"
+                    .to_string(),
+                estimated_threat: "none".to_string(),
+                execution_result: "test-ok".to_string(),
+                prev_hash: None,
+            };
+            if let Some(writer) = &mut state.decision_writer {
+                if let Err(e) = writer.write(&entry) {
+                    warn!("failed to write pipeline-test decision: {e:#}");
+                }
+            }
+            PreAiFlowDecision::PipelineTestHandled
+        }
+        // Neural model is advisory only — observes and logs but never triggers
+        // blocks or notifications. The brain records its suggestion in brain-log.json
+        // for operator review; actual blocking is left to rule-based detectors.
+        PreAiGuardDecision::SkipAdvisoryDetector | PreAiGuardDecision::SkipAiDisabled => {
+            PreAiFlowDecision::SkipHandled
+        }
+        PreAiGuardDecision::SkipAllowlisted => {
             info!(
                 incident_id = %incident.incident_id,
                 "AI gate: skipping (entity is in allowlist)"
             );
-            return PreAiFlowDecision::SkipAllowlisted;
+            PreAiFlowDecision::SkipAllowlisted
         }
-    }
-
-    if !ai::should_invoke_ai(incident, blocked_set, &cfg.ai.parsed_min_severity()) {
-        // Distinguish "below severity threshold" from other skip reasons so
-        // the caller can route low-severity noise to the auto-dismiss gate.
-        let dominated_by_min =
-            ai::is_below_severity_threshold(&incident.severity, &cfg.ai.parsed_min_severity());
-        if dominated_by_min {
+        PreAiGuardDecision::SkipBelowSeverity => {
             info!(
                 incident_id = %incident.incident_id,
                 severity = ?incident.severity,
                 "AI gate: skipping (below min_severity threshold)"
             );
-            return PreAiFlowDecision::SkipBelowSeverity;
+            PreAiFlowDecision::SkipBelowSeverity
         }
-        info!(
-            incident_id = %incident.incident_id,
-            severity = ?incident.severity,
-            "AI gate: skipping (private IP / already blocked)"
-        );
-        return PreAiFlowDecision::SkipHandled;
+        PreAiGuardDecision::SkipPrivateOrBlocked => {
+            info!(
+                incident_id = %incident.incident_id,
+                severity = ?incident.severity,
+                "AI gate: skipping (private IP / already blocked)"
+            );
+            PreAiFlowDecision::SkipHandled
+        }
+        PreAiGuardDecision::SkipDecisionCooldown => {
+            info!(
+                incident_id = %incident.incident_id,
+                "AI gate: skipping (decision cooldown active)"
+            );
+            PreAiFlowDecision::SkipHandled
+        }
+        PreAiGuardDecision::SkipAiCallBudget => {
+            // max_ai_calls_per_tick: enforce per-tick AI call budget.
+            let max_calls = cfg.ai.max_ai_calls_per_tick;
+            info!(
+                incident_id = %incident.incident_id,
+                ai_calls_this_tick,
+                max_calls,
+                "AI gate: skipping (max_ai_calls_per_tick reached - deferred to next tick)"
+            );
+            PreAiFlowDecision::SkipHandled
+        }
+        PreAiGuardDecision::Proceed => PreAiFlowDecision::Proceed,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn default_guard_inputs() -> PreAiGuardInputs {
+        PreAiGuardInputs {
+            is_pipeline_test: false,
+            is_advisory_detector: false,
+            ai_enabled: true,
+            is_allowlisted: false,
+            passes_ai_gate: true,
+            below_severity_threshold: false,
+            in_decision_cooldown: false,
+            ai_calls_this_tick: 0,
+            max_ai_calls_per_tick: 10,
+        }
     }
 
-    // Decision cooldown - suppress repeated AI decisions for the same
-    // action:detector:entity scope within a 1-hour window.
-    let cooldown_cutoff =
-        chrono::Utc::now() - chrono::Duration::seconds(crate::DECISION_COOLDOWN_SECS);
-    let candidates = crate::decision_cooldown_candidates(incident);
-    let in_cooldown = candidates.iter().any(|k| {
-        state
-            .store
-            .get_cooldown(state_store::CooldownTable::Decision, k)
-            .is_some_and(|ts| ts > cooldown_cutoff)
-    });
-    if in_cooldown {
-        info!(
-            incident_id = %incident.incident_id,
-            "AI gate: skipping (decision cooldown active)"
+    #[test]
+    fn decide_pre_ai_guard_pipeline_test_has_highest_priority() {
+        // Invariant: pipeline-test incidents must short-circuit all later guard checks.
+        let mut inputs = default_guard_inputs();
+        inputs.is_pipeline_test = true;
+        inputs.is_advisory_detector = true;
+        inputs.ai_enabled = false;
+        inputs.is_allowlisted = true;
+        inputs.passes_ai_gate = false;
+        inputs.below_severity_threshold = true;
+        inputs.in_decision_cooldown = true;
+        inputs.ai_calls_this_tick = 99;
+
+        assert_eq!(
+            decide_pre_ai_guard(inputs),
+            PreAiGuardDecision::PipelineTestHandled
         );
-        return PreAiFlowDecision::SkipHandled;
     }
 
-    // max_ai_calls_per_tick: enforce per-tick AI call budget.
-    let max_calls = cfg.ai.max_ai_calls_per_tick;
-    if max_calls > 0 && ai_calls_this_tick >= max_calls {
-        info!(
-            incident_id = %incident.incident_id,
-            ai_calls_this_tick,
-            max_calls,
-            "AI gate: skipping (max_ai_calls_per_tick reached - deferred to next tick)"
+    #[test]
+    fn decide_pre_ai_guard_advisory_detector_short_circuits_ai_disabled() {
+        // Invariant: advisory-only detectors stay in observe mode even when AI is disabled.
+        let mut inputs = default_guard_inputs();
+        inputs.is_advisory_detector = true;
+        inputs.ai_enabled = false;
+
+        assert_eq!(
+            decide_pre_ai_guard(inputs),
+            PreAiGuardDecision::SkipAdvisoryDetector
         );
-        return PreAiFlowDecision::SkipHandled;
     }
 
-    PreAiFlowDecision::Proceed
+    #[test]
+    fn decide_pre_ai_guard_skips_when_ai_is_disabled() {
+        // Invariant: when AI is disabled, incidents should skip the entire AI guard chain.
+        let mut inputs = default_guard_inputs();
+        inputs.ai_enabled = false;
+
+        assert_eq!(
+            decide_pre_ai_guard(inputs),
+            PreAiGuardDecision::SkipAiDisabled
+        );
+    }
+
+    #[test]
+    fn decide_pre_ai_guard_allowlist_takes_precedence_over_ai_gate_outcome() {
+        // Invariant: allowlisted entities must bypass AI before private/block/noise gate evaluation.
+        let mut inputs = default_guard_inputs();
+        inputs.is_allowlisted = true;
+        inputs.passes_ai_gate = false;
+        inputs.below_severity_threshold = true;
+
+        assert_eq!(
+            decide_pre_ai_guard(inputs),
+            PreAiGuardDecision::SkipAllowlisted
+        );
+    }
+
+    #[test]
+    fn decide_pre_ai_guard_returns_skip_below_severity_when_min_severity_dominates() {
+        // Invariant: below-min-severity incidents must route to the dedicated noise-gate branch.
+        let mut inputs = default_guard_inputs();
+        inputs.passes_ai_gate = false;
+        inputs.below_severity_threshold = true;
+
+        assert_eq!(
+            decide_pre_ai_guard(inputs),
+            PreAiGuardDecision::SkipBelowSeverity
+        );
+    }
+
+    #[test]
+    fn decide_pre_ai_guard_returns_skip_private_or_blocked_for_non_severity_gate_failures() {
+        // Invariant: AI-gate failures unrelated to min severity map to private/already-blocked skips.
+        let mut inputs = default_guard_inputs();
+        inputs.passes_ai_gate = false;
+        inputs.below_severity_threshold = false;
+
+        assert_eq!(
+            decide_pre_ai_guard(inputs),
+            PreAiGuardDecision::SkipPrivateOrBlocked
+        );
+    }
+
+    #[test]
+    fn decide_pre_ai_guard_returns_skip_decision_cooldown_after_gate_pass() {
+        // Invariant: cooldown must suppress repeated AI decisions when earlier gates already passed.
+        let mut inputs = default_guard_inputs();
+        inputs.in_decision_cooldown = true;
+
+        assert_eq!(
+            decide_pre_ai_guard(inputs),
+            PreAiGuardDecision::SkipDecisionCooldown
+        );
+    }
+
+    #[test]
+    fn decide_pre_ai_guard_returns_skip_ai_call_budget_when_limit_reached() {
+        // Invariant: per-tick AI call budgets must defer additional incidents to the next tick.
+        let mut inputs = default_guard_inputs();
+        inputs.ai_calls_this_tick = 3;
+        inputs.max_ai_calls_per_tick = 3;
+
+        assert_eq!(
+            decide_pre_ai_guard(inputs),
+            PreAiGuardDecision::SkipAiCallBudget
+        );
+    }
+
+    #[test]
+    fn decide_pre_ai_guard_returns_proceed_when_all_guards_pass() {
+        // Invariant: incidents should proceed only when every pre-AI guard check passes.
+        let inputs = default_guard_inputs();
+
+        assert_eq!(decide_pre_ai_guard(inputs), PreAiGuardDecision::Proceed);
+    }
 }


### PR DESCRIPTION
Closes #151.

### Tick-Decision Table (Before)
```text
evaluate_pre_ai_flow (inline guard chain)
  1) pipeline-test tag                         -> PipelineTestHandled
  2) neural_anomaly / host_drift detector      -> SkipHandled
  3) AI disabled                               -> SkipHandled
  4) allowlisted IP/user                       -> SkipAllowlisted
  5) AI gate fails:
     - below min severity                      -> SkipBelowSeverity (noise gate path)
     - otherwise (private/already blocked)     -> SkipHandled
  6) decision cooldown active                  -> SkipHandled
  7) max_ai_calls_per_tick reached             -> SkipHandled
  8) else                                      -> Proceed
```

### Tick-Decision Table (After)
```text
evaluate_pre_ai_flow (orchestration + side effects)
  └─ decide_pre_ai_guard(inputs) [pure helper]
       inputs = {
         is_pipeline_test,
         is_advisory_detector,
         ai_enabled,
         is_allowlisted,
         passes_ai_gate,
         below_severity_threshold,
         in_decision_cooldown,
         ai_calls_this_tick,
         max_ai_calls_per_tick
       }
       output = {
         PipelineTestHandled,
         SkipAdvisoryDetector,
         SkipAiDisabled,
         SkipAllowlisted,
         SkipBelowSeverity,
         SkipPrivateOrBlocked,
         SkipDecisionCooldown,
         SkipAiCallBudget,
         Proceed
       }

  mapping keeps runtime behavior unchanged:
  helper output -> existing PreAiFlowDecision + existing logs + pipeline-test decision write
```

### Branches Pinned By Tests
| Test | Branch pinned |
| --- | --- |
| `decide_pre_ai_guard_pipeline_test_has_highest_priority` | pipeline-test short-circuit precedence over all later guards |
| `decide_pre_ai_guard_advisory_detector_short_circuits_ai_disabled` | advisory detector short-circuit ordering |
| `decide_pre_ai_guard_skips_when_ai_is_disabled` | AI-disabled skip |
| `decide_pre_ai_guard_allowlist_takes_precedence_over_ai_gate_outcome` | allowlist skip precedence over AI gate outcomes |
| `decide_pre_ai_guard_returns_skip_below_severity_when_min_severity_dominates` | below-severity/noise-gate branch |
| `decide_pre_ai_guard_returns_skip_private_or_blocked_for_non_severity_gate_failures` | private-IP/already-blocked branch |
| `decide_pre_ai_guard_returns_skip_decision_cooldown_after_gate_pass` | decision cooldown skip |
| `decide_pre_ai_guard_returns_skip_ai_call_budget_when_limit_reached` | per-tick AI budget/rate-limit skip |
| `decide_pre_ai_guard_returns_proceed_when_all_guards_pass` | full pass-through to Proceed |

### Validation
- `cargo test --workspace`
- `make check`
- `make scenario-qa`
