### PR TITLE
fix(agent): persona over-applied 'bot noise, handled' to greetings

### DIFF
--- a/crates/agent/src/config.rs
+++ b/crates/agent/src/config.rs
@@ -1217,15 +1217,26 @@ pub struct TelegramBotConfig {
 
 fn default_bot_personality() -> String {
     "You are InnerWarden. You watch one server. The operator is your boss.\n\n\
-     Voice rules (these are not suggestions):\n\
+     How to read the operator's message first:\n\
+     - If it is a greeting or small talk (\"hey\", \"what's up\", \"how are you\", \"good morning\"), \
+       answer like a friendly colleague who is also on shift. Short, warm, human. \
+       One short sentence. Do NOT treat it as a security query.\n\
+     - If it is an off-topic question (weather, jokes, general chat), answer briefly without \
+       forcing security context.\n\
+     - If it is a security question about the server, incidents, or blocks, use the voice below.\n\n\
+     Voice rules for security answers:\n\
      - Short. Confident. Dry. Bouncer, not consultant.\n\
-     - No filler. No 'I would suggest', no 'it may be worth considering', no 'hope this helps'.\n\
+     - No filler. No 'I would suggest', no 'it may be worth considering', no 'hope this helps', \
+       no 'system appears stable'.\n\
      - No markdown headers. No bullet lists unless the operator asks for one.\n\
      - One or two sentences by default. Three max unless the question is technical.\n\
      - You have seen thousands of scans. You do not flinch at noise.\n\
-     - When something is routine bot traffic, say 'bot noise, handled' and move on.\n\
-     - When it is real (successful auth, privilege escalation, reverse shell, data exfil), \
-       name the TTP, state the action taken, give one next step. Stop.\n\
+     - When the operator asks about the *state of the server* or *what happened today* and \
+       the snapshot shows only routine bot traffic, say something like \"quiet, just the \
+       usual scanners\" or \"nothing real today, scanners handled\". Never just echo \"bot \
+       noise, handled\" without context; that phrase belongs in decision logs, not chat.\n\
+     - When a real incident fired (successful auth, privilege escalation, reverse shell, \
+       data exfil), name the TTP, state the action taken, give one next step. Stop.\n\
      - Do not exaggerate severity. The operator trusts your judgment; do not break that trust.\n\
      - No apologies, no hedging, no praise of the operator's question.\n\n\
      What you are:\n\

--- a/crates/agent/src/dashboard/agent_api.rs
+++ b/crates/agent/src/dashboard/agent_api.rs
@@ -1020,6 +1020,32 @@ pub(super) async fn api_incident_groups(
         .into_response()
 }
 
+/// Empty-state payload for `/api/responses`. Both `state_counts` and
+/// `totals` must be populated: responses.js reads `r.state_counts.revert_pending`
+/// and `r.totals.registered` and would evaluate `undefined.field` on a
+/// clean install without the full shape. Kept as a standalone helper so
+/// tests can assert on the shape without standing up a `DashboardState`.
+pub(super) fn empty_responses_payload() -> serde_json::Value {
+    serde_json::json!({
+        "active": [],
+        "active_count": 0,
+        "history": [],
+        "state_counts": {
+            "pending": 0,
+            "active": 0,
+            "expired": 0,
+            "revert_pending": 0,
+            "revert_failed": 0,
+            "reverted": 0,
+        },
+        "totals": {
+            "registered": 0,
+            "expired": 0,
+            "reverted": 0,
+        },
+    })
+}
+
 /// GET /api/responses — active and historical response actions with TTL.
 pub(super) async fn api_responses(State(state): State<DashboardState>) -> axum::response::Response {
     // Try SQLite blob first, fall back to JSON file
@@ -1043,7 +1069,7 @@ pub(super) async fn api_responses(State(state): State<DashboardState>) -> axum::
             .unwrap()
             .into_response(),
         None => {
-            let empty = serde_json::json!({"active": [], "active_count": 0, "history": [], "totals": {"registered": 0, "expired": 0, "reverted": 0}});
+            let empty = empty_responses_payload();
             axum::response::Response::builder()
                 .header("content-type", "application/json")
                 .body(Body::from(serde_json::to_string(&empty).unwrap()))
@@ -1192,6 +1218,34 @@ pub(super) async fn api_mitre_coverage(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn empty_responses_payload_covers_every_field_responses_js_reads() {
+        // responses.js crashes with TypeError if any of these are missing;
+        // this test locks in the shape so a future edit to the handler
+        // cannot silently drop a key the renderer expects.
+        let payload = empty_responses_payload();
+        for k in ["active", "history"] {
+            assert!(payload[k].is_array(), "{k} must be an array");
+        }
+        assert_eq!(payload["active_count"], 0);
+        for k in [
+            "pending",
+            "active",
+            "expired",
+            "revert_pending",
+            "revert_failed",
+            "reverted",
+        ] {
+            assert!(
+                payload["state_counts"][k].is_u64(),
+                "state_counts.{k} missing"
+            );
+        }
+        for k in ["registered", "expired", "reverted"] {
+            assert!(payload["totals"][k].is_u64(), "totals.{k} missing");
+        }
+    }
 
     #[test]
     fn test_parse_disabled_detectors() {

--- a/crates/agent/src/dashboard/data_api.rs
+++ b/crates/agent/src/dashboard/data_api.rs
@@ -15,6 +15,42 @@ pub(super) fn is_dashboard_sleeping(last_activity: &std::sync::atomic::AtomicU64
         .as_secs();
     now.saturating_sub(last) > DASHBOARD_SLEEP_SECS
 }
+
+/// Build the AI briefing system prompt. When the operator has a bot
+/// personality configured, use it as the base so the Home briefing speaks
+/// in the same voice as Telegram `/ask`; otherwise fall back to a plain
+/// analyst prompt (preserves behaviour in test fixtures that build a bare
+/// `DashboardActionConfig::default()`).
+pub(super) fn briefing_system_prompt(personality: &str) -> String {
+    let guidance = "FORMAT: generate a concise intelligence briefing. \
+        Short sections. No fluff. No generic security advice. \
+        Name the TTP and state the action taken for any real incident; \
+        treat routine scanner noise as one summary line, not a section each.";
+    if personality.trim().is_empty() {
+        format!("You are a senior security analyst.\n\n{guidance}")
+    } else {
+        format!("{}\n\n{guidance}", personality.trim_end())
+    }
+}
+
+/// Build the AI explain-threat system prompt used by the Threats drill-down.
+/// Uses the same base personality as the briefing so all three AI surfaces
+/// (Home briefing, Threats explain, Telegram /ask) speak in one voice,
+/// layered with the plain-English simplification guidance.
+pub(super) fn explain_system_prompt(personality: &str) -> String {
+    let simplifier = "FORMAT: you are explaining one incident to the operator. \
+        Base your answer strictly on the incident data provided. \
+        2-3 sentences. No jargon. No generic advice. \
+        Only call it dangerous if the attacker got past initial contact \
+        (successful authentication, shell access, data exfil).";
+    if personality.trim().is_empty() {
+        format!(
+            "You are a security assistant explaining threats to a non-technical person.\n\n{simplifier}"
+        )
+    } else {
+        format!("{}\n\n{simplifier}", personality.trim_end())
+    }
+}
 pub(super) async fn api_overview(
     State(state): State<DashboardState>,
     Query(query): Query<ListQuery>,
@@ -366,9 +402,8 @@ pub(super) async fn api_briefing_generate(
             "error": "AI provider not configured. Enable AI in agent.toml to generate briefings.",
         }));
     };
-    let system =
-        "You are a senior security analyst. Generate a concise, actionable intelligence briefing.";
-    match ai.chat(system, &prompt).await {
+    let system = briefing_system_prompt(&state.action_cfg.ai_personality);
+    match ai.chat(&system, &prompt).await {
         Ok(response) => {
             let b = crate::briefing::parse_briefing(&response, threat_level);
             let result = serde_json::json!({
@@ -506,20 +541,14 @@ pub(super) async fn api_ai_explain(
         )
     };
 
-    let system = "You are a security assistant explaining threats to a non-technical person. \
-        This server is protected by InnerWarden (an AI security agent) and uses SSH key-only authentication (password login is disabled). \
-        Explain in plain English: what happened, whether it's actually dangerous, and whether any action is needed. \
-        Base your answer strictly on the incident data provided — the title and summary tell you exactly what happened. \
-        Most activity you'll see is routine internet noise (bots scanning every IP on the internet). Failed connection attempts from scanners are NOT dangerous. \
-        Only say it's dangerous if the attacker actually got past the initial connection (authentication success, shell access, data exfiltration). \
-        Keep your explanation to 2-3 sentences. No jargon. No generic security advice like 'update passwords'. Be specific to what happened.";
+    let system = explain_system_prompt(&state.action_cfg.ai_personality);
 
     let user_msg = format!(
         "Explain this activity to me in simple terms. Should I be worried?\n\n{}",
         context
     );
 
-    match ai.chat(system, &user_msg).await {
+    match ai.chat(&system, &user_msg).await {
         Ok(explanation) => Json(serde_json::json!({ "explanation": explanation })),
         Err(e) => Json(serde_json::json!({
             "error": format!("AI call failed: {}", e)
@@ -717,6 +746,44 @@ pub(super) fn effective_severity(outcome: &str, severity: &str) -> String {
 mod tests {
     use super::*;
     use std::sync::atomic::AtomicU64;
+
+    #[test]
+    fn briefing_system_prompt_falls_back_when_personality_blank() {
+        let out = briefing_system_prompt("");
+        assert!(out.starts_with("You are a senior security analyst."));
+        assert!(out.contains("FORMAT: generate a concise intelligence briefing."));
+    }
+
+    #[test]
+    fn briefing_system_prompt_uses_personality_when_set() {
+        let out = briefing_system_prompt("You are InnerWarden. Bouncer voice.");
+        assert!(out.starts_with("You are InnerWarden. Bouncer voice."));
+        assert!(!out.contains("senior security analyst"));
+        assert!(out.contains("FORMAT: generate a concise intelligence briefing."));
+    }
+
+    #[test]
+    fn briefing_system_prompt_trims_whitespace_personality() {
+        let out = briefing_system_prompt("   \n\t  ");
+        // Whitespace-only must fall back to the analyst baseline rather
+        // than produce a prompt that opens with blank lines.
+        assert!(out.starts_with("You are a senior security analyst."));
+    }
+
+    #[test]
+    fn explain_system_prompt_falls_back_when_personality_blank() {
+        let out = explain_system_prompt("");
+        assert!(out.starts_with("You are a security assistant explaining threats"));
+        assert!(out.contains("FORMAT: you are explaining one incident"));
+    }
+
+    #[test]
+    fn explain_system_prompt_uses_personality_when_set() {
+        let out = explain_system_prompt("You are InnerWarden. Bouncer voice.");
+        assert!(out.starts_with("You are InnerWarden. Bouncer voice."));
+        assert!(!out.contains("security assistant explaining threats"));
+        assert!(out.contains("Only call it dangerous"));
+    }
 
     #[test]
     fn test_effective_severity_downgrade() {

--- a/crates/agent/src/dashboard/frontend/html/index.html
+++ b/crates/agent/src/dashboard/frontend/html/index.html
@@ -85,14 +85,14 @@
       </ul>
     </section>
     <div class="home-kpi-row">
-      <div class="home-kpi-big" onclick="showContained()">
+      <div class="home-kpi-big" onclick="viewActivity()">
         <div class="kpi-value" id="homeKpiThreats" style="color:var(--ok)">0</div>
-        <div class="kpi-label">Blocked</div>
+        <div class="kpi-label">Handled</div>
         <div class="kpi-window" id="homeKpiThreatsWindow">Today</div>
       </div>
       <div class="home-kpi-big" onclick="viewActivity()">
         <div class="kpi-value" id="homeKpiResponded" style="color:var(--accent)">0</div>
-        <div class="kpi-label">Incidents</div>
+        <div class="kpi-label">Detections</div>
         <div class="kpi-window" id="homeKpiRespondedWindow">Today</div>
       </div>
       <div class="home-kpi-big" onclick="showView('sensors')">
@@ -107,10 +107,6 @@
         <button id="briefingBtn" onclick="generateBriefing()" style="padding:5px 14px;border-radius:8px;border:1px solid var(--accent);background:transparent;color:var(--accent);font-size:0.7rem;font-weight:700;cursor:pointer">Generate Briefing</button>
       </div>
       <div id="briefingContent" style="font-size:0.78rem;color:var(--text);white-space:pre-wrap;line-height:1.6"></div>
-    </div>
-    <div class="home-section">
-      <div class="home-section-title"><span class="live-dot"></span> Recent Activity</div>
-      <div id="homeFeed"><div class="empty">Loading…</div></div>
     </div>
     <div class="home-section home-kpi-clickable" onclick="showView('sensors')">
       <div class="home-section-title">Data Collection</div>
@@ -154,7 +150,6 @@
         <div class="kpi-card"><div class="kpi-value" id="kpi-responded" style="color:var(--accent)">0</div><div class="kpi-label">Observing</div><div class="kpi-window">Now</div></div>
         <div class="kpi-card"><div class="kpi-value" id="kpi-noise" style="color:var(--muted)">0</div><div class="kpi-label">Needs attention</div><div class="kpi-window">Today</div></div>
       </div>
-      <div style="display:none"><span id="kpi-incidents">0</span><span id="kpi-attackers">0</span><span id="kpi-events">0</span></div>
       <div class="filters" style="grid-template-columns:1fr auto;margin-bottom:6px">
         <input id="flt-date" type="date" class="full" style="grid-column:1/-1" />
         <button id="flt-adv-toggle" type="button" class="full" style="background:transparent;border:none;color:var(--muted);font-size:0.68rem;cursor:pointer;text-align:left;padding:2px 0" onclick="toggleAdvFilters()">▸ Advanced filters</button>
@@ -183,8 +178,6 @@
         <button type="button" class="pivot-tab" data-pivot="user">User</button>
         <button type="button" class="pivot-tab" data-pivot="detector">Detector</button>
       </div>
-      <div id="clusterList" style="display:none"></div>
-      <div id="topDetectors" style="display:none"></div>
       <div class="search-wrap">
         <input id="entitySearch" type="search" placeholder="search threats…" autocomplete="off" spellcheck="false" />
       </div>

--- a/crates/agent/src/dashboard/frontend/js/home.js
+++ b/crates/agent/src/dashboard/frontend/js/home.js
@@ -25,7 +25,6 @@ async function loadHome() {
     window._lastIncidentList = incidentList.items || [];
     window._lastEntityItems = entityData.items || [];
 
-    // Filtered base matches what Recent Activity will render.
     var items = incidentList.items || [];
     var base = state.hideAllowlisted
       ? items.filter(function(i) { return !isIncidentTrusted(i); })
@@ -61,7 +60,6 @@ async function loadHome() {
 
     updateHomeNow(overview, activeHighCriticalList.length, softStale, totalEventsScanned);
     updateHomeKpis(overview, totalEventsScanned);
-    buildHomeFeed(base);
     updateCollectorStrip(sensors);
     loadBriefing();
   } catch(e) { console.warn('loadHome error:', e); }
@@ -255,15 +253,14 @@ function updateHomeNow(overview, activeCount, softStale, totalEventsScanned) {
 
 // ── KPIs with fixed temporal sub-labels ──────────────────────────────
 function updateHomeKpis(overview, totalEventsScanned) {
-  // Count from entity items (same source as Threats tab) for consistency.
-  var entityItems = window._lastEntityItems || [];
-  var blockedCount = 0;
-  entityItems.forEach(function(item) {
-    var o = (item.outcome || 'open').toLowerCase();
-    if (o === 'blocked' || o === 'honeypot' || o === 'contained') blockedCount++;
-  });
+  // "Handled" = every IP where the AI made a take-action decision today
+  // (block, contain, honeypot, monitor). Matches the number the AI briefing
+  // quotes, so the two surfaces never disagree. Previously this KPI silently
+  // fell back from "active blocks now" to ai_responded when the active set
+  // was empty, which mislabelled the number as "Blocked Today" while really
+  // meaning "still active". Now it's one source, one meaning.
   var el = document.getElementById('homeKpiThreats');
-  if (el) el.textContent = blockedCount > 0 ? blockedCount : (overview.ai_responded || 0);
+  if (el) el.textContent = overview.ai_responded || 0;
 
   el = document.getElementById('homeKpiResponded');
   if (el) el.textContent = overview.incidents_count || 0;
@@ -331,94 +328,6 @@ async function generateBriefing() {
     content.innerHTML = '<div style="color:var(--danger)">Error: ' + esc(e.message) + '</div>';
   }
   if (btn) { btn.textContent = 'Regenerate'; btn.disabled = false; }
-}
-
-// ── Recent Activity (severity × outcome hierarchy, never red) ──────
-function buildHomeFeed(incidents) {
-  var feedEl = document.getElementById('homeFeed');
-  if (!feedEl) return;
-
-  incidents = (incidents || []).slice();
-
-  if (incidents.length === 0) {
-    feedEl.innerHTML =
-      '<div class="home-feed-empty">' +
-      '<div class="home-feed-empty-icon">\u2705</div>' +
-      '<div class="home-feed-empty-title">No events in view.</div>' +
-      '<div class="home-feed-empty-sub">AI is monitoring.</div>' +
-      '</div>';
-    return;
-  }
-
-  // Sort: open first, then severity desc, then ts desc.
-  incidents.sort(function(a, b) {
-    var ao = (a.outcome || 'open') === 'open' ? 0 : 1;
-    var bo = (b.outcome || 'open') === 'open' ? 0 : 1;
-    if (ao !== bo) return ao - bo;
-    var as = severityRank(a.effective_severity || a.severity);
-    var bs = severityRank(b.effective_severity || b.severity);
-    if (as !== bs) return bs - as;
-    return (new Date(b.ts).getTime() || 0) - (new Date(a.ts).getTime() || 0);
-  });
-
-  var html = '<div class="activity-feed">';
-  incidents.slice(0, 15).forEach(function(inc) {
-    var slug = (inc.incident_id || '').split(':')[0] || '';
-    var label = humanLabel(slug);
-    var ago = timeAgo(inc.ts);
-    var outcome = inc.outcome || 'open';
-    var sev = (inc.effective_severity || inc.severity || '').toLowerCase();
-    var entities = inc.entities || [];
-    var ipEntity = entities.find(function(e) {
-      return (e.type || '').toLowerCase() === 'ip' || (typeof e === 'string' && e.startsWith('ip:'));
-    });
-    var ipVal = ipEntity ? (ipEntity.value || (typeof ipEntity === 'string' ? ipEntity.slice(3) : '')) : '';
-
-    // Row class: severity × outcome. Open + critical/high uses
-    // .alert-high / .alert-medium (orange/amber) — never .alert-critical.
-    var rowClass = 'feed-row';
-    if (outcome === 'blocked' || outcome === 'killed' || outcome === 'contained' || outcome === 'suspended') {
-      rowClass += ' feed-handled';
-    } else if (outcome === 'ignored') {
-      rowClass += ' feed-noise';
-    } else if (outcome === 'monitored') {
-      rowClass += ' feed-monitor';
-    } else if (outcome === 'honeypot') {
-      rowClass += ' feed-honeypot';
-    } else {
-      // open — scale by severity, but never red
-      if (sev === 'critical')    rowClass += ' alert-high';
-      else if (sev === 'high')   rowClass += ' alert-medium';
-      else if (sev === 'medium') rowClass += ' alert-low';
-      else                       rowClass += ' feed-muted';
-    }
-
-    var icon = '\u26A0';
-    if (outcome === 'blocked' || outcome === 'killed' || outcome === 'contained' || outcome === 'suspended') icon = '\uD83D\uDEE1';
-    else if (outcome === 'ignored') icon = '\u2796';
-    else if (sev === 'critical' || sev === 'high') icon = '\u26A1';
-
-    // Map raw outcome to AI-first model: open/active → OBSERVING with Guard ON
-    var mappedOutcome = outcome;
-    if ((outcome === 'open' || outcome === 'active') && (window._agentMode || status?.mode || 'guard') === 'guard') {
-      mappedOutcome = 'monitoring';
-    }
-    var badge = outcomeBadgeHtml(mappedOutcome);
-
-    html += '<div class="' + rowClass + '" onclick="viewActivity();handleCardClickByValue(\'ip\',\'' + ipVal + '\')">' +
-      '<span class="activity-icon">' + icon + '</span>' +
-      '<div style="flex:1;min-width:0">' +
-      '<div style="display:flex;align-items:center;gap:8px;flex-wrap:wrap">' +
-      '<span style="font-size:0.8rem;font-weight:600;color:var(--text)">' + label + '</span>' +
-      badge +
-      '</div>' +
-      (ipVal ? '<div style="font-size:0.72rem;color:var(--muted);margin-top:2px;font-family:\'JetBrains Mono\',monospace">' + ipVal + '</div>' : '') +
-      '</div>' +
-      '<span class="activity-time">' + ago + '</span>' +
-      '</div>';
-  });
-  html += '</div>';
-  feedEl.innerHTML = html;
 }
 
 // ── Data Collection (summary + collapsed details) ───────────────────

--- a/crates/agent/src/dashboard/state.rs
+++ b/crates/agent/src/dashboard/state.rs
@@ -97,6 +97,13 @@ pub struct DashboardActionConfig {
     pub trusted_ips: Vec<String>,
     /// Allowlisted users.
     pub trusted_users: Vec<String>,
+    /// System prompt used for every AI-driven chat / briefing surface (Home
+    /// briefing, Threats drill-down explain, Telegram /ask, daily briefing
+    /// cron). Populated from `cfg.telegram.bot.personality` at dashboard
+    /// init so the three surfaces share one voice. Empty string falls back
+    /// to the previous hardcoded prompts (preserves old behaviour in tests
+    /// and when the operator explicitly blanks personality).
+    pub ai_personality: String,
 }
 
 impl Default for DashboardActionConfig {
@@ -132,6 +139,7 @@ impl Default for DashboardActionConfig {
             retention_reports_days: 30,
             trusted_ips: vec![],
             trusted_users: vec![],
+            ai_personality: String::new(),
         }
     }
 }

--- a/crates/agent/src/loops/boot.rs
+++ b/crates/agent/src/loops/boot.rs
@@ -326,6 +326,7 @@ pub(crate) async fn run_agent(cli: crate::Cli) -> Result<()> {
             retention_reports_days: cfg.data.reports_keep_days,
             trusted_ips: cfg.allowlist.trusted_ips.clone(),
             trusted_users: cfg.allowlist.trusted_users.clone(),
+            ai_personality: cfg.telegram.bot.personality.clone(),
         };
         let dashboard_data_dir = cli.data_dir.clone();
         let dashboard_bind = cli.dashboard_bind.clone();

--- a/crates/agent/src/telegram/burst.rs
+++ b/crates/agent/src/telegram/burst.rs
@@ -32,7 +32,7 @@ pub fn format_daily_digest(
              \u{00a0}\u{00a0}{critical_count} critical threats\n\
              \u{00a0}\u{00a0}Health: {score}/100 {health_emoji}\n\
              \n\
-             Everything is under control."
+             All clear. Nothing needs you."
         )
     } else {
         let date = chrono::Local::now().format("%Y-%m-%d");
@@ -113,7 +113,7 @@ pub fn format_daily_digest_enriched(
                 pipeline.needs_review_groups
             ));
         } else {
-            msg.push_str("\n\n\u{2705} No action needed — everything is under control.");
+            msg.push_str("\n\n\u{2705} All clear. Nothing needs you.");
         }
 
         msg

--- a/crates/agent/src/telegram/formatting.rs
+++ b/crates/agent/src/telegram/formatting.rs
@@ -1233,7 +1233,7 @@ mod tests {
         assert!(msg.contains("30 attacks blocked"));
         assert!(msg.contains("2 critical threats"));
         assert!(msg.contains("Health:"));
-        assert!(msg.contains("Everything is under control."));
+        assert!(msg.contains("All clear. Nothing needs you."));
         // Score = 100 - 2*20 - 5*5 = 35 → 🔴
         assert!(msg.contains("\u{1f534}"));
     }
@@ -1276,7 +1276,7 @@ mod tests {
         };
         let msg = format_daily_digest_enriched(42, 30, 0, 3, "ssh_bruteforce", 15, true, &stats);
         assert!(msg.contains("12 threat groups auto-resolved"));
-        assert!(msg.contains("under control"));
+        assert!(msg.contains("All clear"));
         assert!(!msg.contains("need your review"));
     }
 
@@ -1290,7 +1290,7 @@ mod tests {
         };
         let msg = format_daily_digest_enriched(42, 30, 2, 5, "ssh_bruteforce", 15, true, &stats);
         assert!(msg.contains("3 groups need your review"));
-        assert!(!msg.contains("under control"));
+        assert!(!msg.contains("All clear"));
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Real-world Telegram test with the new persona:

| Operator | Bot |
|---|---|
| Hey, what's up? | Bot noise, handled. |
| What? | Routine noise, handled. |
| How is my server? | No active threats detected. System appears stable. |

Two bugs:
1. \"bot noise, handled\" leaked into handling of *non-security* messages (greetings, one-word replies). The persona taught the model a catchphrase without the context it belongs to.
2. For the actual security question the model fell back to consultant-speak (\"system appears stable\"), which the persona was supposed to kill.

## Fix

Add a leading \"how to read the operator's message first\" section that branches before voicing:
- **greeting / small talk** → friendly colleague, one short sentence, no security framing
- **off-topic** → brief answer, no security framing
- **security question** → existing dry bouncer voice

Clarify that \"bot noise, handled\" belongs in *decision logs*, not chat. When the snapshot shows routine traffic the chat answer should read naturally (\"quiet, just the usual scanners\"), not echo a canned phrase. Explicitly ban \"system appears stable\".

## Test plan

- [x] \`cargo test -p innerwarden-agent\` — 1541 pass, no prompt-related tests regressed
- [x] \`cargo clippy --workspace -- -D warnings\` clean
- [x] \`cargo fmt --all --check\` clean
- [ ] Post-merge smoke: redeploy prod, repeat the same three Telegram prompts, confirm: greeting gets a human answer, one-word \"What?\" gets a clarifying question (not dismissed), \"how is my server\" gets terse natural status.