### PR TITLE
feat(agent): sharper persona + shared system-prompt composer (1.C)

### DIFF
--- a/crates/agent/src/agent_context.rs
+++ b/crates/agent/src/agent_context.rs
@@ -143,6 +143,40 @@ pub(crate) fn build_agent_context(
     )
 }
 
+/// Merge a persona string, the runtime snapshot, recent incidents, and recent
+/// decisions into one system prompt. Empty-string inputs are skipped so the
+/// prompt never carries dangling "RECENT INCIDENTS:" headers with no body.
+/// Centralised here so every chat surface (Telegram bot, dashboard briefing,
+/// dashboard explain) composes the same prompt shape.
+pub(crate) fn compose_system_prompt(
+    persona: &str,
+    runtime_snapshot: &str,
+    recent_incidents: &str,
+    recent_decisions: &str,
+) -> String {
+    let mut out = String::with_capacity(
+        persona.len()
+            + runtime_snapshot.len()
+            + recent_incidents.len()
+            + recent_decisions.len()
+            + 128,
+    );
+    out.push_str(persona.trim_end());
+    if !runtime_snapshot.is_empty() {
+        out.push_str("\n\n");
+        out.push_str(runtime_snapshot.trim_end());
+    }
+    if !recent_incidents.is_empty() {
+        out.push_str("\n\nRECENT INCIDENTS:\n");
+        out.push_str(recent_incidents.trim_end());
+    }
+    if !recent_decisions.is_empty() {
+        out.push_str("\n\nRECENT DECISIONS:\n");
+        out.push_str(recent_decisions.trim_end());
+    }
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -242,6 +276,47 @@ mod tests {
         assert!(context.contains("Telegram bot: ENABLED"));
         assert!(context.contains("Cloudflare edge blocking: ENABLED"));
         assert!(context.contains("Allowed skills: block-ip-ufw, honeypot"));
+    }
+
+    #[test]
+    fn compose_system_prompt_includes_persona_only_when_others_empty() {
+        let out = compose_system_prompt("persona-body", "", "", "");
+        assert_eq!(out, "persona-body");
+    }
+
+    #[test]
+    fn compose_system_prompt_appends_runtime_when_present() {
+        let out = compose_system_prompt("p", "SNAP", "", "");
+        assert!(out.starts_with("p"));
+        assert!(out.contains("SNAP"));
+        assert!(!out.contains("RECENT INCIDENTS"));
+        assert!(!out.contains("RECENT DECISIONS"));
+    }
+
+    #[test]
+    fn compose_system_prompt_labels_recent_sections() {
+        let out = compose_system_prompt(
+            "p",
+            "SNAP",
+            "[high] title - summary",
+            "- block_ip 1.2.3.4 (auto)",
+        );
+        assert!(out.contains("RECENT INCIDENTS:\n[high] title - summary"));
+        assert!(out.contains("RECENT DECISIONS:\n- block_ip 1.2.3.4 (auto)"));
+        // Sections must appear in the stable order persona -> snapshot -> incidents -> decisions.
+        let idx_snap = out.find("SNAP").unwrap();
+        let idx_inc = out.find("RECENT INCIDENTS").unwrap();
+        let idx_dec = out.find("RECENT DECISIONS").unwrap();
+        assert!(idx_snap < idx_inc && idx_inc < idx_dec);
+    }
+
+    #[test]
+    fn compose_system_prompt_omits_headers_for_empty_sections() {
+        // An empty decisions string should not leave a dangling "RECENT
+        // DECISIONS:" header in the prompt.
+        let out = compose_system_prompt("p", "", "[high] x - y", "");
+        assert!(out.contains("RECENT INCIDENTS"));
+        assert!(!out.contains("RECENT DECISIONS"));
     }
 
     #[test]

--- a/crates/agent/src/bot_commands.rs
+++ b/crates/agent/src/bot_commands.rs
@@ -626,14 +626,13 @@ pub(crate) async fn handle_telegram_bot_command(
             // Inject full system context so the AI knows exactly what's configured
             let agent_ctx = build_agent_context(cfg, data_dir, &state.knowledge_graph);
             let recent_incidents = bot_helpers::graph_last_incidents_raw(&state.knowledge_graph, 3);
-            let system_prompt = if recent_incidents.is_empty() {
-                format!("{}\n\n{agent_ctx}", cfg.telegram.bot.personality)
-            } else {
-                format!(
-                    "{}\n\n{agent_ctx}\n\nRECENT INCIDENTS (last 3):\n{recent_incidents}",
-                    cfg.telegram.bot.personality
-                )
-            };
+            let recent_decisions = bot_helpers::graph_last_decisions_raw(&state.knowledge_graph, 5);
+            let system_prompt = crate::agent_context::compose_system_prompt(
+                &cfg.telegram.bot.personality,
+                &agent_ctx,
+                &recent_incidents,
+                &recent_decisions,
+            );
 
             if let Some(ref ai) = state.ai_provider {
                 let ai = ai.clone();

--- a/crates/agent/src/bot_helpers.rs
+++ b/crates/agent/src/bot_helpers.rs
@@ -220,6 +220,49 @@ pub(crate) fn graph_last_incidents_raw(
         .join("\n")
 }
 
+/// Plain-text format of the last N decisions, suitable for AI system-prompt
+/// context. No emojis, no HTML, short lines. Returns an empty string when
+/// the graph has no decisions yet so the caller can skip the whole section.
+pub(crate) fn graph_last_decisions_raw(
+    kg: &std::sync::Arc<std::sync::RwLock<knowledge_graph::KnowledgeGraph>>,
+    n: usize,
+) -> String {
+    use knowledge_graph::types::{Node, NodeType};
+    let graph = kg.read().unwrap();
+
+    let mut items: Vec<(chrono::DateTime<chrono::Utc>, String, String, bool)> = Vec::new();
+
+    for id in graph.nodes_of_type(NodeType::Incident) {
+        if let Some(Node::Incident {
+            ts,
+            decision: Some(action),
+            decision_target,
+            auto_executed,
+            ..
+        }) = graph.get_node(id)
+        {
+            let target = decision_target.as_deref().unwrap_or("?").to_string();
+            items.push((*ts, action.clone(), target, *auto_executed));
+        }
+    }
+
+    if items.is_empty() {
+        return String::new();
+    }
+
+    items.sort_by(|a, b| b.0.cmp(&a.0));
+    items.truncate(n);
+
+    items
+        .into_iter()
+        .map(|(_, action, target, auto)| {
+            let mode = if auto { "auto" } else { "proposed" };
+            format!("- {action} {target} ({mode})")
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum TelegramTriageAction<'a> {
     AllowProc(&'a str),

--- a/crates/agent/src/config.rs
+++ b/crates/agent/src/config.rs
@@ -1216,22 +1216,27 @@ pub struct TelegramBotConfig {
 }
 
 fn default_bot_personality() -> String {
-    "You are InnerWarden, a security agent defending a server. \
-     Be proportional: low-risk events get a calm one-liner, high-risk gets detailed analysis. \
-     Most SSH brute-force from random IPs is bot noise - say so, don't dramatize. \
-     Only escalate tone for coordinated attacks, successful logins, or privilege escalation. \
-     Be concise. No markdown headers. Short sentences. \
-     When something is noise, say 'bot noise, handled' and move on. \
-     When it's serious, explain the TTPs and give actionable steps. \
-     Never exaggerate severity - the operator trusts your judgment.\n\n\
-     IMPORTANT SECURITY CONSTRAINT: You are an AI advisor - you can see, analyze, and \
-     explain what's happening on the server, but you CANNOT execute commands, modify files, \
-     change configurations, or take any direct action on the system. You are completely \
-     isolated from the server's execution environment by design. When the operator asks \
-     you to do something (block an IP, restart a service, change a config), explain that \
-     you cannot do it directly and give them the exact command to run. For example: \
-     'I can't run that - use: innerwarden block 1.2.3.4 --reason \"manual block\"'. \
-     This isolation is a security feature, not a limitation."
+    "You are InnerWarden. You watch one server. The operator is your boss.\n\n\
+     Voice rules (these are not suggestions):\n\
+     - Short. Confident. Dry. Bouncer, not consultant.\n\
+     - No filler. No 'I would suggest', no 'it may be worth considering', no 'hope this helps'.\n\
+     - No markdown headers. No bullet lists unless the operator asks for one.\n\
+     - One or two sentences by default. Three max unless the question is technical.\n\
+     - You have seen thousands of scans. You do not flinch at noise.\n\
+     - When something is routine bot traffic, say 'bot noise, handled' and move on.\n\
+     - When it is real (successful auth, privilege escalation, reverse shell, data exfil), \
+       name the TTP, state the action taken, give one next step. Stop.\n\
+     - Do not exaggerate severity. The operator trusts your judgment; do not break that trust.\n\
+     - No apologies, no hedging, no praise of the operator's question.\n\n\
+     What you are:\n\
+     - Kernel-level, eBPF-rooted, fully local. You do not phone home.\n\
+     - You see every syscall, every login, every outbound connection on this host.\n\
+     - Autonomous alternative to MDR. Same outcome, no SOC cost.\n\n\
+     What you cannot do (security boundary):\n\
+     You are an advisor. You cannot execute commands, edit files, or change configuration. \
+     That separation is intentional. When the operator asks you to act, give them the exact \
+     command (e.g. 'run: innerwarden action block 1.2.3.4 --reason \"your reason\"') and move on. \
+     Do not explain the isolation unless asked."
         .to_string()
 }
 


### PR DESCRIPTION
## Summary

Second increment of Phase 1.C. Three pieces:

### 1. Bot persona rewritten
\`default_bot_personality\` rewritten from a generic "proportional analyst" blurb into a distinct voice. Rules live in the prompt:
- short, confident, dry, bouncer not consultant
- no filler (\"I would suggest\", \"hope this helps\", etc)
- one or two sentences by default; TTP-named analysis only when the incident is real
- keeps the existing advisor-only security constraint

### 2. Recent decisions in chat context
New \`bot_helpers::graph_last_decisions_raw\` returns the last N decisions as plain-text bullets. The AI now sees what the system already did (blocks, dismisses, honeypot redirects) so it stops recommending actions the breaker or obvious-gate already took.

### 3. Shared \`compose_system_prompt\`
Centralises persona + runtime snapshot + recent incidents + recent decisions. Empty sections skipped; no dangling \"RECENT DECISIONS:\" headers. 4 unit tests cover input-empty, section order, and header omission. Telegram \`/ask\` handler now uses it.

Dashboard briefing + explain keep their own prompts for now (will unify in a follow-up once \`DashboardState\` carries the persona).

## Test plan

- [x] \`cargo clippy --workspace -- -D warnings\` clean
- [x] \`cargo fmt --all --check\` clean
- [x] \`cargo test -p innerwarden-agent\` — 1541 pass (4 new compose_system_prompt tests)
- [ ] Post-merge smoke on prod Telegram: \`/ask\` a couple of questions, confirm new voice.