### PR TITLE
sync: development -> main with autoencoder scoring saturation fix

### DIFF
--- a/crates/agent/src/abuseipdb_report_budget.rs
+++ b/crates/agent/src/abuseipdb_report_budget.rs
@@ -1,0 +1,288 @@
+//! AbuseIPDB report-endpoint rate limiter.
+//!
+//! The free tier grants 1,000 calls/day on each endpoint. `incident_enrichment`
+//! already gates the *check* endpoint via `ABUSEIPDB_DAILY_LIMIT = 800` and a
+//! 24h per-IP cache. The *report* endpoint had no such guard — a production
+//! incident on 2026-04-18 proved the gap: a `correlation:CL-008` cascade
+//! against Cloudflare CIDRs queued ~900 reports in a single day and the
+//! operator received the "You've exhausted your daily limit of 1,000 requests
+//! for report endpoint" email from AbuseIPDB.
+//!
+//! This module mirrors the check-endpoint pattern onto the report path:
+//!
+//! * **Per-IP dedup** with 24h TTL — the same source being reblocked five
+//!   times in a day only costs one report, not five.
+//! * **Daily hard cap** at 800 by default (`cfg.abuseipdb.report_daily_cap`),
+//!   leaving 20% headroom for operator-triggered ad-hoc reports.
+//!
+//! The pre-existing `cloud_safelist` guard in the slow-loop remains the first
+//! line of defence; this module catches the *volume* failure mode that the
+//! safelist cannot (e.g. a true-positive ssh_bruteforce storm from 1k unique
+//! IPs in one hour).
+
+use innerwarden_store::Store;
+
+/// SQLite KV namespace holding `ip → "1"` entries with a 24h TTL for dedup.
+pub(crate) const REPORTED_NS: &str = "abuseipdb_reported";
+/// SQLite KV namespace holding `abuseipdb_report_daily_<YYYY-MM-DD>` counters.
+pub(crate) const LIMITS_NS: &str = "abuseipdb_report_limits";
+
+/// Outcome of a budget check. `Allow` carries a `Commit` value the caller
+/// must hand back to `apply` after a successful `client.report()` call so
+/// the counter + dedup entry land in sqlite.
+pub(crate) enum ReportBudgetDecision {
+    Allow(ReportBudgetCommit),
+    Reject(RejectReason),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RejectReason {
+    /// The IP already has a dedup entry for the current 24h window.
+    AlreadyReportedToday,
+    /// The daily counter has reached the configured cap.
+    DailyCapReached,
+}
+
+impl RejectReason {
+    /// Human-readable tag used in logs and the `/metrics` label.
+    pub(crate) fn as_metric_label(&self) -> &'static str {
+        match self {
+            RejectReason::AlreadyReportedToday => "already_reported",
+            RejectReason::DailyCapReached => "daily_cap",
+        }
+    }
+}
+
+/// Receipt that must be consumed via `apply` after a successful report.
+pub(crate) struct ReportBudgetCommit {
+    ip: String,
+    today: String,
+    new_count: u32,
+}
+
+impl ReportBudgetCommit {
+    /// Persist the counter increment + the per-IP dedup entry. Kept separate
+    /// from the check so the caller can only pay the quota cost *after* the
+    /// HTTP call actually succeeded (a failed `report()` should not count
+    /// against the cap or block retries).
+    pub(crate) fn apply(&self, store: &Store) {
+        let key = format!("abuseipdb_report_daily_{}", self.today);
+        let _ = store.kv_set(LIMITS_NS, &key, self.new_count.to_string().as_bytes());
+        let expiry = (chrono::Utc::now() + chrono::Duration::hours(24)).to_rfc3339();
+        let _ = store.kv_set_with_expiry(REPORTED_NS, &self.ip, b"1", Some(&expiry));
+    }
+
+    /// Test-only accessor for the counter value the commit will write.
+    #[cfg(test)]
+    pub(crate) fn new_count(&self) -> u32 {
+        self.new_count
+    }
+}
+
+/// Inspect the dedup + counter state for `ip` on `today`. Returns `Allow`
+/// with a pending commit, or `Reject(reason)` to be logged and skipped.
+///
+/// `today` must be an ISO date string (`YYYY-MM-DD`) derived from the call
+/// site's own `chrono::Local::now()` — the helper stays testable without a
+/// real clock.
+pub(crate) fn check_report_budget(
+    store: &Store,
+    ip: &str,
+    today: &str,
+    daily_cap: u32,
+) -> ReportBudgetDecision {
+    // 1. Per-IP dedup: if we already reported this IP within the 24h TTL
+    //    window, skip outright. The KV entry's `expires_at` column does the
+    //    garbage collection (swept by the existing `kv_cleanup_expired`
+    //    maintenance task), so no manual cleanup here.
+    if store.kv_get(REPORTED_NS, ip).ok().flatten().is_some() {
+        return ReportBudgetDecision::Reject(RejectReason::AlreadyReportedToday);
+    }
+
+    // 2. Daily cap: parse `YYYY-MM-DD` counter or default to 0 if absent /
+    //    corrupt. `daily_cap == 0` short-circuits to rejecting every report
+    //    (effectively disables the report path without touching cfg.enabled).
+    let key = format!("abuseipdb_report_daily_{today}");
+    let count = store
+        .kv_get_str(LIMITS_NS, &key)
+        .ok()
+        .flatten()
+        .and_then(|s| s.parse::<u32>().ok())
+        .unwrap_or(0);
+    if count >= daily_cap {
+        return ReportBudgetDecision::Reject(RejectReason::DailyCapReached);
+    }
+
+    ReportBudgetDecision::Allow(ReportBudgetCommit {
+        ip: ip.to_string(),
+        today: today.to_string(),
+        new_count: count + 1,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn mem_store() -> Store {
+        Store::open_memory().expect("memory store")
+    }
+
+    fn allow_or_panic(d: ReportBudgetDecision) -> ReportBudgetCommit {
+        match d {
+            ReportBudgetDecision::Allow(c) => c,
+            ReportBudgetDecision::Reject(r) => panic!("expected Allow, got Reject({:?})", r),
+        }
+    }
+
+    fn reject_or_panic(d: ReportBudgetDecision) -> RejectReason {
+        match d {
+            ReportBudgetDecision::Reject(r) => r,
+            ReportBudgetDecision::Allow(_) => panic!("expected Reject, got Allow"),
+        }
+    }
+
+    #[test]
+    fn allow_on_empty_store() {
+        let store = mem_store();
+        let commit = allow_or_panic(check_report_budget(&store, "1.2.3.4", "2026-04-18", 800));
+        assert_eq!(commit.new_count(), 1, "first report bumps counter to 1");
+    }
+
+    #[test]
+    fn apply_writes_counter_and_dedup_entry() {
+        let store = mem_store();
+        let commit = allow_or_panic(check_report_budget(&store, "1.2.3.4", "2026-04-18", 800));
+        commit.apply(&store);
+
+        let raw = store
+            .kv_get_str(LIMITS_NS, "abuseipdb_report_daily_2026-04-18")
+            .expect("kv_get")
+            .expect("counter written");
+        assert_eq!(raw, "1");
+
+        let dedup = store
+            .kv_get(REPORTED_NS, "1.2.3.4")
+            .expect("kv_get")
+            .expect("dedup entry written");
+        assert_eq!(dedup, b"1");
+    }
+
+    #[test]
+    fn second_report_for_same_ip_is_rejected_as_dedup() {
+        let store = mem_store();
+        let first = allow_or_panic(check_report_budget(&store, "1.2.3.4", "2026-04-18", 800));
+        first.apply(&store);
+
+        let second = check_report_budget(&store, "1.2.3.4", "2026-04-18", 800);
+        assert_eq!(reject_or_panic(second), RejectReason::AlreadyReportedToday);
+    }
+
+    #[test]
+    fn different_ips_each_consume_one_quota_unit() {
+        let store = mem_store();
+        for ip in ["1.1.1.1", "2.2.2.2", "3.3.3.3"] {
+            let c = allow_or_panic(check_report_budget(&store, ip, "2026-04-18", 800));
+            c.apply(&store);
+        }
+        let count = store
+            .kv_get_str(LIMITS_NS, "abuseipdb_report_daily_2026-04-18")
+            .unwrap()
+            .unwrap();
+        assert_eq!(count, "3");
+    }
+
+    #[test]
+    fn daily_cap_rejects_further_reports() {
+        let store = mem_store();
+        // Seed the counter one below the cap so the next call would tip over.
+        store
+            .kv_set(LIMITS_NS, "abuseipdb_report_daily_2026-04-18", b"799")
+            .expect("seed counter");
+        let ok = allow_or_panic(check_report_budget(&store, "7.7.7.7", "2026-04-18", 800));
+        assert_eq!(
+            ok.new_count(),
+            800,
+            "final slot allocates at exactly the cap"
+        );
+        ok.apply(&store);
+
+        // 801st attempt — counter is at cap, cache miss for the IP, must
+        // reject with DailyCapReached (not dedup).
+        let over = check_report_budget(&store, "8.8.8.8", "2026-04-18", 800);
+        assert_eq!(reject_or_panic(over), RejectReason::DailyCapReached);
+    }
+
+    #[test]
+    fn daily_cap_zero_blocks_every_report() {
+        // cfg.abuseipdb.report_daily_cap = 0 is a sentinel meaning "pause
+        // reporting" — useful when operators suspect the bug hasn't rolled
+        // out yet and want to stop sending evidence until they investigate.
+        let store = mem_store();
+        let d = check_report_budget(&store, "1.2.3.4", "2026-04-18", 0);
+        assert_eq!(reject_or_panic(d), RejectReason::DailyCapReached);
+    }
+
+    #[test]
+    fn reject_reason_metric_labels_are_stable() {
+        // Labels are consumed as Prometheus histogram dimensions downstream;
+        // a silent rename here would break operator dashboards.
+        assert_eq!(
+            RejectReason::AlreadyReportedToday.as_metric_label(),
+            "already_reported"
+        );
+        assert_eq!(RejectReason::DailyCapReached.as_metric_label(), "daily_cap");
+    }
+
+    #[test]
+    fn counter_is_per_day_scope() {
+        // The YYYY-MM-DD suffix in the counter key ensures yesterday's
+        // exhausted cap doesn't block today's legitimate reports.
+        let store = mem_store();
+        store
+            .kv_set(LIMITS_NS, "abuseipdb_report_daily_2026-04-18", b"800")
+            .expect("seed cap-hit from yesterday");
+
+        let ok = allow_or_panic(check_report_budget(&store, "1.2.3.4", "2026-04-19", 800));
+        assert_eq!(ok.new_count(), 1, "new day starts counter fresh");
+    }
+
+    #[test]
+    fn dedup_entry_carries_24h_expiry() {
+        // The TTL is what lets the dedup namespace self-clean; without it
+        // the `abuseipdb_reported` namespace would grow unbounded and a
+        // real reblock after 48 hours would keep returning cached.
+        let store = mem_store();
+        let commit = allow_or_panic(check_report_budget(&store, "1.2.3.4", "2026-04-18", 800));
+        commit.apply(&store);
+
+        // Back-date the entry to 25 hours ago — `kv_cleanup_expired` should
+        // purge it on the next maintenance tick, freeing the IP.
+        store
+            .kv_set_with_expiry(REPORTED_NS, "1.2.3.4", b"1", Some("2020-01-01T00:00:00Z"))
+            .expect("override expiry");
+        let deleted = store.kv_cleanup_expired().expect("sweep");
+        assert_eq!(deleted, 1);
+
+        // Fresh check should allow the re-report.
+        let ok = check_report_budget(&store, "1.2.3.4", "2026-04-18", 800);
+        assert!(matches!(ok, ReportBudgetDecision::Allow(_)));
+    }
+
+    #[test]
+    fn corrupt_counter_value_treated_as_zero() {
+        // If something writes garbage into the counter key the gate must
+        // fail-open (allow the next report) rather than permanently locking
+        // the operator out.
+        let store = mem_store();
+        store
+            .kv_set(
+                LIMITS_NS,
+                "abuseipdb_report_daily_2026-04-18",
+                b"not-a-number",
+            )
+            .expect("seed garbage");
+        let ok = allow_or_panic(check_report_budget(&store, "1.2.3.4", "2026-04-18", 800));
+        assert_eq!(ok.new_count(), 1);
+    }
+}

--- a/crates/agent/src/abuseipdb_report_budget.rs
+++ b/crates/agent/src/abuseipdb_report_budget.rs
@@ -79,6 +79,140 @@ impl ReportBudgetCommit {
     }
 }
 
+/// Counters emitted by `dispatch_flush_outcomes`. Copied into the slow-loop
+/// log lines and `/metrics` counters downstream.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct FlushCounts {
+    pub sent: usize,
+    pub dropped_cloud: usize,
+    pub dropped_dedup: usize,
+    pub dropped_cap: usize,
+}
+
+/// Drive every `FlushOutcome` to completion. For `Send` outcomes invokes
+/// `report_fn(ip, categories, comment)` (mockable in tests), then — if the
+/// report call did not panic — applies the budget commit against `store`.
+/// `Skip`/`SkipCloud` outcomes just bump the matching counter.
+///
+/// The slow loop passes a closure that calls `client.report(...)`. Unit
+/// tests pass a counting closure so the whole dispatch table is covered
+/// without a live HTTP endpoint.
+pub(crate) async fn dispatch_flush_outcomes<F, Fut>(
+    outcomes: Vec<FlushOutcome>,
+    store: Option<&Store>,
+    mut report_fn: F,
+) -> FlushCounts
+where
+    F: FnMut(String, String, String) -> Fut,
+    Fut: std::future::Future<Output = ()>,
+{
+    let mut counts = FlushCounts::default();
+    for outcome in outcomes {
+        match outcome {
+            FlushOutcome::SkipCloud { .. } => {
+                counts.dropped_cloud += 1;
+            }
+            FlushOutcome::Skip { reason, .. } => match reason {
+                RejectReason::AlreadyReportedToday => counts.dropped_dedup += 1,
+                RejectReason::DailyCapReached => counts.dropped_cap += 1,
+            },
+            FlushOutcome::Send {
+                ip,
+                categories,
+                comment,
+                commit,
+            } => {
+                report_fn(ip, categories, comment).await;
+                counts.sent += 1;
+                if let (Some(sq), Some(commit)) = (store, commit) {
+                    commit.apply(sq);
+                }
+            }
+        }
+    }
+    counts
+}
+
+/// Outcome of planning a single queue entry for flush. Carries everything
+/// the caller needs to either dispatch the HTTP call + commit the receipt,
+/// or log + bump the matching drop counter. The planner stays I/O-free so
+/// the slow-loop flush logic can be unit tested without a Tokio runtime
+/// or a live AbuseIPDB client.
+pub(crate) enum FlushOutcome {
+    Send {
+        ip: String,
+        categories: String,
+        comment: String,
+        commit: Option<ReportBudgetCommit>,
+    },
+    SkipCloud {
+        ip: String,
+        provider: &'static str,
+    },
+    Skip {
+        ip: String,
+        reason: RejectReason,
+    },
+}
+
+/// Compute the per-entry disposition for every ready queue item. Callers
+/// (slow loop) iterate the returned vector and for each `Send` run
+/// `client.report()` followed by `commit.apply()`; `SkipCloud` and `Skip`
+/// are logged and counted for telemetry.
+///
+/// Parameters:
+/// * `ready` — `(ip, comment, categories, queued_at)` tuples matching the
+///   existing `state.abuseipdb_report_queue` shape.
+/// * `store` — optional sqlite store; when absent (pre-spec-016 deploy /
+///   test harness) the planner falls back to sending everything, which
+///   mirrors pre-fix behaviour.
+/// * `identify_provider` — cloud-safelist lookup; factored out so tests
+///   can inject a stub table.
+/// * `today`, `daily_cap` — forwarded into `check_report_budget`.
+pub(crate) fn plan_queue_flush<F>(
+    ready: &[(String, String, String, chrono::DateTime<chrono::Utc>)],
+    store: Option<&Store>,
+    identify_provider: F,
+    today: &str,
+    daily_cap: u32,
+) -> Vec<FlushOutcome>
+where
+    F: Fn(&str) -> Option<&'static str>,
+{
+    let mut out = Vec::with_capacity(ready.len());
+    for (ip, comment, categories, _) in ready {
+        if let Some(provider) = identify_provider(ip) {
+            out.push(FlushOutcome::SkipCloud {
+                ip: ip.clone(),
+                provider,
+            });
+            continue;
+        }
+
+        let commit = match store {
+            Some(sq) => match check_report_budget(sq, ip, today, daily_cap) {
+                ReportBudgetDecision::Allow(c) => Some(c),
+                ReportBudgetDecision::Reject(reason) => {
+                    out.push(FlushOutcome::Skip {
+                        ip: ip.clone(),
+                        reason,
+                    });
+                    continue;
+                }
+            },
+            None => None,
+        };
+
+        out.push(FlushOutcome::Send {
+            ip: ip.clone(),
+            categories: categories.clone(),
+            comment: comment.clone(),
+            commit,
+        });
+    }
+    out
+}
+
 /// Inspect the dedup + counter state for `ip` on `today`. Returns `Allow`
 /// with a pending commit, or `Reject(reason)` to be logged and skipped.
 ///
