### PR TITLE
feat: startup banner + voice on autonomous decisions (1.C A+B)

### DIFF
--- a/crates/agent/src/decision_block_ip.rs
+++ b/crates/agent/src/decision_block_ip.rs
@@ -317,7 +317,7 @@ pub(crate) fn consult_circuit_breaker(
                 limit,
                 hour = %hour,
                 mode = mode.as_label(),
-                "circuit breaker TRIPPED — pausing block pipeline until UTC hour rolls over (or run `innerwarden system circuit-reset`)"
+                "circuit breaker tripped. Block pipeline paused until next UTC hour (or run `innerwarden system circuit-reset`)."
             );
         }
         crate::circuit_breaker::Decision::RefuseAfterTrip { count, limit, hour } => {
@@ -326,7 +326,7 @@ pub(crate) fn consult_circuit_breaker(
                 count,
                 limit,
                 hour = %hour,
-                "circuit breaker still tripped — block refused silently"
+                "circuit breaker still tripped. Block refused silently."
             );
         }
         crate::circuit_breaker::Decision::AutoRearm { count, limit, hour } => {
@@ -335,7 +335,7 @@ pub(crate) fn consult_circuit_breaker(
                 count,
                 limit,
                 hour = %hour,
-                "circuit breaker auto-rearmed — new UTC hour, counters reset"
+                "circuit breaker auto-rearmed. New UTC hour, counters reset."
             );
         }
         crate::circuit_breaker::Decision::Allow { .. } => {}

--- a/crates/agent/src/incident_autodismiss.rs
+++ b/crates/agent/src/incident_autodismiss.rs
@@ -90,7 +90,7 @@ fn detector_from_incident_id(incident_id: &str) -> &str {
 
 fn autodismiss_reason(detector: &str, severity: &innerwarden_core::event::Severity) -> String {
     format!(
-        "Auto-dismissed: {detector} below AI severity threshold (severity {:?})",
+        "Low-priority {detector} ({:?}). Filed, not firing.",
         severity,
     )
 }

--- a/crates/agent/src/incident_obvious.rs
+++ b/crates/agent/src/incident_obvious.rs
@@ -80,12 +80,14 @@ pub(crate) async fn try_handle_obvious_incident(
         auto_execute: true,
         reason: match obvious_detector_policy(detector) {
             ObviousPolicy::RepeatOffender => {
-                format!("Auto-blocked: obvious {detector} from repeat offender {ip}")
+                format!("Shut the door on {ip}. {detector}, seen before. No more guesses.")
             }
             ObviousPolicy::FirstHit => {
-                format!("Auto-blocked: {detector} from {ip} (first hit is the attack)")
+                format!(
+                    "Shut the door on {ip}. {detector} caught on first try. Compromise averted."
+                )
             }
-            ObviousPolicy::None => format!("Auto-blocked: {detector} from {ip}"),
+            ObviousPolicy::None => format!("Shut the door on {ip}. {detector}."),
         },
         alternatives: vec![],
         estimated_threat: "high".to_string(),

--- a/crates/ctl/src/banner.rs
+++ b/crates/ctl/src/banner.rs
@@ -1,0 +1,111 @@
+//! Startup banner for the `innerwarden` CLI.
+//!
+//! Shown when the binary runs with no arguments. The banner has no operational
+//! purpose; it exists so the first run does not feel like talking to a
+//! compiler.
+
+use std::io::{IsTerminal, Write};
+
+const BANNER: &str = r#"
+   █ █▄░█ █▄░█ █▀▀ █▀█ █░█░█ ▄▀█ █▀█ █▀▄ █▀▀ █▄░█
+   █ █░▀█ █░▀█ ██▄ █▀▄ ▀▄▀▄▀ █▀█ █▀▄ █▄▀ ██▄ █░▀█
+"#;
+
+const TAGLINES: &[&str] = &[
+    "kernel-level. autonomous. no SOC.",
+    "your server, with a shorter temper.",
+    "detection, triage, response. one daemon.",
+    "the guard dog that reads kernel events.",
+    "ring -2 to ring 3. one binary.",
+    "install once. forget. stay protected.",
+];
+
+pub fn render(version: &str, writer: &mut dyn Write) -> std::io::Result<()> {
+    let use_color = should_color();
+    let dim = if use_color { "\x1b[2m" } else { "" };
+    let accent = if use_color { "\x1b[38;5;208m" } else { "" };
+    let reset = if use_color { "\x1b[0m" } else { "" };
+
+    writeln!(writer, "{accent}{}{reset}", BANNER.trim_end_matches('\n'))?;
+    writeln!(
+        writer,
+        "      {dim}v{version} · {tag}{reset}",
+        tag = pick_tagline(version),
+    )?;
+    writeln!(writer)?;
+    Ok(())
+}
+
+fn should_color() -> bool {
+    if std::env::var_os("NO_COLOR").is_some() {
+        return false;
+    }
+    std::io::stdout().is_terminal()
+}
+
+fn pick_tagline(seed: &str) -> &'static str {
+    if TAGLINES.is_empty() {
+        return "";
+    }
+    let idx = seed
+        .bytes()
+        .fold(0u64, |acc, b| acc.wrapping_add(b as u64))
+        .wrapping_add(seconds_of_day())
+        % TAGLINES.len() as u64;
+    TAGLINES[idx as usize]
+}
+
+fn seconds_of_day() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs() % 86_400)
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn render_writes_version_and_banner() {
+        let mut buf = Vec::new();
+        render("0.12.3", &mut buf).unwrap();
+        let out = String::from_utf8(buf).unwrap();
+        assert!(out.contains("v0.12.3"), "must print version: {out}");
+        // Banner uses block glyphs for the stylized "INNER WARDEN" text.
+        assert!(out.contains('█'), "must print banner glyphs: {out}");
+    }
+
+    #[test]
+    fn render_writes_one_of_the_taglines() {
+        let mut buf = Vec::new();
+        render("0.12.3", &mut buf).unwrap();
+        let out = String::from_utf8(buf).unwrap();
+        assert!(
+            TAGLINES.iter().any(|t| out.contains(t)),
+            "must print one of the taglines: {out}"
+        );
+    }
+
+    #[test]
+    fn pick_tagline_returns_non_empty_for_valid_input() {
+        for seed in ["", "a", "version", "0.12.3"] {
+            let t = pick_tagline(seed);
+            assert!(!t.is_empty(), "tagline must be non-empty for seed {seed:?}");
+        }
+    }
+
+    #[test]
+    fn render_respects_no_color_env() {
+        // The render function itself emits ANSI only when should_color() is
+        // true; directly test should_color's NO_COLOR gate via env.
+        // Save + restore so the test is hermetic.
+        let prior = std::env::var_os("NO_COLOR");
+        std::env::set_var("NO_COLOR", "1");
+        assert!(!should_color());
+        match prior {
+            Some(v) => std::env::set_var("NO_COLOR", v),
+            None => std::env::remove_var("NO_COLOR"),
+        }
+    }
+}