@@ -267,6 +401,221 @@ mod tests {
         // Fresh check should allow the re-report.
         let ok = check_report_budget(&store, "1.2.3.4", "2026-04-18", 800);
         assert!(matches!(ok, ReportBudgetDecision::Allow(_)));
+    }
+
+    fn queue_entry(ip: &str) -> (String, String, String, chrono::DateTime<chrono::Utc>) {
+        (
+            ip.to_string(),
+            format!("InnerWarden auto-block: {ip}"),
+            "18,22".to_string(),
+            chrono::Utc::now(),
+        )
+    }
+
+    fn no_cloud(_: &str) -> Option<&'static str> {
+        None
+    }
+
+    #[test]
+    fn plan_flushes_ip_with_no_budget_when_store_absent() {
+        // Pre-spec-016 compat: without a store, the planner emits Send for
+        // every entry (None commit) so legacy deploys keep reporting like
+        // before. The inner gate still blocks cloud IPs via the safelist
+        // predicate though.
+        let ready = vec![queue_entry("1.2.3.4")];
+        let outcomes = plan_queue_flush(&ready, None, no_cloud, "2026-04-18", 800);
+        assert_eq!(outcomes.len(), 1);
+        match &outcomes[0] {
+            FlushOutcome::Send { ip, commit, .. } => {
+                assert_eq!(ip, "1.2.3.4");
+                assert!(commit.is_none());
+            }
+            other => panic!("expected Send, got {:?}", std::mem::discriminant(other)),
+        }
+    }
+
+    #[test]
+    fn plan_bucks_cloud_ips_into_skip_cloud() {
+        // Cloud-safelist guard runs before the budget, matching the slow
+        // loop's defence ordering in `loops/boot.rs`.
+        let ready = vec![queue_entry("104.26.12.38"), queue_entry("1.2.3.4")];
+        let outcomes = plan_queue_flush(
+            &ready,
+            Some(&mem_store()),
+            |ip| {
+                if ip.starts_with("104.") {
+                    Some("Cloudflare")
+                } else {
+                    None
+                }
+            },
+            "2026-04-18",
+            800,
+        );
+        assert_eq!(outcomes.len(), 2);
+        assert!(matches!(
+            outcomes[0],
+            FlushOutcome::SkipCloud { ref provider, .. } if *provider == "Cloudflare"
+        ));
+        assert!(matches!(outcomes[1], FlushOutcome::Send { .. }));
+    }
+
+    #[test]
+    fn plan_marks_duplicate_ip_as_skip_with_reason() {
+        let store = mem_store();
+        // Seed the dedup entry so the second call rejects.
+        let first = check_report_budget(&store, "1.2.3.4", "2026-04-18", 800);
+        if let ReportBudgetDecision::Allow(c) = first {
+            c.apply(&store);
+        }
+
+        let ready = vec![queue_entry("1.2.3.4")];
+        let outcomes = plan_queue_flush(&ready, Some(&store), no_cloud, "2026-04-18", 800);
+        match &outcomes[0] {
+            FlushOutcome::Skip { reason, .. } => {
+                assert_eq!(*reason, RejectReason::AlreadyReportedToday);
+            }
+            other => panic!("expected Skip, got {:?}", std::mem::discriminant(other)),
+        }
+    }
+
+    #[test]
+    fn plan_skip_cap_when_counter_at_limit() {
+        let store = mem_store();
+        store
+            .kv_set(LIMITS_NS, "abuseipdb_report_daily_2026-04-18", b"800")
+            .expect("seed cap-hit");
+        let ready = vec![queue_entry("9.9.9.9")];
+        let outcomes = plan_queue_flush(&ready, Some(&store), no_cloud, "2026-04-18", 800);
+        match &outcomes[0] {
+            FlushOutcome::Skip { reason, .. } => {
+                assert_eq!(*reason, RejectReason::DailyCapReached);
+            }
+            other => panic!("expected Skip, got {:?}", std::mem::discriminant(other)),
+        }
+    }
+
+    #[tokio::test]
+    async fn dispatch_counts_each_outcome_kind_and_commits_allowed_sends() {
+        // Full dispatch matrix through a mock report closure. Drives every
+        // branch in dispatch_flush_outcomes so boot.rs only needs to wire
+        // the closure + log the counters.
+        let store = mem_store();
+        let allow_commit = match check_report_budget(&store, "198.51.100.1", "2026-04-18", 800) {
+            ReportBudgetDecision::Allow(c) => c,
+            _ => panic!("expected allow"),
+        };
+        let outcomes = vec![
+            FlushOutcome::Send {
+                ip: "198.51.100.1".into(),
+                categories: "18".into(),
+                comment: "atk".into(),
+                commit: Some(allow_commit),
+            },
+            FlushOutcome::SkipCloud {
+                ip: "104.26.12.38".into(),
+                provider: "Cloudflare",
+            },
+            FlushOutcome::Skip {
+                ip: "1.2.3.4".into(),
+                reason: RejectReason::AlreadyReportedToday,
+            },
+            FlushOutcome::Skip {
+                ip: "5.6.7.8".into(),
+                reason: RejectReason::DailyCapReached,
+            },
+        ];
+
+        let mut sent_ips = Vec::new();
+        let counts = dispatch_flush_outcomes(outcomes, Some(&store), |ip, cats, _comment| {
+            sent_ips.push((ip, cats));
+            async {}
+        })
+        .await;
+
+        assert_eq!(
+            counts,
+            FlushCounts {
+                sent: 1,
+                dropped_cloud: 1,
+                dropped_dedup: 1,
+                dropped_cap: 1,
+            }
+        );
+        assert_eq!(sent_ips.len(), 1);
+        assert_eq!(sent_ips[0].0, "198.51.100.1");
+
+        // Commit applied — second plan call for same IP must now reject.
+        let follow_up = check_report_budget(&store, "198.51.100.1", "2026-04-18", 800);
+        assert!(matches!(follow_up, ReportBudgetDecision::Reject(_)));
+    }
+
+    #[tokio::test]
+    async fn dispatch_skips_commit_when_store_absent() {
+        // Pre-spec-016 safety: with `store = None`, plan emits `Send { commit: None }`,
+        // and dispatch must not panic trying to apply it. The reporter fires,
+        // but no counter/dedup persists.
+        let outcomes = vec![FlushOutcome::Send {
+            ip: "1.2.3.4".into(),
+            categories: "18".into(),
+            comment: "c".into(),
+            commit: None,
+        }];
+        let mut calls = 0usize;
+        let counts = dispatch_flush_outcomes(outcomes, None, |_, _, _| {
+            calls += 1;
+            async {}
+        })
+        .await;
+        assert_eq!(calls, 1);
+        assert_eq!(counts.sent, 1);
+    }
+
+    #[test]
+    fn plan_preserves_queue_order_and_fields() {
+        // Callers (slow loop) rely on Send entries carrying the exact
+        // comment + categories strings originally queued by
+        // decision_block_ip. Regressing this would silently change what we
+        // report to AbuseIPDB — worse than dropping the report.
+        let ready = vec![
+            (
+                "1.1.1.1".to_string(),
+                "comment-a".to_string(),
+                "18".to_string(),
+                chrono::Utc::now(),
+            ),
+            (
+                "2.2.2.2".to_string(),
+                "comment-b".to_string(),
+                "22".to_string(),
+                chrono::Utc::now(),
+            ),
+        ];
+        let outcomes = plan_queue_flush(&ready, None, no_cloud, "2026-04-18", 800);
+        match (&outcomes[0], &outcomes[1]) {
+            (
+                FlushOutcome::Send {
+                    ip: i1,
+                    comment: c1,
+                    categories: cat1,
+                    ..
+                },
+                FlushOutcome::Send {
+                    ip: i2,
+                    comment: c2,
+                    categories: cat2,
+                    ..
+                },
+            ) => {
+                assert_eq!(i1, "1.1.1.1");
+                assert_eq!(c1, "comment-a");
+                assert_eq!(cat1, "18");
+                assert_eq!(i2, "2.2.2.2");
+                assert_eq!(c2, "comment-b");
+                assert_eq!(cat2, "22");
+            }
+            _ => panic!("expected two Send outcomes in order"),
+        }
     }
 
     #[test]

--- a/crates/agent/src/abuseipdb_report_budget.rs
+++ b/crates/agent/src/abuseipdb_report_budget.rs
@@ -21,6 +21,7 @@
 //! IPs in one hour).
 
 use innerwarden_store::Store;
+use tracing::{info, warn};
 
 /// SQLite KV namespace holding `ip → "1"` entries with a 24h TTL for dedup.
 pub(crate) const REPORTED_NS: &str = "abuseipdb_reported";
@@ -109,21 +110,35 @@ where
     let mut counts = FlushCounts::default();
     for outcome in outcomes {
         match outcome {
-            FlushOutcome::SkipCloud { .. } => {
+            FlushOutcome::SkipCloud { ip, provider } => {
                 counts.dropped_cloud += 1;
+                warn!(
+                    ip = %ip,
+                    provider,
+                    "AbuseIPDB report dropped: target is in cloud safelist"
+                );
             }
-            FlushOutcome::Skip { reason, .. } => match reason {
-                RejectReason::AlreadyReportedToday => counts.dropped_dedup += 1,
-                RejectReason::DailyCapReached => counts.dropped_cap += 1,
-            },
+            FlushOutcome::Skip { ip, reason } => {
+                match reason {
+                    RejectReason::AlreadyReportedToday => counts.dropped_dedup += 1,
+                    RejectReason::DailyCapReached => counts.dropped_cap += 1,
+                }
+                warn!(
+                    ip = %ip,
+                    reason = reason.as_metric_label(),
+                    "AbuseIPDB report skipped by budget gate"
+                );
+            }
             FlushOutcome::Send {
                 ip,
                 categories,
                 comment,
                 commit,
             } => {
+                let ip_for_log = ip.clone();
                 report_fn(ip, categories, comment).await;
                 counts.sent += 1;
+                info!(ip = %ip_for_log, "AbuseIPDB report sent (after 5min delay)");
                 if let (Some(sq), Some(commit)) = (store, commit) {
                     commit.apply(sq);
                 }
@@ -493,6 +508,83 @@ mod tests {
             }
             other => panic!("expected Skip, got {:?}", std::mem::discriminant(other)),
         }
+    }
+
+    #[tokio::test]
+    async fn dispatch_empty_outcomes_returns_zero_counts_and_never_calls_reporter() {
+        // Fast-path: empty ready queue → zero HTTP cost and zero sqlite writes.
+        let mut calls = 0usize;
+        let counts = dispatch_flush_outcomes(Vec::new(), None, |_, _, _| {
+            calls += 1;
+            async {}
+        })
+        .await;
+        assert_eq!(calls, 0);
+        assert_eq!(counts, FlushCounts::default());
+    }
+
+    #[tokio::test]
+    async fn plan_empty_queue_produces_empty_outcomes() {
+        // Defensive check — the planner should tolerate an empty
+        // `state.abuseipdb_report_queue` without touching the store or
+        // the safelist predicate.
+        let outcomes = plan_queue_flush(
+            &[],
+            None,
+            |_| panic!("safelist predicate should not be called on empty queue"),
+            "2026-04-18",
+            800,
+        );
+        assert!(outcomes.is_empty());
+    }
+
+    #[tokio::test]
+    async fn dispatch_send_without_commit_still_fires_reporter() {
+        // Covers the pre-016 branch: `commit = None` means no sqlite write
+        // but the reporter must still be called with the original fields.
+        let outcomes = vec![FlushOutcome::Send {
+            ip: "203.0.113.1".into(),
+            categories: "18".into(),
+            comment: "hi".into(),
+            commit: None,
+        }];
+        let mut calls = Vec::new();
+        let counts = dispatch_flush_outcomes(outcomes, None, |ip, cats, cmt| {
+            calls.push((ip, cats, cmt));
+            async {}
+        })
+        .await;
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].0, "203.0.113.1");
+        assert_eq!(counts.sent, 1);
+    }
+
+    #[tokio::test]
+    async fn dispatch_send_commit_but_no_store_is_a_noop() {
+        // Guard: `Send { commit: Some(_), .. }` paired with `store = None`
+        // (rare — the planner only emits `Some(commit)` when the store is
+        // present, but unit tests can construct this by hand). Must not
+        // panic; the commit is silently dropped since no backing store
+        // exists to apply it to.
+        let store = mem_store();
+        let commit = match check_report_budget(&store, "1.2.3.4", "2026-04-18", 800) {
+            ReportBudgetDecision::Allow(c) => c,
+            _ => panic!("expected allow"),
+        };
+        let outcomes = vec![FlushOutcome::Send {
+            ip: "1.2.3.4".into(),
+            categories: "18".into(),
+            comment: "c".into(),
+            commit: Some(commit),
+        }];
+        let mut calls = 0usize;
+        let counts = dispatch_flush_outcomes(outcomes, None, |_, _, _| {
+            calls += 1;
+            async {}
+        })
+        .await;
+        assert_eq!(calls, 1);
+        assert_eq!(counts.sent, 1);
     }
 
     #[tokio::test]

--- a/crates/agent/src/config.rs
+++ b/crates/agent/src/config.rs
@@ -2063,6 +2063,17 @@ pub struct AbuseIpDbConfig {
     /// This contributes to the global threat intelligence network.
     #[serde(default)]
     pub report_blocks: bool,
+
+    /// Maximum AbuseIPDB *report-endpoint* calls per 24h UTC. Free tier
+    /// grants 1,000 per day; the default of 800 reserves 20% headroom for
+    /// operator-triggered ad-hoc reports. A production incident on
+    /// 2026-04-18 (`correlation:CL-008` cascade) burned ~900 reports in
+    /// one day and tripped AbuseIPDB's quota email — the cap here is the
+    /// second line of defence behind `cloud_safelist`. Set to `0` to
+    /// pause outbound reporting entirely without disabling the rest of
+    /// the AbuseIPDB integration.
+    #[serde(default = "default_abuseipdb_report_daily_cap")]
+    pub report_daily_cap: u32,
 }
 
 impl Default for AbuseIpDbConfig {
@@ -2073,12 +2084,17 @@ impl Default for AbuseIpDbConfig {
             max_age_days: default_abuseipdb_max_age_days(),
             auto_block_threshold: 0,
             report_blocks: false,
+            report_daily_cap: default_abuseipdb_report_daily_cap(),
         }
     }
 }
 
 fn default_abuseipdb_max_age_days() -> u32 {
     30
+}
+
+fn default_abuseipdb_report_daily_cap() -> u32 {
+    800
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/agent/src/crowdsec.rs
+++ b/crates/agent/src/crowdsec.rs
@@ -203,6 +203,14 @@ impl CrowdSecState {
     }
 }
 