--- a/crates/ctl/src/commands/ops.rs
+++ b/crates/ctl/src/commands/ops.rs
@@ -2189,10 +2189,10 @@ mod tests {
             agent_config: data_dir.join("agent.toml"),
             data_dir: data_dir.to_path_buf(),
             dry_run,
-            command: crate::Command::Decisions {
+            command: Some(crate::Command::Decisions {
                 days: 1,
                 action: None,
-            },
+            }),
         }
     }
 

--- a/crates/ctl/src/main.rs
+++ b/crates/ctl/src/main.rs
@@ -10,6 +10,7 @@ use std::path::{Path, PathBuf};
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
 
+mod banner;
 mod calibrate;
 mod capabilities;
 mod capability;
@@ -40,7 +41,7 @@ use innerwarden_core::audit::{append_admin_action, current_operator, AdminAction
 #[derive(Parser)]
 #[command(
     name = "innerwarden",
-    about = "InnerWarden — self-defending security for Linux and macOS",
+    about = "InnerWarden. self-defending security for Linux and macOS.",
     long_about = "8 commands to protect your server:\n\n\
                   \x20 get       Query status, incidents, decisions, reports\n\
                   \x20 stream    Monitor events in real-time\n\
@@ -70,7 +71,7 @@ struct Cli {
     dry_run: bool,
 
     #[command(subcommand)]
-    command: Command,
+    command: Option<Command>,
 }
 
 #[derive(Subcommand)]
@@ -169,7 +170,7 @@ enum Command {
         command: ModuleCommand,
     },
 
-    /// AI agent management — install, scan, connect, monitor agents.
+    /// AI agent management. Install, scan, connect, monitor agents.
     ///
     /// Run without arguments for an interactive menu.
     ///
@@ -1938,7 +1939,15 @@ fn main() -> Result<()> {
         }
     }
 
-    match cli.command {
+    let Some(command) = cli.command.take() else {
+        banner::render(env!("CARGO_PKG_VERSION"), &mut std::io::stdout()).ok();
+        use clap::CommandFactory;
+        Cli::command().print_help()?;
+        println!();
+        return Ok(());
+    };
+
+    match command {
         // ===================================================================
         // New grouped commands
         // ===================================================================
@@ -2594,10 +2603,10 @@ mod tests {
             agent_config: data_dir.join("agent.toml"),
             data_dir: data_dir.to_path_buf(),
             dry_run: false,
-            command: Command::Decisions {
+            command: Some(Command::Decisions {
                 days: 1,
                 action: None,
-            },
+            }),
         }
     }
 


### PR DESCRIPTION
## Summary

First increment of Phase 1.C (cool factor for OSS). Two pieces:

### A. CLI banner
Running \`innerwarden\` bare (no subcommand) now prints a stylized banner + rotating tagline + version, then drops into normal help. Respects \`NO_COLOR\`. First contact with the tool feels less like a compiler error.

### B. Voice on autonomous decisions
Decision audit reasons + log lines rewritten from stock \`Auto-blocked: X from Y\` to something with a personality:

- **obvious-gate RepeatOffender**: \`Shut the door on {ip}. {detector}, seen before. No more guesses.\`
- **obvious-gate FirstHit**: \`Shut the door on {ip}. {detector} caught on first try. Compromise averted.\`
- **noise-gate dismiss**: \`Low-priority {detector} ({severity}). Filed, not firing.\`
- **circuit breaker trip / refuse / rearm**: rewritten without em dashes, reads like short status updates.

Em dashes removed from the root \`about\` string too.

## Test plan

- [x] \`cargo clippy --workspace -- -D warnings\` clean
- [x] \`cargo fmt --all --check\` clean
- [x] \`cargo test -p innerwarden-agent\` - 1537 pass
- [x] \`cargo test -p innerwarden-ctl\` - 437 pass (3 new banner tests)
- [x] Smoke: \`target/debug/innerwarden-ctl\` prints banner + help
- [ ] Smoke on prod after merge: banner renders with colour in TTY, \`NO_COLOR=1\` suppresses ANSI, a real obvious-gate block shows new reason text in \`innerwarden get decisions\`.