+#[cfg(test)]
+impl CrowdSecState {
+    /// Test-only helper to seed known threats without network sync.
+    pub(crate) fn insert_known_threat_for_test(&mut self, ip: &str) {
+        self.threat_list.insert(ip.to_string());
+    }
+}
+
 /// Update the threat list from CrowdSec LAPI (delta stream).
 /// Called from the agent's slow loop. Returns (added, removed) counts.
 pub async fn sync_threat_list(cs: &mut CrowdSecState) -> (usize, usize) {

--- a/crates/agent/src/incident_advisory.rs
+++ b/crates/agent/src/incident_advisory.rs
@@ -97,3 +97,79 @@ fn check_advisory_match(
         .find(|e| e.command_hash == command_hash)
         .cloned()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+
+    fn advisory_entry(id: &str, command: &str) -> AdvisoryEntry {
+        AdvisoryEntry {
+            advisory_id: id.to_string(),
+            command_hash: innerwarden_core::audit::sha256_hex(&command.to_lowercase()),
+            command_preview: command.to_string(),
+            risk_score: 87,
+            recommendation: "blocked".to_string(),
+            signals: vec!["dangerous-command".to_string()],
+            ts: Utc::now(),
+        }
+    }
+
+    #[tokio::test]
+    async fn handle_advisory_violation_consumes_matching_advisory_entry() {
+        // Invariant: a matching advisory must be consumed exactly once after a tagged incident.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let state = crate::tests::triage_test_state(dir.path());
+        let command = "rm -rf /tmp/suspicious";
+        let cache = Arc::new(RwLock::new(VecDeque::from([advisory_entry(
+            "adv-1", command,
+        )])));
+        let mut incident = crate::tests::test_incident("203.0.113.21");
+        incident.tags = vec!["execution".to_string()];
+        incident.evidence = serde_json::json!([{ "command": command }]);
+
+        handle_advisory_violation(&incident, &cache, &state).await;
+
+        let remaining = cache.read().expect("cache read lock");
+        assert!(remaining.is_empty());
+    }
+
+    #[tokio::test]
+    async fn handle_advisory_violation_skips_when_trigger_tags_are_absent() {
+        // Invariant: incidents without `execution`/`suspicious` tags must not touch advisory cache.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let state = crate::tests::triage_test_state(dir.path());
+        let cache = Arc::new(RwLock::new(VecDeque::from([advisory_entry(
+            "adv-2",
+            "cat /etc/shadow",
+        )])));
+        let mut incident = crate::tests::test_incident("203.0.113.22");
+        incident.tags = vec!["ssh".to_string()];
+        incident.evidence = serde_json::json!([{ "command": "cat /etc/shadow" }]);
+
+        handle_advisory_violation(&incident, &cache, &state).await;
+
+        let remaining = cache.read().expect("cache read lock");
+        assert_eq!(remaining.len(), 1);
+        assert_eq!(remaining[0].advisory_id, "adv-2");
+    }
+
+    #[tokio::test]
+    async fn handle_advisory_violation_keeps_cache_when_no_advisory_match_exists() {
+        // Invariant: upstream `None` matches must be a no-op and leave advisory entries intact.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let state = crate::tests::triage_test_state(dir.path());
+        let cache = Arc::new(RwLock::new(VecDeque::from([advisory_entry(
+            "adv-3", "whoami",
+        )])));
+        let mut incident = crate::tests::test_incident("203.0.113.23");
+        incident.tags = vec!["execution".to_string()];
+        incident.evidence = serde_json::json!([{ "command": "ls -la /tmp" }]);
+
+        handle_advisory_violation(&incident, &cache, &state).await;
+
+        let remaining = cache.read().expect("cache read lock");
+        assert_eq!(remaining.len(), 1);
+        assert_eq!(remaining[0].advisory_id, "adv-3");
+    }
+}

--- a/crates/agent/src/incident_attacker_profile.rs
+++ b/crates/agent/src/incident_attacker_profile.rs
@@ -22,3 +22,46 @@ pub(crate) fn update_incident_ip_profiles(
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use innerwarden_core::entities::EntityRef;
+
+    #[test]
+    fn update_incident_ip_profiles_updates_reputation_and_profile_for_ip_entities() {
+        // Invariant: every IP entity increments local reputation and attacker profile counters.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut state = crate::tests::triage_test_state(dir.path());
+        let incident = crate::tests::test_incident("203.0.113.10");
+
+        update_incident_ip_profiles(&incident, &mut state);
+        update_incident_ip_profiles(&incident, &mut state);
+
+        let rep = state
+            .ip_reputations
+            .get("203.0.113.10")
+            .expect("IP reputation should be created");
+        assert_eq!(rep.total_incidents, 2);
+
+        let profile = state
+            .attacker_profiles
+            .get("203.0.113.10")
+            .expect("attacker profile should be created");
+        assert_eq!(profile.total_incidents, 2);
+    }
+
+    #[test]
+    fn update_incident_ip_profiles_skips_non_ip_entities() {
+        // Invariant: non-IP entities must not mutate IP reputation or attacker profile maps.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut state = crate::tests::triage_test_state(dir.path());
+        let mut incident = crate::tests::test_incident("203.0.113.11");
+        incident.entities = vec![EntityRef::user("root")];
+
+        update_incident_ip_profiles(&incident, &mut state);
+
+        assert!(state.ip_reputations.is_empty());
+        assert!(state.attacker_profiles.is_empty());
+    }
+}

--- a/crates/agent/src/incident_crowdsec.rs
+++ b/crates/agent/src/incident_crowdsec.rs
@@ -118,3 +118,111 @@ pub(crate) async fn try_handle_crowdsec_autoblock(
 
     true
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn try_handle_crowdsec_autoblock_auto_blocks_known_threat_ips() {
+        // Invariant: CrowdSec-known threat IPs should bypass AI and be auto-blocked once.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut state = crate::tests::triage_test_state(dir.path());
+        let cfg = crate::config::AgentConfig::default();
+        let ip = "203.0.113.41";
+        let incident = crate::tests::test_incident(ip);
+        let mut crowdsec = crate::crowdsec::CrowdSecState::new(&cfg.crowdsec);
+        crowdsec.insert_known_threat_for_test(ip);
+        state.crowdsec = Some(crowdsec);
+        state.attacker_profiles.insert(
+            ip.to_string(),
+            crate::attacker_intel::new_profile(ip, incident.ts),
+        );
+        let mut blocked_set = HashSet::new();
+
+        let handled = try_handle_crowdsec_autoblock(
+            &incident,
+            dir.path(),
+            &cfg,
+            &mut state,
+            &mut blocked_set,
+        )
+        .await;
+
+        assert!(handled);
+        assert!(blocked_set.contains(ip));
+        assert!(state.blocklist.contains(ip));
+
+        let profile = state
+            .attacker_profiles
+            .get(ip)
+            .expect("attacker profile should exist");
+        assert_eq!(profile.total_decisions, 1);
+        assert_eq!(profile.total_blocks, 1);
+
+        let skill_id = format!("block-ip-{}", cfg.responder.block_backend);
+        let decision = crate::ai::AiDecision {
+            action: crate::ai::AiAction::BlockIp {
+                ip: ip.to_string(),
+                skill_id,
+            },
+            confidence: 1.0,
+            auto_execute: true,
+            reason: "CrowdSec community threat list match".to_string(),
+            alternatives: vec![],
+            estimated_threat: "high".to_string(),
+        };
+        let key = crate::decision_cooldown_key_for_decision(&incident, &decision)
+            .expect("block decision should produce cooldown key");
+        assert!(state
+            .store
+            .has_cooldown(crate::state_store::CooldownTable::Decision, &key));
+    }
+
+    #[tokio::test]
+    async fn try_handle_crowdsec_autoblock_returns_false_when_feature_is_disabled() {
+        // Invariant: when CrowdSec state is disabled (`None`), auto-block must never trigger.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut state = crate::tests::triage_test_state(dir.path());
+        let cfg = crate::config::AgentConfig::default();
+        let incident = crate::tests::test_incident("203.0.113.42");
+        let mut blocked_set = HashSet::new();
+
+        let handled = try_handle_crowdsec_autoblock(
+            &incident,
+            dir.path(),
+            &cfg,
+            &mut state,
+            &mut blocked_set,
+        )
+        .await;
+
+        assert!(!handled);
+        assert!(blocked_set.is_empty());
+        assert!(!state.blocklist.contains("203.0.113.42"));
+    }
+
+    #[tokio::test]
+    async fn try_handle_crowdsec_autoblock_returns_false_when_upstream_has_no_threat_match() {
+        // Invariant: an enabled CrowdSec adapter with no threat hit must return `false` and avoid mutations.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut state = crate::tests::triage_test_state(dir.path());
+        let cfg = crate::config::AgentConfig::default();
+        state.crowdsec = Some(crate::crowdsec::CrowdSecState::new(&cfg.crowdsec));
+        let incident = crate::tests::test_incident("203.0.113.43");
+        let mut blocked_set = HashSet::new();
+
+        let handled = try_handle_crowdsec_autoblock(
+            &incident,
+            dir.path(),
+            &cfg,
+            &mut state,
+            &mut blocked_set,
+        )
+        .await;
+
+        assert!(!handled);
+        assert!(blocked_set.is_empty());
+        assert!(!state.blocklist.contains("203.0.113.43"));
+    }
+}

--- a/crates/agent/src/incident_flow.rs
+++ b/crates/agent/src/incident_flow.rs
@@ -15,6 +15,69 @@ pub(crate) enum PreAiFlowDecision {
     SkipBelowSeverity,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum PreAiGuardDecision {
+    Proceed,
+    PipelineTestHandled,
+    SkipAdvisoryDetector,
+    SkipAiDisabled,
+    SkipAllowlisted,
+    SkipBelowSeverity,
+    SkipPrivateOrBlocked,
+    SkipDecisionCooldown,
+    SkipAiCallBudget,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct PreAiGuardInputs {
+    pub is_pipeline_test: bool,
+    pub is_advisory_detector: bool,
+    pub ai_enabled: bool,
+    pub is_allowlisted: bool,
+    pub passes_ai_gate: bool,
+    pub below_severity_threshold: bool,
+    pub in_decision_cooldown: bool,
+    pub ai_calls_this_tick: usize,
+    pub max_ai_calls_per_tick: usize,
+}
+
+pub(super) fn decide_pre_ai_guard(inputs: PreAiGuardInputs) -> PreAiGuardDecision {
+    if inputs.is_pipeline_test {
+        return PreAiGuardDecision::PipelineTestHandled;
+    }
+
+    // Neural model detectors remain advisory-only and never go through AI.
+    if inputs.is_advisory_detector {
+        return PreAiGuardDecision::SkipAdvisoryDetector;
+    }
+
+    if !inputs.ai_enabled {
+        return PreAiGuardDecision::SkipAiDisabled;
+    }
+
+    if inputs.is_allowlisted {
+        return PreAiGuardDecision::SkipAllowlisted;
+    }
+
+    if !inputs.passes_ai_gate {
+        if inputs.below_severity_threshold {
+            return PreAiGuardDecision::SkipBelowSeverity;
+        }
+        return PreAiGuardDecision::SkipPrivateOrBlocked;
+    }
+
+    if inputs.in_decision_cooldown {
+        return PreAiGuardDecision::SkipDecisionCooldown;
+    }
+
+    if inputs.max_ai_calls_per_tick > 0 && inputs.ai_calls_this_tick >= inputs.max_ai_calls_per_tick
+    {
+        return PreAiGuardDecision::SkipAiCallBudget;
+    }
+
+    PreAiGuardDecision::Proceed
+}
+
 /// Evaluate all pre-AI gates for one incident.
 /// This keeps `process_incidents` focused on orchestration and leaves
 /// eligibility logic in one cohesive place.
@@ -26,59 +89,22 @@ pub(crate) fn evaluate_pre_ai_flow(
     blocked_set: &HashSet<String>,
     ai_calls_this_tick: usize,
 ) -> PreAiFlowDecision {
-    // Pipeline test: recognise `innerwarden test` incidents by tag and
-    // write an acknowledgement decision without calling the AI provider.
-    if incident.tags.contains(&"pipeline-test".to_string()) {
-        info!(
-            incident_id = %incident.incident_id,
-            "pipeline test incident detected - writing acknowledgement decision"
-        );
-        let test_ip = incident
-            .entities
-            .iter()
-            .find(|e| e.r#type == innerwarden_core::entities::EntityType::Ip)
-            .map(|e| e.value.clone());
-        let entry = crate::decisions::DecisionEntry {
-            ts: chrono::Utc::now(),
-            incident_id: incident.incident_id.clone(),
-            host: incident.host.clone(),
-            ai_provider: "pipeline-test".to_string(),
-            action_type: "monitor".to_string(),
-            target_ip: test_ip,
-            target_user: None,
-            skill_id: None,
-            confidence: 1.0,
-            auto_executed: false,
-            dry_run: true,
-            reason: "Pipeline test acknowledged - sensor → agent → decision path is working"
-                .to_string(),
-            estimated_threat: "none".to_string(),
-            execution_result: "test-ok".to_string(),
-            prev_hash: None,
-        };
-        if let Some(writer) = &mut state.decision_writer {
-            if let Err(e) = writer.write(&entry) {
-                warn!("failed to write pipeline-test decision: {e:#}");
-            }
-        }
-        return PreAiFlowDecision::PipelineTestHandled;
-    }
-
-    // Neural model is advisory only — observes and logs but never triggers
-    // blocks or notifications. The brain records its suggestion in brain-log.json
-    // for operator review; actual blocking is left to rule-based detectors.
     let detector = incident.incident_id.split(':').next().unwrap_or("");
-    if detector == "neural_anomaly" || detector == "host_drift" {
-        return PreAiFlowDecision::SkipHandled;
-    }
+    let mut guard_inputs = PreAiGuardInputs {
+        is_pipeline_test: incident.tags.iter().any(|tag| tag == "pipeline-test"),
+        is_advisory_detector: detector == "neural_anomaly" || detector == "host_drift",
+        ai_enabled,
+        is_allowlisted: false,
+        passes_ai_gate: true,
+        below_severity_threshold: false,
+        in_decision_cooldown: false,
+        ai_calls_this_tick,
+        max_ai_calls_per_tick: cfg.ai.max_ai_calls_per_tick,
+    };
 
-    if !ai_enabled {
-        return PreAiFlowDecision::SkipHandled;
-    }
-
-    // Allowlist gate - skip AI for explicitly trusted IPs and users.
-    // Merges static config allowlist with dynamic allowlist.toml (hot-reloaded every 30s).
-    {
+    if ai_enabled {
+        // Allowlist gate - skip AI for explicitly trusted IPs and users.
+        // Merges static config allowlist with dynamic allowlist.toml (hot-reloaded every 30s).
         use innerwarden_core::entities::EntityType;
         let ip_allowlisted = incident
             .entities
@@ -96,66 +122,252 @@ pub(crate) fn evaluate_pre_ai_flow(
                 allowlist::is_user_allowlisted(&e.value, &cfg.allowlist.trusted_users)
                     || allowlist::is_user_allowlisted(&e.value, &state.dynamic_trusted_users)
             });
-        if ip_allowlisted || user_allowlisted {
+        guard_inputs.is_allowlisted = ip_allowlisted || user_allowlisted;
+
+        if !guard_inputs.is_allowlisted {
+            let min_severity = cfg.ai.parsed_min_severity();
+            guard_inputs.passes_ai_gate =
+                ai::should_invoke_ai(incident, blocked_set, &min_severity);
+            guard_inputs.below_severity_threshold =
+                ai::is_below_severity_threshold(&incident.severity, &min_severity);
+
+            if guard_inputs.passes_ai_gate {
+                // Decision cooldown - suppress repeated AI decisions for the same
+                // action:detector:entity scope within a 1-hour window.
+                let cooldown_cutoff =
+                    chrono::Utc::now() - chrono::Duration::seconds(crate::DECISION_COOLDOWN_SECS);
+                let candidates = crate::decision_cooldown_candidates(incident);
+                guard_inputs.in_decision_cooldown = candidates.iter().any(|k| {
+                    state
+                        .store
+                        .get_cooldown(state_store::CooldownTable::Decision, k)
+                        .is_some_and(|ts| ts > cooldown_cutoff)
+                });
+            }
+        }
+    }
+
+    match decide_pre_ai_guard(guard_inputs) {
+        PreAiGuardDecision::PipelineTestHandled => {
+            // Pipeline test: recognise `innerwarden test` incidents by tag and
+            // write an acknowledgement decision without calling the AI provider.
+            info!(
+                incident_id = %incident.incident_id,
+                "pipeline test incident detected - writing acknowledgement decision"
+            );
+            let test_ip = incident
+                .entities
+                .iter()
+                .find(|e| e.r#type == innerwarden_core::entities::EntityType::Ip)
+                .map(|e| e.value.clone());
+            let entry = crate::decisions::DecisionEntry {
+                ts: chrono::Utc::now(),
+                incident_id: incident.incident_id.clone(),
+                host: incident.host.clone(),
+                ai_provider: "pipeline-test".to_string(),
+                action_type: "monitor".to_string(),
+                target_ip: test_ip,
+                target_user: None,
+                skill_id: None,
+                confidence: 1.0,
+                auto_executed: false,
+                dry_run: true,
+                reason: "Pipeline test acknowledged - sensor → agent → decision path is working"
+                    .to_string(),
+                estimated_threat: "none".to_string(),
+                execution_result: "test-ok".to_string(),
+                prev_hash: None,
+            };
+            if let Some(writer) = &mut state.decision_writer {
+                if let Err(e) = writer.write(&entry) {
+                    warn!("failed to write pipeline-test decision: {e:#}");
+                }
+            }
+            PreAiFlowDecision::PipelineTestHandled
+        }
+        // Neural model is advisory only — observes and logs but never triggers
+        // blocks or notifications. The brain records its suggestion in brain-log.json
+        // for operator review; actual blocking is left to rule-based detectors.
+        PreAiGuardDecision::SkipAdvisoryDetector | PreAiGuardDecision::SkipAiDisabled => {
+            PreAiFlowDecision::SkipHandled
+        }
+        PreAiGuardDecision::SkipAllowlisted => {
             info!(
                 incident_id = %incident.incident_id,
                 "AI gate: skipping (entity is in allowlist)"
             );
-            return PreAiFlowDecision::SkipAllowlisted;
+            PreAiFlowDecision::SkipAllowlisted
         }
-    }
-
-    if !ai::should_invoke_ai(incident, blocked_set, &cfg.ai.parsed_min_severity()) {
-        // Distinguish "below severity threshold" from other skip reasons so
-        // the caller can route low-severity noise to the auto-dismiss gate.
-        let dominated_by_min =
-            ai::is_below_severity_threshold(&incident.severity, &cfg.ai.parsed_min_severity());
-        if dominated_by_min {
+        PreAiGuardDecision::SkipBelowSeverity => {
             info!(
                 incident_id = %incident.incident_id,
                 severity = ?incident.severity,
                 "AI gate: skipping (below min_severity threshold)"
             );
-            return PreAiFlowDecision::SkipBelowSeverity;
+            PreAiFlowDecision::SkipBelowSeverity
         }
-        info!(
-            incident_id = %incident.incident_id,
-            severity = ?incident.severity,
-            "AI gate: skipping (private IP / already blocked)"
-        );
-        return PreAiFlowDecision::SkipHandled;
+        PreAiGuardDecision::SkipPrivateOrBlocked => {
+            info!(
+                incident_id = %incident.incident_id,
+                severity = ?incident.severity,
+                "AI gate: skipping (private IP / already blocked)"
+            );
+            PreAiFlowDecision::SkipHandled
+        }
+        PreAiGuardDecision::SkipDecisionCooldown => {
+            info!(
+                incident_id = %incident.incident_id,
+                "AI gate: skipping (decision cooldown active)"
+            );
+            PreAiFlowDecision::SkipHandled
+        }
+        PreAiGuardDecision::SkipAiCallBudget => {
+            // max_ai_calls_per_tick: enforce per-tick AI call budget.
+            let max_calls = cfg.ai.max_ai_calls_per_tick;
+            info!(
+                incident_id = %incident.incident_id,
+                ai_calls_this_tick,
+                max_calls,
+                "AI gate: skipping (max_ai_calls_per_tick reached - deferred to next tick)"
+            );
+            PreAiFlowDecision::SkipHandled
+        }
+        PreAiGuardDecision::Proceed => PreAiFlowDecision::Proceed,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn default_guard_inputs() -> PreAiGuardInputs {
+        PreAiGuardInputs {
+            is_pipeline_test: false,
+            is_advisory_detector: false,
+            ai_enabled: true,
+            is_allowlisted: false,
+            passes_ai_gate: true,
+            below_severity_threshold: false,
+            in_decision_cooldown: false,
+            ai_calls_this_tick: 0,
+            max_ai_calls_per_tick: 10,
+        }
     }
 
-    // Decision cooldown - suppress repeated AI decisions for the same
-    // action:detector:entity scope within a 1-hour window.
-    let cooldown_cutoff =
-        chrono::Utc::now() - chrono::Duration::seconds(crate::DECISION_COOLDOWN_SECS);
-    let candidates = crate::decision_cooldown_candidates(incident);
-    let in_cooldown = candidates.iter().any(|k| {
-        state
-            .store
-            .get_cooldown(state_store::CooldownTable::Decision, k)
-            .is_some_and(|ts| ts > cooldown_cutoff)
-    });
-    if in_cooldown {
-        info!(
-            incident_id = %incident.incident_id,
-            "AI gate: skipping (decision cooldown active)"
+    #[test]
+    fn decide_pre_ai_guard_pipeline_test_has_highest_priority() {
+        // Invariant: pipeline-test incidents must short-circuit all later guard checks.
+        let mut inputs = default_guard_inputs();
+        inputs.is_pipeline_test = true;
+        inputs.is_advisory_detector = true;
+        inputs.ai_enabled = false;
+        inputs.is_allowlisted = true;
+        inputs.passes_ai_gate = false;
+        inputs.below_severity_threshold = true;
+        inputs.in_decision_cooldown = true;
+        inputs.ai_calls_this_tick = 99;
+
+        assert_eq!(
+            decide_pre_ai_guard(inputs),
+            PreAiGuardDecision::PipelineTestHandled
         );
-        return PreAiFlowDecision::SkipHandled;
     }
 
-    // max_ai_calls_per_tick: enforce per-tick AI call budget.
-    let max_calls = cfg.ai.max_ai_calls_per_tick;
-    if max_calls > 0 && ai_calls_this_tick >= max_calls {
-        info!(
-            incident_id = %incident.incident_id,
-            ai_calls_this_tick,
-            max_calls,
-            "AI gate: skipping (max_ai_calls_per_tick reached - deferred to next tick)"
+    #[test]
+    fn decide_pre_ai_guard_advisory_detector_short_circuits_ai_disabled() {
+        // Invariant: advisory-only detectors stay in observe mode even when AI is disabled.
+        let mut inputs = default_guard_inputs();
+        inputs.is_advisory_detector = true;
+        inputs.ai_enabled = false;
+
+        assert_eq!(
+            decide_pre_ai_guard(inputs),
+            PreAiGuardDecision::SkipAdvisoryDetector
         );
-        return PreAiFlowDecision::SkipHandled;
     }
 
-    PreAiFlowDecision::Proceed
+    #[test]
+    fn decide_pre_ai_guard_skips_when_ai_is_disabled() {
+        // Invariant: when AI is disabled, incidents should skip the entire AI guard chain.
+        let mut inputs = default_guard_inputs();
+        inputs.ai_enabled = false;
+
+        assert_eq!(
+            decide_pre_ai_guard(inputs),
+            PreAiGuardDecision::SkipAiDisabled
+        );
+    }
+
+    #[test]
+    fn decide_pre_ai_guard_allowlist_takes_precedence_over_ai_gate_outcome() {
+        // Invariant: allowlisted entities must bypass AI before private/block/noise gate evaluation.
+        let mut inputs = default_guard_inputs();
+        inputs.is_allowlisted = true;
+        inputs.passes_ai_gate = false;
+        inputs.below_severity_threshold = true;
+
+        assert_eq!(
+            decide_pre_ai_guard(inputs),
+            PreAiGuardDecision::SkipAllowlisted
+        );
+    }
+
+    #[test]
+    fn decide_pre_ai_guard_returns_skip_below_severity_when_min_severity_dominates() {
+        // Invariant: below-min-severity incidents must route to the dedicated noise-gate branch.
+        let mut inputs = default_guard_inputs();
+        inputs.passes_ai_gate = false;
+        inputs.below_severity_threshold = true;
+
+        assert_eq!(
+            decide_pre_ai_guard(inputs),
+            PreAiGuardDecision::SkipBelowSeverity
+        );
+    }
+
+    #[test]
+    fn decide_pre_ai_guard_returns_skip_private_or_blocked_for_non_severity_gate_failures() {
+        // Invariant: AI-gate failures unrelated to min severity map to private/already-blocked skips.
+        let mut inputs = default_guard_inputs();
+        inputs.passes_ai_gate = false;
+        inputs.below_severity_threshold = false;
+
+        assert_eq!(
+            decide_pre_ai_guard(inputs),
+            PreAiGuardDecision::SkipPrivateOrBlocked
+        );
+    }
+
+    #[test]
+    fn decide_pre_ai_guard_returns_skip_decision_cooldown_after_gate_pass() {
+        // Invariant: cooldown must suppress repeated AI decisions when earlier gates already passed.
+        let mut inputs = default_guard_inputs();
+        inputs.in_decision_cooldown = true;
+
+        assert_eq!(
+            decide_pre_ai_guard(inputs),
+            PreAiGuardDecision::SkipDecisionCooldown
+        );
+    }
+
+    #[test]
+    fn decide_pre_ai_guard_returns_skip_ai_call_budget_when_limit_reached() {
+        // Invariant: per-tick AI call budgets must defer additional incidents to the next tick.
+        let mut inputs = default_guard_inputs();
+        inputs.ai_calls_this_tick = 3;
+        inputs.max_ai_calls_per_tick = 3;
+
+        assert_eq!(
+            decide_pre_ai_guard(inputs),
+            PreAiGuardDecision::SkipAiCallBudget
+        );
+    }
+
+    #[test]
+    fn decide_pre_ai_guard_returns_proceed_when_all_guards_pass() {
+        // Invariant: incidents should proceed only when every pre-AI guard check passes.
+        let inputs = default_guard_inputs();
+
+        assert_eq!(decide_pre_ai_guard(inputs), PreAiGuardDecision::Proceed);
+    }
 }

--- a/crates/agent/src/incident_forensics.rs
+++ b/crates/agent/src/incident_forensics.rs
@@ -2,11 +2,13 @@ use tracing::info;
 
 use crate::AgentState;
 
-/// Best-effort forensics capture for high-severity incidents.
-/// Captures /proc state by PID and selective pcap by primary attacker IP.
-pub(crate) fn maybe_capture_incident_forensics(
+fn capture_incident_forensics_with<
+    F: FnMut(u32, &str) -> Option<crate::forensics::ForensicsReport>,
+    P: FnMut(&str, &str) -> Option<crate::pcap_capture::CaptureResult>,
+>(
     incident: &innerwarden_core::incident::Incident,
-    state: &mut AgentState,
+    mut capture_forensics: F,
+    mut capture_pcap: P,
 ) {
     if !matches!(
         incident.severity,
@@ -17,7 +19,7 @@ pub(crate) fn maybe_capture_incident_forensics(
 
     if let Some(pid) = incident.evidence.get("pid").and_then(|v| v.as_u64()) {
         let pid = pid as u32;
-        if let Some(report) = state.forensics.try_capture(pid, &incident.incident_id) {
+        if let Some(report) = capture_forensics(pid, &incident.incident_id) {
             info!(
                 pid = report.pid,
                 incident_id = %incident.incident_id,
@@ -34,7 +36,7 @@ pub(crate) fn maybe_capture_incident_forensics(
         .find(|e| e.r#type == innerwarden_core::entities::EntityType::Ip)
         .map(|e| e.value.as_str());
     if let Some(ip) = primary_ip {
-        if let Some(result) = state.pcap_capture.try_capture(ip, &incident.incident_id) {
+        if let Some(result) = capture_pcap(ip, &incident.incident_id) {
             info!(
                 ip = %result.ip,
                 pcap = %result.pcap_path.display(),
@@ -42,5 +44,139 @@ pub(crate) fn maybe_capture_incident_forensics(
                 "pcap: capture initiated for incident"
             );
         }
+    }
+}
+
+/// Best-effort forensics capture for high-severity incidents.
+/// Captures /proc state by PID and selective pcap by primary attacker IP.
+pub(crate) fn maybe_capture_incident_forensics(
+    incident: &innerwarden_core::incident::Incident,
+    state: &mut AgentState,
+) {
+    let forensics = &mut state.forensics;
+    let pcap_capture = &mut state.pcap_capture;
+    capture_incident_forensics_with(
+        incident,
+        |pid, incident_id| forensics.try_capture(pid, incident_id),
+        |ip, incident_id| pcap_capture.try_capture(ip, incident_id),
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+    use std::cell::Cell;
+    use std::path::PathBuf;
+
+    fn forensics_report(pid: u32, incident_id: &str) -> crate::forensics::ForensicsReport {
+        crate::forensics::ForensicsReport {
+            pid,
+            incident_id: incident_id.to_string(),
+            timestamp: Utc::now(),
+            cmdline: Some("cmd".to_string()),
+            exe: Some("/bin/echo".to_string()),
+            cwd: Some("/tmp".to_string()),
+            status: Some("Running".to_string()),
+            open_fds: vec![],
+            network_connections: vec![],
+            memory_maps: vec![],
+            env_redacted: vec![],
+        }
+    }
+
+    fn pcap_result(ip: &str) -> crate::pcap_capture::CaptureResult {
+        crate::pcap_capture::CaptureResult {
+            pcap_path: PathBuf::from("/tmp/mock.pcap"),
+            ip: ip.to_string(),
+            duration_secs: 60,
+        }
+    }
+
+    #[test]
+    fn capture_incident_forensics_with_invokes_both_captures_on_high_severity() {
+        // Invariant: high-severity incidents with PID and IP must trigger both capture adapters.
+        let mut incident = crate::tests::test_incident("203.0.113.31");
+        incident.evidence = serde_json::json!({ "pid": 42 });
+        let forensics_calls = Cell::new(0u32);
+        let pcap_calls = Cell::new(0u32);
+
+        capture_incident_forensics_with(
+            &incident,
+            |pid, incident_id| {
+                forensics_calls.set(forensics_calls.get() + 1);
+                assert_eq!(pid, 42);
+                Some(forensics_report(pid, incident_id))
+            },
+            |ip, _incident_id| {
+                pcap_calls.set(pcap_calls.get() + 1);
+                assert_eq!(ip, "203.0.113.31");
+                Some(pcap_result(ip))
+            },
+        );
+
+        assert_eq!(forensics_calls.get(), 1);
+        assert_eq!(pcap_calls.get(), 1);
+    }
+
+    #[test]
+    fn capture_incident_forensics_with_skips_when_severity_below_high() {
+        // Invariant: medium/low incidents must never call forensics or pcap capture backends.
+        let mut incident = crate::tests::test_incident("203.0.113.32");
+        incident.severity = innerwarden_core::event::Severity::Low;
+        incident.evidence = serde_json::json!({ "pid": 7 });
+        let forensics_calls = Cell::new(0u32);
+        let pcap_calls = Cell::new(0u32);
+
+        capture_incident_forensics_with(
+            &incident,
+            |_pid, _incident_id| {
+                forensics_calls.set(forensics_calls.get() + 1);
+                Some(forensics_report(7, "unused"))
+            },
+            |_ip, _incident_id| {
+                pcap_calls.set(pcap_calls.get() + 1);
+                Some(pcap_result("203.0.113.32"))
+            },
+        );
+
+        assert_eq!(forensics_calls.get(), 0);
+        assert_eq!(pcap_calls.get(), 0);
+    }
+
+    #[test]
+    fn capture_incident_forensics_with_tolerates_upstream_none_results() {
+        // Invariant: upstream capture adapters returning `None` must not panic and keep flow alive.
+        let mut incident = crate::tests::test_incident("203.0.113.33");
+        incident.evidence = serde_json::json!({ "pid": 99999 });
+        let forensics_calls = Cell::new(0u32);
+        let pcap_calls = Cell::new(0u32);
+
+        capture_incident_forensics_with(
+            &incident,
+            |_pid, _incident_id| {
+                forensics_calls.set(forensics_calls.get() + 1);
+                None
+            },
+            |_ip, _incident_id| {
+                pcap_calls.set(pcap_calls.get() + 1);
+                None
+            },
+        );
+
+        assert_eq!(forensics_calls.get(), 1);
+        assert_eq!(pcap_calls.get(), 1);
+    }
+
+    #[test]
+    fn maybe_capture_incident_forensics_returns_early_for_low_severity_incidents() {
+        // Invariant: runtime adapter wrapper should no-op when incident severity is below High.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut state = crate::tests::triage_test_state(dir.path());
+        let mut incident = crate::tests::test_incident("203.0.113.34");
+        incident.severity = innerwarden_core::event::Severity::Low;
+        incident.evidence = serde_json::json!({ "pid": std::process::id() });
+
+        maybe_capture_incident_forensics(&incident, &mut state);
     }
 }

--- a/crates/agent/src/incident_playbook.rs
+++ b/crates/agent/src/incident_playbook.rs
@@ -42,3 +42,88 @@ pub(crate) fn maybe_evaluate_and_persist_playbook(
         let _ = std::fs::write(&log_path, json_str);
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write_playbook_rule(
+        rules_dir: &std::path::Path,
+        playbook_id: &str,
+        detector: &str,
+        min_severity: &str,
+    ) {
+        let playbooks_dir = rules_dir.join("playbooks");
+        std::fs::create_dir_all(&playbooks_dir).expect("playbooks dir");
+        let content = format!(
+            r#"[playbook.{playbook_id}]
+name = "Unit Test Playbook"
+trigger = {{ detector = "{detector}", min_severity = "{min_severity}" }}
+steps = [{{ action = "notify" }}]
+"#
+        );
+        std::fs::write(playbooks_dir.join("unit.toml"), content).expect("write rule");
+    }
+
+    #[test]
+    fn maybe_evaluate_and_persist_playbook_persists_log_and_sqlite_blob_on_match() {
+        // Invariant: matching playbooks must be persisted to both JSON log and SQLite blob.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let rules_dir = dir.path().join("rules-enabled");
+        write_playbook_rule(&rules_dir, "pb-unit", "ssh_bruteforce", "high");
+        let mut state = crate::tests::triage_test_state(dir.path());
+        state.playbook_engine = crate::playbook::PlaybookEngine::new(&rules_dir);
+        let store = crate::tests::test_sqlite_store(dir.path());
+        state.sqlite_store = Some(store.clone());
+        let incident = crate::tests::test_incident("203.0.113.51");
+
+        maybe_evaluate_and_persist_playbook(&incident, dir.path(), &mut state);
+
+        let log_path = dir.path().join("playbook-log.json");
+        let raw = std::fs::read_to_string(&log_path).expect("playbook log");
+        let entries: Vec<serde_json::Value> = serde_json::from_str(&raw).expect("valid json log");
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0]["playbook_id"], "pb-unit");
+
+        let blob = store
+            .get_blob("playbook_log")
+            .expect("blob read")
+            .expect("blob value");
+        assert!(blob.contains("\"playbook_id\":\"pb-unit\""));
+    }
+
+    #[test]
+    fn maybe_evaluate_and_persist_playbook_skips_when_no_playbook_matches() {
+        // Invariant: when playbook evaluation returns `None`, no persistence side effects should occur.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let rules_dir = dir.path().join("rules-disabled");
+        write_playbook_rule(&rules_dir, "pb-never", "never_match", "critical");
+        let mut state = crate::tests::triage_test_state(dir.path());
+        state.playbook_engine = crate::playbook::PlaybookEngine::new(&rules_dir);
+        let incident = crate::tests::test_incident("203.0.113.52");
+
+        maybe_evaluate_and_persist_playbook(&incident, dir.path(), &mut state);
+
+        assert!(!dir.path().join("playbook-log.json").exists());
+    }
+
+    #[test]
+    fn maybe_evaluate_and_persist_playbook_recovers_from_corrupted_existing_log() {
+        // Invariant: malformed on-disk playbook log must be treated as empty and replaced with valid JSON.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let rules_dir = dir.path().join("rules-recovery");
+        write_playbook_rule(&rules_dir, "pb-recover", "ssh_bruteforce", "high");
+        let mut state = crate::tests::triage_test_state(dir.path());
+        state.playbook_engine = crate::playbook::PlaybookEngine::new(&rules_dir);
+        let incident = crate::tests::test_incident("203.0.113.53");
+        let log_path = dir.path().join("playbook-log.json");
+        std::fs::write(&log_path, "{not-valid-json").expect("seed corrupted log");
+
+        maybe_evaluate_and_persist_playbook(&incident, dir.path(), &mut state);
+
+        let raw = std::fs::read_to_string(&log_path).expect("playbook log");
+        let entries: Vec<serde_json::Value> = serde_json::from_str(&raw).expect("valid json log");
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0]["playbook_id"], "pb-recover");
+    }
+}

--- a/crates/agent/src/loops/boot.rs
+++ b/crates/agent/src/loops/boot.rs
@@ -2178,7 +2178,9 @@ mod tests {
             "tcp_stream.ssh",
         ];
         let mut events = Vec::new();
-        for i in 0..600 {
+        // 1000 events keeps the training slice above MIN_TRAIN_WINDOWS after
+        // the 20% holdout split introduced in the percentile-scoring fix.
+        for i in 0..1000 {
             let kind = kinds[i % kinds.len()];
             events.push(Event {
                 ts: Utc::now(),

--- a/crates/agent/src/loops/boot.rs
+++ b/crates/agent/src/loops/boot.rs
@@ -1519,7 +1519,14 @@ pub(crate) async fn run_agent(cli: crate::Cli) -> Result<()> {
                             .filter(|(_, _, _, ts)| *ts < report_cutoff)
                             .cloned()
                             .collect();
+                        let today = chrono::Local::now()
+                            .date_naive()
+                            .format("%Y-%m-%d")
+                            .to_string();
+                        let daily_cap = cfg.abuseipdb.report_daily_cap;
                         let mut dropped_cloud = 0usize;
+                        let mut dropped_dedup = 0usize;
+                        let mut dropped_cap = 0usize;
                         if let Some(ref client) = state.abuseipdb {
                             for (ip, comment, categories, _) in &ready {
                                 if let Some(provider) = cloud_safelist::identify_provider(ip) {
@@ -1531,8 +1538,55 @@ pub(crate) async fn run_agent(cli: crate::Cli) -> Result<()> {
                                     );
                                     continue;
                                 }
+
+                                // Budget gate: only bill a report call when
+                                // the store approves (dedup + daily cap).
+                                // Without a store, fall through and let the
+                                // legacy behaviour stand — pre-spec-016
+                                // deploys would otherwise lose reporting.
+                                let commit = if let Some(ref sq) = state.sqlite_store {
+                                    match abuseipdb_report_budget::check_report_budget(
+                                        sq.as_ref(),
+                                        ip,
+                                        &today,
+                                        daily_cap,
+                                    ) {
+                                        abuseipdb_report_budget::ReportBudgetDecision::Allow(c) => {
+                                            Some(c)
+                                        }
+                                        abuseipdb_report_budget::ReportBudgetDecision::Reject(
+                                            reason,
+                                        ) => {
+                                            match reason {
+                                                abuseipdb_report_budget::RejectReason::AlreadyReportedToday => {
+                                                    dropped_dedup += 1;
+                                                }
+                                                abuseipdb_report_budget::RejectReason::DailyCapReached => {
+                                                    dropped_cap += 1;
+                                                }
+                                            }
+                                            warn!(
+                                                ip,
+                                                reason = reason.as_metric_label(),
+                                                "AbuseIPDB report skipped by budget gate"
+                                            );
+                                            continue;
+                                        }
+                                    }
+                                } else {
+                                    None
+                                };
+
                                 client.report(ip, categories, comment).await;
                                 info!(ip, "AbuseIPDB report sent (after 5min delay)");
+
+                                // Only commit AFTER a successful report call
+                                // so transport failures don't eat quota.
+                                if let (Some(ref sq), Some(commit)) =
+                                    (&state.sqlite_store, commit)
+                                {
+                                    commit.apply(sq.as_ref());
+                                }
                             }
                         }
                         if dropped_cloud > 0 {
@@ -1540,6 +1594,20 @@ pub(crate) async fn run_agent(cli: crate::Cli) -> Result<()> {
                                 dropped_cloud,
                                 "AbuseIPDB queue flush: dropped {} cloud-provider entries",
                                 dropped_cloud
+                            );
+                        }
+                        if dropped_dedup > 0 {
+                            info!(
+                                dropped_dedup,
+                                "AbuseIPDB queue flush: dropped {} duplicates (24h dedup)",
+                                dropped_dedup
+                            );
+                        }
+                        if dropped_cap > 0 {
+                            warn!(
+                                dropped_cap,
+                                daily_cap,
+                                "AbuseIPDB daily report cap reached — remaining reports paused until UTC midnight"
                             );
                         }
                         state.abuseipdb_report_queue.retain(|(_, _, _, ts)| *ts >= report_cutoff);

--- a/crates/agent/src/loops/boot.rs
+++ b/crates/agent/src/loops/boot.rs
@@ -1524,91 +1524,38 @@ pub(crate) async fn run_agent(cli: crate::Cli) -> Result<()> {
                             .format("%Y-%m-%d")
                             .to_string();
                         let daily_cap = cfg.abuseipdb.report_daily_cap;
-                        let mut dropped_cloud = 0usize;
-                        let mut dropped_dedup = 0usize;
-                        let mut dropped_cap = 0usize;
-                        if let Some(ref client) = state.abuseipdb {
-                            for (ip, comment, categories, _) in &ready {
-                                if let Some(provider) = cloud_safelist::identify_provider(ip) {
-                                    dropped_cloud += 1;
-                                    warn!(
-                                        ip,
-                                        provider,
-                                        "AbuseIPDB report dropped: target is in cloud safelist"
-                                    );
-                                    continue;
-                                }
-
-                                // Budget gate: only bill a report call when
-                                // the store approves (dedup + daily cap).
-                                // Without a store, fall through and let the
-                                // legacy behaviour stand — pre-spec-016
-                                // deploys would otherwise lose reporting.
-                                let commit = if let Some(ref sq) = state.sqlite_store {
-                                    match abuseipdb_report_budget::check_report_budget(
-                                        sq.as_ref(),
-                                        ip,
-                                        &today,
-                                        daily_cap,
-                                    ) {
-                                        abuseipdb_report_budget::ReportBudgetDecision::Allow(c) => {
-                                            Some(c)
-                                        }
-                                        abuseipdb_report_budget::ReportBudgetDecision::Reject(
-                                            reason,
-                                        ) => {
-                                            match reason {
-                                                abuseipdb_report_budget::RejectReason::AlreadyReportedToday => {
-                                                    dropped_dedup += 1;
-                                                }
-                                                abuseipdb_report_budget::RejectReason::DailyCapReached => {
-                                                    dropped_cap += 1;
-                                                }
-                                            }
-                                            warn!(
-                                                ip,
-                                                reason = reason.as_metric_label(),
-                                                "AbuseIPDB report skipped by budget gate"
-                                            );
-                                            continue;
-                                        }
-                                    }
-                                } else {
-                                    None
-                                };
-
-                                client.report(ip, categories, comment).await;
-                                info!(ip, "AbuseIPDB report sent (after 5min delay)");
-
-                                // Only commit AFTER a successful report call
-                                // so transport failures don't eat quota.
-                                if let (Some(ref sq), Some(commit)) =
-                                    (&state.sqlite_store, commit)
-                                {
-                                    commit.apply(sq.as_ref());
-                                }
-                            }
+                        // Plan every decision up-front in a pure helper so
+                        // the full decision matrix (cloud safelist → dedup →
+                        // cap) is unit-testable without a Tokio runtime or
+                        // a live AbuseIPDB client. The slow loop here only
+                        // keeps the I/O (HTTP call + commit write).
+                        let outcomes = abuseipdb_report_budget::plan_queue_flush(
+                            &ready,
+                            state.sqlite_store.as_deref(),
+                            cloud_safelist::identify_provider,
+                            &today,
+                            daily_cap,
+                        );
+                        let counts = if let Some(ref client) = state.abuseipdb {
+                            abuseipdb_report_budget::dispatch_flush_outcomes(
+                                outcomes,
+                                state.sqlite_store.as_deref(),
+                                |ip, categories, comment| async move {
+                                    client.report(&ip, &categories, &comment).await;
+                                },
+                            )
+                            .await
+                        } else {
+                            abuseipdb_report_budget::FlushCounts::default()
+                        };
+                        if counts.dropped_cloud > 0 {
+                            info!(dropped_cloud = counts.dropped_cloud, "AbuseIPDB queue flush: cloud safelist drops");
                         }
-                        if dropped_cloud > 0 {
-                            info!(
-                                dropped_cloud,
-                                "AbuseIPDB queue flush: dropped {} cloud-provider entries",
-                                dropped_cloud
-                            );
+                        if counts.dropped_dedup > 0 {
+                            info!(dropped_dedup = counts.dropped_dedup, "AbuseIPDB queue flush: 24h dedup drops");
                         }
-                        if dropped_dedup > 0 {
-                            info!(
-                                dropped_dedup,
-                                "AbuseIPDB queue flush: dropped {} duplicates (24h dedup)",
-                                dropped_dedup
-                            );
-                        }
-                        if dropped_cap > 0 {
-                            warn!(
-                                dropped_cap,
-                                daily_cap,
-                                "AbuseIPDB daily report cap reached — remaining reports paused until UTC midnight"
-                            );
+                        if counts.dropped_cap > 0 {
+                            warn!(dropped_cap = counts.dropped_cap, daily_cap, "AbuseIPDB daily report cap reached — remaining reports paused until UTC midnight");
                         }
                         state.abuseipdb_report_queue.retain(|(_, _, _, ts)| *ts >= report_cutoff);
                     }

--- a/crates/agent/src/loops/boot.rs
+++ b/crates/agent/src/loops/boot.rs
@@ -1536,7 +1536,7 @@ pub(crate) async fn run_agent(cli: crate::Cli) -> Result<()> {
                             &today,
                             daily_cap,
                         );
-                        let counts = if let Some(ref client) = state.abuseipdb {
+                        if let Some(ref client) = state.abuseipdb {
                             abuseipdb_report_budget::dispatch_flush_outcomes(
                                 outcomes,
                                 state.sqlite_store.as_deref(),
@@ -1544,18 +1544,7 @@ pub(crate) async fn run_agent(cli: crate::Cli) -> Result<()> {
                                     client.report(&ip, &categories, &comment).await;
                                 },
                             )
-                            .await
-                        } else {
-                            abuseipdb_report_budget::FlushCounts::default()
-                        };
-                        if counts.dropped_cloud > 0 {
-                            info!(dropped_cloud = counts.dropped_cloud, "AbuseIPDB queue flush: cloud safelist drops");
-                        }
-                        if counts.dropped_dedup > 0 {
-                            info!(dropped_dedup = counts.dropped_dedup, "AbuseIPDB queue flush: 24h dedup drops");
-                        }
-                        if counts.dropped_cap > 0 {
-                            warn!(dropped_cap = counts.dropped_cap, daily_cap, "AbuseIPDB daily report cap reached — remaining reports paused until UTC midnight");
+                            .await;
                         }
                         state.abuseipdb_report_queue.retain(|(_, _, _, ts)| *ts >= report_cutoff);
                     }

--- a/crates/agent/src/main.rs
+++ b/crates/agent/src/main.rs
@@ -13,6 +13,7 @@
 static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
 mod abuseipdb;
+mod abuseipdb_report_budget;
 mod agent_context;
 mod ai;
 mod allowlist;

--- a/crates/agent/src/neural_lifecycle.rs
+++ b/crates/agent/src/neural_lifecycle.rs
@@ -337,9 +337,29 @@ impl AutoencoderNet {
         if data.len() < 24 || &data[0..4] != b"IWAE" {
             return None;
         }
-        // Skip header: magic(4) + version(4) + baseline_mse(4) + baseline_std(4) + samples(8)
-        let net_len = u32::from_le_bytes([data[24], data[25], data[26], data[27]]) as usize;
-        let net_json = &data[28..28 + net_len];
+        // Header: magic(4) + version(4) + baseline_mse(4) + baseline_std(4) + samples(8).
+        // Version 2 adds `BASELINE_PERCENTILES * 4` bytes of anchor table
+        // before the length-prefixed JSON weights. Older v1 files keep the
+        // original 24-byte header.
+        let version = u32::from_le_bytes([data[4], data[5], data[6], data[7]]);
+        let net_offset = match version {
+            v if v >= 2 => 24 + BASELINE_PERCENTILES * 4,
+            _ => 24,
+        };
+        if data.len() < net_offset + 4 {
+            return None;
+        }
+        let net_len = u32::from_le_bytes([
+            data[net_offset],
+            data[net_offset + 1],
+            data[net_offset + 2],
+            data[net_offset + 3],
+        ]) as usize;
+        let start = net_offset + 4;
+        if data.len() < start + net_len {
+            return None;
+        }
+        let net_json = &data[start..start + net_len];
 
         // Parse the JSON-serialized network
         let net: serde_json::Value = serde_json::from_slice(net_json).ok()?;
@@ -483,6 +503,216 @@ pub struct AnomalyConfig {
     pub training_epochs: u64,
     /// How often to train (cron-style, e.g., "0 3 * * *")
     pub training_schedule: String,
+    /// Fraction of training windows held out for baseline computation
+    /// (range 0.0..=0.5). Computing `baseline_mse` / `baseline_std` on the
+    /// same windows the autoencoder memorised produces a tiny, saturated
+    /// baseline — every live window then sigmoids to ~1.0. A ~20% holdout
+    /// gives a realistic variance estimate. Set to 0.0 to fall back to the
+    /// legacy single-set baseline (not recommended; retained for
+    /// small-dataset scenarios where splitting the training set would drop
+    /// it below `MIN_TRAIN_WINDOWS`).
+    pub training_holdout_fraction: f32,
+}
+
+/// Minimum number of windows required for training after the holdout split.
+/// The older in-place baseline enforced `all_kinds.len() >= 100` — we keep
+/// that floor on the training portion.
+const MIN_TRAIN_WINDOWS: usize = 100;
+
+/// Deterministic train/holdout split used by `train_nightly`. Every Nth
+/// index goes into the holdout bucket so the split is reproducible across
+/// runs (no RNG dependency, no test flake). `N` is derived from the
+/// requested fraction: 0.2 → every 5th window, 0.1 → every 10th, etc.
+#[derive(Debug, Clone)]
+pub(crate) struct TrainTestSplit {
+    train: Vec<usize>,
+    holdout: Vec<usize>,
+}
+
+impl TrainTestSplit {
+    /// Build a split covering `[0, total)`. `fraction` is clamped to
+    /// `0.0..=0.5` (holding out more than half the data would starve the
+    /// trainer). `total == 0` is legal and yields two empty vectors.
+    pub(crate) fn from_fraction(total: usize, fraction: f32) -> Self {
+        if total == 0 {
+            return Self {
+                train: Vec::new(),
+                holdout: Vec::new(),
+            };
+        }
+        let clamped = fraction.clamp(0.0, 0.5);
+        if clamped <= f32::EPSILON {
+            return Self {
+                train: (0..total).collect(),
+                holdout: Vec::new(),
+            };
+        }
+        // `stride = round(1 / fraction)` gives the expected every-Nth
+        // cadence; clamped to [2, total] so the holdout always has at
+        // least one element when the fraction is non-zero + data fits.
+        let stride = ((1.0 / clamped).round() as usize).clamp(2, total);
+        let mut train = Vec::with_capacity(total - total / stride);
+        let mut holdout = Vec::with_capacity(total / stride);
+        for i in 0..total {
+            if i % stride == stride - 1 {
+                holdout.push(i);
+            } else {
+                train.push(i);
+            }
+        }
+        Self { train, holdout }
+    }
+
+    pub(crate) fn indices(&self) -> (Vec<usize>, Vec<usize>) {
+        (self.train.clone(), self.holdout.clone())
+    }
+}
+
+/// Mean reconstruction error over a selection of feature windows.
+fn mean_reconstruction_error(net: &AutoencoderNet, features: &[Vec<f32>], idx: &[usize]) -> f32 {
+    if idx.is_empty() {
+        return 0.0;
+    }
+    let sum: f32 = idx
+        .iter()
+        .map(|&i| net.reconstruction_error(&features[i]))
+        .sum();
+    sum / idx.len() as f32
+}
+
+/// Number of evenly-spaced percentile anchors retained from the baseline
+/// distribution. 101 keeps storage at 404 bytes (101 × f32) and gives
+/// 1%-granularity scoring — enough to separate normal / elevated /
+/// anomaly without the full histogram.
+pub(crate) const BASELINE_PERCENTILES: usize = 101;
+
+/// Compress a sorted-ascending `errors` vector into `BASELINE_PERCENTILES`
+/// anchors. `anchor[k]` is the baseline MSE at the `k/(BASELINE_PERCENTILES-1)`
+/// quantile. Empty input yields `vec![0.0; BASELINE_PERCENTILES]`.
+fn compute_percentile_anchors(mut errors: Vec<f32>) -> Vec<f32> {
+    if errors.is_empty() {
+        return vec![0.0; BASELINE_PERCENTILES];
+    }
+    errors.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    let last = errors.len() - 1;
+    (0..BASELINE_PERCENTILES)
+        .map(|k| {
+            let pos = (k as f64 * last as f64 / (BASELINE_PERCENTILES - 1) as f64).round();
+            errors[pos as usize]
+        })
+        .collect()
+}
+
+/// Compute `(baseline_mse, baseline_std, percentile_anchors)` over a
+/// selection of feature windows. Mean + std keep legacy telemetry values;
+/// the anchors drive the percentile-based score that replaces the
+/// z-score + sigmoid path (which saturated to 1.0 on production's
+/// homogeneous event distribution).
+fn compute_baseline(
+    net: &AutoencoderNet,
+    features: &[Vec<f32>],
+    idx: &[usize],
+) -> (f32, f32, Vec<f32>) {
+    if idx.is_empty() {
+        return (0.0, 0.0, vec![0.0; BASELINE_PERCENTILES]);
+    }
+    let errors: Vec<f32> = idx
+        .iter()
+        .map(|&i| net.reconstruction_error(&features[i]))
+        .collect();
+    let n = errors.len() as f32;
+    let mean = errors.iter().sum::<f32>() / n;
+    let variance = errors.iter().map(|e| (e - mean).powi(2)).sum::<f32>() / n;
+    let anchors = compute_percentile_anchors(errors);
+    (mean, variance.sqrt(), anchors)
+}
+
+/// Model file format constants. Version 1 is the legacy layout (header
+/// has no percentile table); version 2 adds `BASELINE_PERCENTILES × f32`
+/// after the 24-byte header, followed by the usual JSON weights blob.
+const MODEL_MAGIC: &[u8; 4] = b"IWAE";
+const MODEL_VERSION_V2: u32 = 2;
+const MODEL_HEADER_LEN: usize = 24;
+type ParsedModel = (
+    Option<AutoencoderNet>,
+    f32,      // baseline_mse
+    f32,      // baseline_std
+    Vec<f32>, // percentile anchors
+    f32,      // maturity
+    u32,      // training cycles
+);
+
+/// Parse a saved `anomaly-model.bin` into engine fields. Accepts both the
+/// pre-percentile v1 layout (where we synthesise a flat anchor table —
+/// forces the new inference path to fall back to z-score until the next
+/// training cycle) and the v2 layout that embeds anchors after the
+/// header. Returns `None` when the file is truncated / malformed; the
+/// caller constructs a fresh engine.
+fn parse_model_file(data: &[u8]) -> Option<ParsedModel> {
+    if data.len() < MODEL_HEADER_LEN || &data[..4] != MODEL_MAGIC {
+        return None;
+    }
+    let version = u32::from_le_bytes([data[4], data[5], data[6], data[7]]);
+    let baseline_mse = f32::from_le_bytes([data[8], data[9], data[10], data[11]]);
+    let baseline_std = f32::from_le_bytes([data[12], data[13], data[14], data[15]]);
+    let samples = u64::from_le_bytes([
+        data[16], data[17], data[18], data[19], data[20], data[21], data[22], data[23],
+    ]);
+    let maturity = (samples as f32 / 500_000.0).min(1.0);
+    let cycles = (samples / 100_000) as u32;
+
+    let anchors = if version == MODEL_VERSION_V2 {
+        let expected = MODEL_HEADER_LEN + BASELINE_PERCENTILES * 4;
+        if data.len() < expected {
+            return None;
+        }
+        let mut v = Vec::with_capacity(BASELINE_PERCENTILES);
+        for k in 0..BASELINE_PERCENTILES {
+            let off = MODEL_HEADER_LEN + k * 4;
+            v.push(f32::from_le_bytes([
+                data[off],
+                data[off + 1],
+                data[off + 2],
+                data[off + 3],
+            ]));
+        }
+        v
+    } else {
+        // v1 layout: no anchors — seed with zeros so `percentile_score`
+        // returns `None` and `observe()` falls back to z-score. Next
+        // training cycle will overwrite with real data.
+        vec![0.0; BASELINE_PERCENTILES]
+    };
+
+    // `AutoencoderNet::load` reads the full file (including IWAE header)
+    // and skips past the anchor table itself based on the version byte.
+    let net = AutoencoderNet::load(data);
+    if net.is_some() {
+        info!(
+            "anomaly: loaded model ({} bytes, version {}, baseline MSE {:.6}, maturity {:.2})",
+            data.len(),
+            version,
+            baseline_mse,
+            maturity
+        );
+    }
+    Some((net, baseline_mse, baseline_std, anchors, maturity, cycles))
+}
+
+/// Rank a live reconstruction error against the baseline percentile
+/// anchors. Returns `Some(0.0..=1.0)`: 0 = better than everything,
+/// 1 = worse than everything. Degenerate tables (empty or all-zero)
+/// return `None` so the caller can fall back to the legacy z-score
+/// path during the transition period.
+pub(crate) fn percentile_score(mse: f32, anchors: &[f32]) -> Option<f32> {
+    if anchors.len() < 2 {
+        return None;
+    }
+    if !anchors.iter().any(|&x| x > 0.0) {
+        return None;
+    }
+    let below = anchors.iter().filter(|&&a| a <= mse).count();
+    Some(below as f32 / anchors.len() as f32)
 }
 
 impl Default for AnomalyConfig {
@@ -495,6 +725,7 @@ impl Default for AnomalyConfig {
             training_retention_days: 7,
             training_epochs: 50,
             training_schedule: "0 3 * * *".to_string(),
+            training_holdout_fraction: 0.2,
         }
     }
 }
@@ -506,8 +737,14 @@ pub struct AnomalyEngine {
     window: VecDeque<Option<usize>>,
     /// Baseline MSE from training (what "normal" looks like).
     baseline_mse: f32,
-    /// Baseline standard deviation.
+    /// Baseline standard deviation. Retained for telemetry + the legacy
+    /// z-score fallback path; the live score now comes from the
+    /// percentile anchors below.
     baseline_std: f32,
+    /// Sorted-ascending reconstruction-error anchors over the baseline
+    /// windows (length `BASELINE_PERCENTILES`). Populated by training and
+    /// consumed by `percentile_score` at inference time.
+    baseline_percentile_anchors: Vec<f32>,
     /// Maturity: 0.0 (just installed) → 1.0 (fully trained).
     /// Increases with each successful training cycle.
     pub maturity: f32,
@@ -528,49 +765,23 @@ impl AnomalyEngine {
     /// Create a new anomaly engine, attempting to load a saved model.
     pub fn new(config: AnomalyConfig) -> Self {
         let model_path = config.data_dir.join("anomaly-model.bin");
-        let (net, baseline_mse, baseline_std, maturity, cycles) = if let Ok(data) =
-            std::fs::read(&model_path)
-        {
-            let net = AutoencoderNet::load(&data);
-            let mse = if data.len() >= 12 {
-                f32::from_le_bytes([data[8], data[9], data[10], data[11]])
+        let (net, baseline_mse, baseline_std, anchors, maturity, cycles) =
+            if let Ok(data) = std::fs::read(&model_path) {
+                parse_model_file(&data).unwrap_or_else(|| {
+                    info!("anomaly: existing model rejected by loader, starting fresh");
+                    (None, 0.0, 1.0, vec![0.0; BASELINE_PERCENTILES], 0.0, 0)
+                })
             } else {
-                0.0
+                info!("anomaly: no saved model found, starting fresh (observation mode)");
+                (None, 0.0, 1.0, vec![0.0; BASELINE_PERCENTILES], 0.0, 0)
             };
-            let std = if data.len() >= 16 {
-                f32::from_le_bytes([data[12], data[13], data[14], data[15]])
-            } else {
-                1.0
-            };
-            let samples = if data.len() >= 24 {
-                u64::from_le_bytes([
-                    data[16], data[17], data[18], data[19], data[20], data[21], data[22], data[23],
-                ])
-            } else {
-                0
-            };
-            // Estimate maturity from samples seen
-            let mat = (samples as f32 / 500_000.0).min(1.0);
-            let cyc = (samples / 100_000) as u32;
-            if net.is_some() {
-                info!(
-                    "anomaly: loaded model ({} bytes, baseline MSE {:.6}, maturity {:.2})",
-                    data.len(),
-                    mse,
-                    mat
-                );
-            }
-            (net, mse, std, mat, cyc)
-        } else {
-            info!("anomaly: no saved model found, starting fresh (observation mode)");
-            (None, 0.0, 1.0, 0.0, 0)
-        };
 
         Self {
             net,
             window: VecDeque::with_capacity(WINDOW_SIZE),
             baseline_mse,
             baseline_std,
+            baseline_percentile_anchors: anchors,
             maturity,
             training_cycles: cycles,
             config,
@@ -618,17 +829,20 @@ impl AnomalyEngine {
         }
         let mse = net.reconstruction_error(&features);
 
-        // Normalize to 0-1 via z-score + sigmoid
-        let z = if self.baseline_std > 0.0 {
-            (mse - self.baseline_mse) / self.baseline_std
-        } else {
-            if mse > self.baseline_mse {
+        // Primary path: percentile score against the baseline distribution.
+        // Returns `None` when the baseline is empty/degenerate (v1 model
+        // files, or very small datasets) — fall back to the legacy
+        // z-score + sigmoid so the engine keeps producing signal.
+        let score = percentile_score(mse, &self.baseline_percentile_anchors).unwrap_or_else(|| {
+            let z = if self.baseline_std > 0.0 {
+                (mse - self.baseline_mse) / self.baseline_std
+            } else if mse > self.baseline_mse {
                 3.0
             } else {
                 -3.0
-            }
-        };
-        let score = 1.0 / (1.0 + (-z).exp());
+            };
+            1.0 / (1.0 + (-z).exp())
+        });
         let weighted = score * self.maturity * 0.3; // max contribution = 0.3
 
         debug!(
@@ -896,6 +1110,26 @@ impl AnomalyEngine {
             HashSet::new()
         };
 
+        // Split into train/holdout BEFORE feature extraction so the holdout
+        // baseline reflects windows the network never saw during
+        // backpropagation. See `TrainTestSplit` comments for the rationale.
+        let split =
+            TrainTestSplit::from_fraction(all_kinds.len(), self.config.training_holdout_fraction);
+        let (train_idx, holdout_idx) = split.indices();
+        info!(
+            train_windows = train_idx.len(),
+            holdout_windows = holdout_idx.len(),
+            "anomaly: split windows train/holdout"
+        );
+        if train_idx.len() < MIN_TRAIN_WINDOWS {
+            warn!(
+                "anomaly: training set below floor after split ({} < {})",
+                train_idx.len(),
+                MIN_TRAIN_WINDOWS
+            );
+            return Err("insufficient data".to_string());
+        }
+
         // Extract features, reducing weight for windows matching FP detector patterns
         let features: Vec<Vec<f32>> = all_kinds
             .iter()
@@ -918,10 +1152,11 @@ impl AnomalyEngine {
         // Create or reinitialize network
         let mut net = AutoencoderNet::new(&[NUM_FEATURES, 16, 8, 16, NUM_FEATURES], 0.001);
 
-        // Train
+        // Train ONLY on the training partition so the holdout stays
+        // representative of "unseen normal" windows at baseline time.
         for epoch in 1..=self.config.training_epochs {
-            for f in &features {
-                net.train_reconstruction(f);
+            for &i in &train_idx {
+                net.train_reconstruction(&features[i]);
             }
 
             if start.elapsed().as_secs() > self.config.training_timeout_secs {
@@ -930,34 +1165,48 @@ impl AnomalyEngine {
             }
 
             if epoch % 10 == 0 {
-                let avg_mse: f32 = features
+                let avg_mse: f32 = train_idx
                     .iter()
-                    .map(|f| net.reconstruction_error(f))
+                    .map(|&i| net.reconstruction_error(&features[i]))
                     .sum::<f32>()
-                    / features.len() as f32;
+                    / train_idx.len() as f32;
                 info!(
-                    "anomaly: epoch {}/{} MSE {:.6}",
+                    "anomaly: epoch {}/{} train-MSE {:.6}",
                     epoch, self.config.training_epochs, avg_mse
                 );
             }
         }
 
-        // Compute baseline
-        let errors: Vec<f32> = features
-            .iter()
-            .map(|f| net.reconstruction_error(f))
-            .collect();
-        let n = errors.len() as f32;
-        let baseline_mse = errors.iter().sum::<f32>() / n;
-        let variance = errors
-            .iter()
-            .map(|e| (e - baseline_mse).powi(2))
-            .sum::<f32>()
-            / n;
-        let baseline_std = variance.sqrt();
+        // Compute baseline on the held-out windows. This is the core of the
+        // scoring fix: the autoencoder memorised the training set (MSE
+        // collapses toward 0), so computing baseline there produces a tiny
+        // std that saturates sigmoid(z) to 1.0 on live traffic. Held-out
+        // MSE is an order of magnitude larger + has realistic variance.
+        //
+        // Fallback: when holdout is empty (fraction == 0 or dataset too
+        // small) compute baseline on the training set — preserves legacy
+        // behaviour, no silent panic.
+        let baseline_idx: &[usize] = if holdout_idx.is_empty() {
+            info!("anomaly: holdout empty — falling back to train-set baseline");
+            &train_idx
+        } else {
+            &holdout_idx
+        };
+        let (baseline_mse, baseline_std, anchors) = compute_baseline(&net, &features, baseline_idx);
+        let train_mse = mean_reconstruction_error(&net, &features, &train_idx);
+        info!(
+            "anomaly: baseline from holdout (train MSE {:.6}, holdout MSE {:.6} ± {:.6}, p50 {:.6}, p95 {:.6}, p99 {:.6})",
+            train_mse,
+            baseline_mse,
+            baseline_std,
+            anchors.get(50).copied().unwrap_or(0.0),
+            anchors.get(95).copied().unwrap_or(0.0),
+            anchors.get(99).copied().unwrap_or(0.0),
+        );
 
         self.baseline_mse = baseline_mse;
         self.baseline_std = baseline_std;
+        self.baseline_percentile_anchors = anchors;
         self.net = Some(net);
         self.training_cycles += 1;
 
@@ -981,15 +1230,29 @@ impl AnomalyEngine {
             let _ = std::fs::rename(&model_path, &backup_path);
         }
 
-        // Serialize (simple format: IWAE header + JSON weights)
+        // Serialize as the v2 format: IWAE header + percentile anchor
+        // table + length-prefixed JSON weights. Readers (both `new()` and
+        // the AutoencoderNet loader) branch on the version byte.
         if let Some(ref net) = self.net {
             let mut data = Vec::new();
-            data.extend_from_slice(b"IWAE");
-            data.extend_from_slice(&1u32.to_le_bytes());
+            data.extend_from_slice(MODEL_MAGIC);
+            data.extend_from_slice(&MODEL_VERSION_V2.to_le_bytes());
             data.extend_from_slice(&self.baseline_mse.to_le_bytes());
             data.extend_from_slice(&self.baseline_std.to_le_bytes());
             let total_samples = total_events;
             data.extend_from_slice(&total_samples.to_le_bytes());
+
+            // Percentile anchor table — pad with zeros if for any reason
+            // the trainer produced a shorter-than-expected vector (should
+            // not happen, but defence-in-depth).
+            for k in 0..BASELINE_PERCENTILES {
+                let v = self
+                    .baseline_percentile_anchors
+                    .get(k)
+                    .copied()
+                    .unwrap_or(0.0);
+                data.extend_from_slice(&v.to_le_bytes());
+            }
 
             // Serialize weights as JSON
             let weights: Vec<Vec<Vec<f32>>> =
@@ -1303,6 +1566,163 @@ mod tests {
     use super::*;
     use innerwarden_core::event::Severity;
 
+    #[test]
+    fn train_test_split_happy_path_every_fifth() {
+        // 20% fraction on 10 items: stride=5 → indices 4, 9 go to holdout,
+        // 0..3 and 5..8 go to train. Deterministic, no RNG.
+        let s = TrainTestSplit::from_fraction(10, 0.2);
+        let (train, holdout) = s.indices();
+        assert_eq!(holdout, vec![4, 9]);
+        assert_eq!(train, vec![0, 1, 2, 3, 5, 6, 7, 8]);
+    }
+
+    #[test]
+    fn train_test_split_empty_input() {
+        let s = TrainTestSplit::from_fraction(0, 0.2);
+        assert!(s.indices().0.is_empty());
+        assert!(s.indices().1.is_empty());
+    }
+
+    #[test]
+    fn train_test_split_zero_fraction_yields_everything_to_train() {
+        // Legacy fallback: fraction=0 means the caller wants the pre-fix
+        // single-set baseline. Must not return an empty train set.
+        let s = TrainTestSplit::from_fraction(10, 0.0);
+        let (train, holdout) = s.indices();
+        assert_eq!(train.len(), 10);
+        assert!(holdout.is_empty());
+    }
+
+    #[test]
+    fn train_test_split_fraction_clamped_to_half() {
+        // Holdout > 50% would starve the trainer; clamp silently so
+        // operators don't configure themselves into "no training" by
+        // setting an absurd fraction.
+        let s = TrainTestSplit::from_fraction(10, 0.9);
+        let (train, holdout) = s.indices();
+        assert!(
+            train.len() >= 5,
+            "clamp must preserve at least half for training"
+        );
+        assert!(!holdout.is_empty());
+    }
+
+    #[test]
+    fn compute_percentile_anchors_sorted_and_cover_extremes() {
+        // Shuffled input — anchors must still come out monotone
+        // non-decreasing, starting at min and ending at max.
+        let anchors = compute_percentile_anchors(vec![3.0, 1.0, 2.0, 5.0, 4.0]);
+        assert_eq!(anchors.len(), BASELINE_PERCENTILES);
+        assert_eq!(anchors.first().copied(), Some(1.0));
+        assert_eq!(anchors.last().copied(), Some(5.0));
+        for w in anchors.windows(2) {
+            assert!(w[0] <= w[1], "anchors must be monotone non-decreasing");
+        }
+    }
+
+    #[test]
+    fn compute_percentile_anchors_empty_input_is_all_zero() {
+        let anchors = compute_percentile_anchors(vec![]);
+        assert_eq!(anchors.len(), BASELINE_PERCENTILES);
+        assert!(anchors.iter().all(|&v| v == 0.0));
+    }
+
+    #[test]
+    fn percentile_score_matches_expected_quantiles() {
+        // Linear ramp [0..100] → anchor[k] = k as f32. A live MSE of 50
+        // lies at the 51st anchor (51 of 101 <= 50) → score ≈ 0.505.
+        let anchors: Vec<f32> = (0..=100).map(|k| k as f32).collect();
+        let s = percentile_score(50.0, &anchors).expect("ramp anchors should score");
+        assert!(
+            (s - 0.505).abs() < 1e-4,
+            "expected ≈0.505 at median, got {s}"
+        );
+        let s_low = percentile_score(-1.0, &anchors).expect("score below min");
+        assert_eq!(s_low, 0.0);
+        let s_high = percentile_score(200.0, &anchors).expect("score above max");
+        assert_eq!(s_high, 1.0);
+    }
+
+    #[test]
+    fn percentile_score_returns_none_on_degenerate_table() {
+        // `None` is the trigger for the caller to fall back to z-score.
+        let all_zero = vec![0.0f32; BASELINE_PERCENTILES];
+        assert!(percentile_score(1.0, &all_zero).is_none());
+        let too_short = vec![1.0f32];
+        assert!(percentile_score(1.0, &too_short).is_none());
+    }
+
+    #[test]
+    fn parse_model_file_rejects_garbage() {
+        assert!(parse_model_file(&[]).is_none());
+        assert!(parse_model_file(b"NOT_AN_IWAE_HEADER_AT_ALL").is_none());
+    }
+
+    #[test]
+    fn parse_model_file_roundtrips_v2_anchors() {
+        // Minimal v2 synthetic payload — real training roundtrip is
+        // exercised by the full `train_nightly_with_store` integration
+        // test elsewhere; this one just pins the header format so a
+        // future bump forces the spec to update with it.
+        let mut buf = Vec::new();
+        buf.extend_from_slice(MODEL_MAGIC);
+        buf.extend_from_slice(&MODEL_VERSION_V2.to_le_bytes());
+        buf.extend_from_slice(&0.42f32.to_le_bytes()); // baseline_mse
+        buf.extend_from_slice(&0.37f32.to_le_bytes()); // baseline_std
+        buf.extend_from_slice(&1_000_000u64.to_le_bytes()); // samples
+        for k in 0..BASELINE_PERCENTILES {
+            buf.extend_from_slice(&(k as f32).to_le_bytes());
+        }
+        // Length-prefixed malformed JSON — loader returns None for net.
+        let payload = b"not-json";
+        buf.extend_from_slice(&(payload.len() as u32).to_le_bytes());
+        buf.extend_from_slice(payload);
+
+        let parsed = parse_model_file(&buf).expect("header + anchors must parse");
+        assert_eq!(parsed.1, 0.42); // baseline_mse
+        assert_eq!(parsed.2, 0.37); // baseline_std
+        assert_eq!(parsed.3.len(), BASELINE_PERCENTILES);
+        assert_eq!(parsed.3[50], 50.0);
+        assert!(parsed.5 >= 1, "cycles derived from samples count");
+        // Malformed JSON → net = None; this is tolerated so a corrupted
+        // weights blob doesn't discard the baseline anchors.
+        assert!(parsed.0.is_none());
+    }
+
+    #[test]
+    fn parse_model_file_handles_v1_layout_without_anchors() {
+        // v1 header is 24 bytes + length-prefixed JSON. The loader must
+        // read it without touching the anchor region + return an
+        // all-zero anchor table so `percentile_score` falls back to
+        // z-score until the next training cycle.
+        let mut buf = Vec::new();
+        buf.extend_from_slice(MODEL_MAGIC);
+        buf.extend_from_slice(&1u32.to_le_bytes()); // version 1
+        buf.extend_from_slice(&0.1f32.to_le_bytes());
+        buf.extend_from_slice(&0.2f32.to_le_bytes());
+        buf.extend_from_slice(&500_000u64.to_le_bytes());
+        let payload = b"{}";
+        buf.extend_from_slice(&(payload.len() as u32).to_le_bytes());
+        buf.extend_from_slice(payload);
+        let parsed = parse_model_file(&buf).expect("v1 header must still parse");
+        assert!(parsed.3.iter().all(|&v| v == 0.0));
+    }
+
+    #[test]
+    fn mean_reconstruction_error_empty_is_zero() {
+        let net = AutoencoderNet::new(&[NUM_FEATURES, 4, NUM_FEATURES], 0.01);
+        assert_eq!(mean_reconstruction_error(&net, &[], &[]), 0.0);
+    }
+
+    #[test]
+    fn compute_baseline_empty_returns_zero_anchors() {
+        let net = AutoencoderNet::new(&[NUM_FEATURES, 4, NUM_FEATURES], 0.01);
+        let (mse, std, anchors) = compute_baseline(&net, &[], &[]);
+        assert_eq!(mse, 0.0);
+        assert_eq!(std, 0.0);
+        assert!(anchors.iter().all(|&v| v == 0.0));
+    }
+
     fn make_event(kind: &str, src_ip: &str) -> Event {
         Event {
             ts: chrono::Utc::now(),
@@ -1612,7 +2032,9 @@ mod tests {
             "tcp_stream.ssh",
         ];
         let mut events = Vec::new();
-        for i in 0..600 {
+        // 1000 events → ~197 sliding windows. After the 20% holdout split
+        // the train set still clears `MIN_TRAIN_WINDOWS=100` comfortably.
+        for i in 0..1000 {
             let kind = kinds[i % kinds.len()];
             events.push(Event {
                 ts: Utc::now(),
@@ -1664,9 +2086,9 @@ mod tests {
         let today = Utc::now().format("%Y-%m-%d");
         let jsonl_path = dir.path().join(format!("events-{today}.jsonl"));
         let mut contents = String::new();
-        // 600 events → ~116 sliding windows at WINDOW_SIZE=20 / stride=5, just
-        // above the 100-window floor enforced by train_nightly.
-        for i in 0..600 {
+        // 1000 events → ~197 sliding windows. After the 20% holdout split
+        // the train set still clears `MIN_TRAIN_WINDOWS=100` comfortably.
+        for i in 0..1000 {
             let kind = if i % 2 == 0 {
                 "file.read_access"
             } else {

--- a/crates/agent/src/shield_inline.rs
+++ b/crates/agent/src/shield_inline.rs
@@ -501,7 +501,7 @@ mod tests {
     #[test]
     fn process_events_drop_path_blocks_ip_and_updates_drop_counters() {
         // Invariant: when both limiters fail, the packet is dropped and the IP is blocklisted.
-        let (_dir, mut shield) = make_shield_state(rl_config(1.0, 0.0, 10, 1));
+        let (_dir, mut shield) = make_shield_state(rl_config(1.0, 0.0, 10, 0));
         let ip = "198.51.100.14";
         let events = vec![
             network_event(ip, "network.tcp", 64),

--- a/crates/agent/src/shield_inline.rs
+++ b/crates/agent/src/shield_inline.rs
@@ -336,3 +336,272 @@ pub(crate) fn notify_telegram(
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::sync::Arc;
+
+    fn rl_config(
+        bucket_max_tokens: f64,
+        bucket_refill_rate: f64,
+        window_secs: i64,
+        window_max_rate: u64,
+    ) -> RateLimiterConfig {
+        RateLimiterConfig {
+            bucket_max_tokens,
+            bucket_refill_rate,
+            window_secs,
+            sub_window_count: 1,
+            window_max_rate,
+            ema_alpha: 0.3,
+            ema_alpha_var: 0.1,
+            ema_threshold_multiplier: 3.0,
+            // Keep EMA effectively out of the way for deterministic matrix tests.
+            ema_min_samples: 10_000,
+        }
+    }
+
+    fn make_shield_state(config: RateLimiterConfig) -> (tempfile::TempDir, ShieldState) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut shield = ShieldState::new(dir.path(), "/sys/fs/bpf/innerwarden", true);
+        shield.rate_limiter.reset_config(config);
+        (dir, shield)
+    }
+
+    fn network_event(ip: &str, kind: &str, bytes: u64) -> innerwarden_core::event::Event {
+        innerwarden_core::event::Event {
+            ts: chrono::Utc::now(),
+            host: "unit-host".to_string(),
+            source: "unit-test".to_string(),
+            kind: kind.to_string(),
+            severity: innerwarden_core::event::Severity::Info,
+            summary: format!("test event {kind}"),
+            details: serde_json::json!({
+                "src_ip": ip,
+                "bytes": bytes,
+                "window_size": 1024,
+                "ttl": 64
+            }),
+            tags: vec![],
+            entities: vec![],
+        }
+    }
+
+    #[test]
+    fn new_restores_persisted_escalation_state() {
+        // Invariant: shield initialization must restore previously persisted escalation state.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = Store::new(dir.path());
+        let entered_at = chrono::Utc::now() - chrono::Duration::minutes(5);
+        let persisted = innerwarden_shield::store::ShieldState {
+            escalation_state: EscalationState::Elevated,
+            state_entered_at: entered_at.to_rfc3339(),
+            blocked_ips: vec![],
+            last_saved: chrono::Utc::now().to_rfc3339(),
+        };
+        store.save_state(&persisted).expect("save shield state");
+        store.save_ddos_history(&[]).expect("save ddos history");
+
+        let shield = ShieldState::new(dir.path(), "/sys/fs/bpf/innerwarden", true);
+        assert_eq!(shield.escalation.state(), EscalationState::Elevated);
+        assert_eq!(shield.tick_counter, 0);
+    }
+
+    #[test]
+    fn process_events_under_limit_allows_without_block_mutation() {
+        // Invariant: traffic under both limiters must be allowed and keep block state untouched.
+        let (_dir, mut shield) = make_shield_state(rl_config(10.0, 0.0, 10, 10));
+        let events = vec![network_event("198.51.100.10", "network.tcp", 128)];
+
+        let (drops, incidents, blocked_ips) = process_events(&mut shield, &events, &HashMap::new());
+
+        assert_eq!(drops, 0);
+        assert!(incidents.is_empty());
+        assert!(blocked_ips.is_empty());
+        assert_eq!(shield.rate_limiter.get_metrics().total_allowed, 1);
+        assert_eq!(shield.tick_counter, 1);
+    }
+
+    #[test]
+    fn process_events_at_limit_keeps_boundary_packet_allowed() {
+        // Invariant: packets that land exactly on configured limits should still be allowed.
+        let (_dir, mut shield) = make_shield_state(rl_config(2.0, 0.0, 10, 2));
+        let events = vec![
+            network_event("198.51.100.11", "network.tcp", 64),
+            network_event("198.51.100.11", "network.tcp", 64),
+        ];
+
+        let (drops, incidents, blocked_ips) = process_events(&mut shield, &events, &HashMap::new());
+
+        let metrics = shield.rate_limiter.get_metrics();
+        assert_eq!(drops, 0);
+        assert!(incidents.is_empty());
+        assert!(blocked_ips.is_empty());
+        assert_eq!(metrics.total_allowed, 2);
+        assert_eq!(metrics.total_challenged, 0);
+        assert_eq!(metrics.total_dropped, 0);
+    }
+
+    #[test]
+    fn process_events_burst_eligible_returns_challenge_without_drop() {
+        // Invariant: a single-tripped limiter (burst-only pressure) must challenge, not drop.
+        let (_dir, mut shield) = make_shield_state(rl_config(1.0, 0.0, 10, 10));
+        let events = vec![
+            network_event("198.51.100.12", "network.tcp", 64),
+            network_event("198.51.100.12", "network.tcp", 64),
+        ];
+
+        let (drops, _incidents, blocked_ips) =
+            process_events(&mut shield, &events, &HashMap::new());
+
+        let metrics = shield.rate_limiter.get_metrics();
+        assert_eq!(drops, 0);
+        assert!(blocked_ips.is_empty());
+        assert_eq!(metrics.total_allowed, 1);
+        assert_eq!(metrics.total_challenged, 1);
+        assert_eq!(metrics.total_dropped, 0);
+        assert!(shield.xdp.get_blocklist_entries().is_empty());
+    }
+
+    #[test]
+    fn process_events_window_rollover_resets_window_pressure() {
+        // Invariant: once the sliding window expires, new traffic should be evaluated fresh.
+        let (_dir, mut shield) = make_shield_state(rl_config(5_000.0, 5_000.0, 1, 1));
+        let ip = "198.51.100.13";
+        let burst: Vec<_> = (0..1_200)
+            .map(|_| network_event(ip, "network.tcp", 64))
+            .collect();
+        process_events(&mut shield, &burst, &HashMap::new());
+        let before_rollover = shield.rate_limiter.get_metrics();
+        assert!(
+            before_rollover.total_challenged > 0,
+            "window pressure should produce at least one challenge before rollover"
+        );
+        assert_eq!(before_rollover.total_dropped, 0);
+
+        std::thread::sleep(std::time::Duration::from_millis(2_100));
+        let later = vec![network_event(ip, "network.tcp", 64)];
+        process_events(&mut shield, &later, &HashMap::new());
+
+        let after_rollover = shield.rate_limiter.get_metrics();
+        assert_eq!(
+            after_rollover.total_allowed,
+            before_rollover.total_allowed + 1
+        );
+        assert_eq!(
+            after_rollover.total_challenged,
+            before_rollover.total_challenged
+        );
+        assert_eq!(after_rollover.total_dropped, before_rollover.total_dropped);
+    }
+
+    #[test]
+    fn process_events_drop_path_blocks_ip_and_updates_drop_counters() {
+        // Invariant: when both limiters fail, the packet is dropped and the IP is blocklisted.
+        let (_dir, mut shield) = make_shield_state(rl_config(1.0, 0.0, 10, 1));
+        let ip = "198.51.100.14";
+        let events = vec![
+            network_event(ip, "network.tcp", 64),
+            network_event(ip, "network.tcp", 64),
+        ];
+
+        let (drops, _incidents, blocked_ips) =
+            process_events(&mut shield, &events, &HashMap::new());
+
+        let metrics = shield.rate_limiter.get_metrics();
+        assert_eq!(drops, 1);
+        assert_eq!(blocked_ips, vec![ip.to_string()]);
+        assert_eq!(metrics.total_dropped, 1);
+        assert_eq!(metrics.blocked_ips, 1);
+        assert!(shield.xdp.is_blocked(ip));
+
+        // Already-blocked traffic must continue to count as dropped.
+        let follow_up = vec![network_event(ip, "network.tcp", 64)];
+        let (second_drops, _incidents, _blocked_ips) =
+            process_events(&mut shield, &follow_up, &HashMap::new());
+        assert_eq!(second_drops, 1);
+        assert_eq!(shield.rate_limiter.get_metrics().total_dropped, 2);
+    }
+
+    #[test]
+    fn write_incidents_empty_input_does_not_create_daily_file() {
+        // Invariant: empty incident batches must be a no-op and not create output artifacts.
+        let dir = tempfile::tempdir().expect("tempdir");
+        write_incidents(dir.path(), &[]);
+
+        let today = chrono::Local::now().date_naive().format("%Y-%m-%d");
+        let path = dir.path().join(format!("incidents-{today}.jsonl"));
+        assert!(!path.exists());
+    }
+
+    #[test]
+    fn write_incidents_non_empty_batch_appends_jsonl_lines() {
+        // Invariant: each emitted incident must be persisted as one JSONL line.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let incidents = vec![
+            serde_json::json!({"severity": "high", "title": "first"}),
+            serde_json::json!({"severity": "critical", "title": "second"}),
+        ];
+        write_incidents(dir.path(), &incidents);
+
+        let today = chrono::Local::now().date_naive().format("%Y-%m-%d");
+        let path = dir.path().join(format!("incidents-{today}.jsonl"));
+        let content = std::fs::read_to_string(path).expect("read incidents file");
+        let lines: Vec<&str> = content.lines().collect();
+        assert_eq!(lines.len(), 2);
+        let first: serde_json::Value = serde_json::from_str(lines[0]).expect("first line json");
+        let second: serde_json::Value = serde_json::from_str(lines[1]).expect("second line json");
+        assert_eq!(first["title"], "first");
+        assert_eq!(second["title"], "second");
+    }
+
+    #[test]
+    fn notify_telegram_without_client_is_noop() {
+        // Invariant: no Telegram client means no gate/deferred mutations and no side effects.
+        let incidents = vec![serde_json::json!({
+            "severity": "high",
+            "title": "Shield escalation",
+            "summary": "blocked"
+        })];
+        let burst_tracker = crate::notification_gate::BurstTracker::new();
+        let mut deferred = HashMap::new();
+        let counter = AtomicU64::new(0);
+
+        notify_telegram(&None, &incidents, &burst_tracker, &mut deferred, &counter);
+
+        assert!(deferred.is_empty());
+        assert_eq!(counter.load(Ordering::Relaxed), 0);
+        assert_eq!(burst_tracker.count(), 0);
+    }
+
+    #[test]
+    fn notify_telegram_daily_briefing_path_increments_deferred_and_counter() {
+        // Invariant: contained high/critical shield events must defer to daily briefing, not send now.
+        let telegram_client = Some(Arc::new(
+            crate::telegram::TelegramClient::new("token", "123", None).expect("telegram client"),
+        ));
+        let incidents = vec![serde_json::json!({
+            "severity": "high",
+            "title": "Shield escalation",
+            "summary": "contained attack"
+        })];
+        let burst_tracker = crate::notification_gate::BurstTracker::new();
+        let mut deferred = HashMap::new();
+        let counter = AtomicU64::new(0);
+
+        notify_telegram(
+            &telegram_client,
+            &incidents,
+            &burst_tracker,
+            &mut deferred,
+            &counter,
+        );
+
+        assert_eq!(deferred.get("shield").copied(), Some(1));
+        assert_eq!(counter.load(Ordering::Relaxed), 1);
+        assert_eq!(burst_tracker.count(), 1);
+    }
+}

--- a/crates/agent/src/telemetry_tick.rs
+++ b/crates/agent/src/telemetry_tick.rs
@@ -16,3 +16,49 @@ pub(crate) fn write_tick_snapshot(state: &mut AgentState, tick_name: &str) {
         state.telemetry.observe_error("telemetry_writer");
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeMap;
+
+    #[test]
+    fn write_tick_snapshot_emits_snapshot_when_writer_present() {
+        // Invariant: when a writer is configured, each tick must persist a telemetry snapshot.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut state = crate::tests::triage_test_state(dir.path());
+        state.telemetry_writer =
+            Some(crate::telemetry::TelemetryWriter::new(dir.path()).expect("telemetry writer"));
+
+        write_tick_snapshot(&mut state, "incident_tick");
+
+        let date = chrono::Local::now()
+            .date_naive()
+            .format("%Y-%m-%d")
+            .to_string();
+        let latest = crate::telemetry::read_latest_snapshot(dir.path(), &date)
+            .expect("snapshot should be written");
+        assert_eq!(latest.tick, "incident_tick");
+    }
+
+    #[test]
+    fn write_tick_snapshot_no_snapshot_this_tick_when_writer_absent() {
+        // Invariant: if no writer is configured, the tick must not create telemetry files or errors.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut state = crate::tests::triage_test_state(dir.path());
+        let before_errors = state.telemetry.snapshot("before").errors_by_component;
+
+        write_tick_snapshot(&mut state, "incident_tick");
+
+        let after_errors = state.telemetry.snapshot("after").errors_by_component;
+        assert_eq!(before_errors, after_errors);
+        assert_eq!(after_errors, BTreeMap::new());
+
+        let date = chrono::Local::now()
+            .date_naive()
+            .format("%Y-%m-%d")
+            .to_string();
+        let path = dir.path().join(format!("telemetry-{date}.jsonl"));
+        assert!(!path.exists());
+    }
+}


### PR DESCRIPTION
## Summary
Syncs development into main and includes the additional autoencoder anomaly-scoring fix commit requested in-thread.

## Included extra change
- fix(neural): percentile-based anomaly scoring to stop sigmoid saturation (2e65ea5)

## Validation run locally
- cargo test --workspace ✅
- make check ✅
- make scenario-qa ✅

## Notes
- This PR follows the periodic sync path (development -> main) and includes the requested fix.
