### PR TITLE
feat(agent): lower ai.min_severity default from high to medium

### DIFF
--- a/crates/agent/src/config.rs
+++ b/crates/agent/src/config.rs
@@ -579,9 +579,18 @@ pub struct AiConfig {
     pub protected_ips: Vec<String>,
 
     /// Minimum incident severity sent to AI analysis.
-    /// "high" (default) = only High/Critical go to AI.
-    /// "medium" = Medium/High/Critical go to AI (more aggressive, more API calls).
+    /// "medium" (default) = Medium/High/Critical go to AI.
+    /// "high" = only High/Critical go to AI (more conservative, fewer API calls).
     /// "low" = all incidents go to AI (expensive, not recommended).
+    ///
+    /// The default was "high" prior to v0.12.4. Production audit on
+    /// 2026-04-15 found 1812 incidents → 0 AI-executed blocks; the "high"
+    /// floor combined with the confidence_threshold bug in spec 018
+    /// meant most real threats never reached AI triage. Lowering to
+    /// "medium" lets AI see the Medium-severity layer (where most bot
+    /// campaigns live) while keeping Low in the noise-gate. Operators
+    /// with OpenAI/Anthropic cost sensitivity can set this back to
+    /// "high" explicitly; Ollama local is free.
     #[serde(default = "default_ai_min_severity")]
     pub min_severity: String,
 
@@ -621,7 +630,7 @@ fn default_batch_window_secs() -> u64 {
 }
 
 fn default_ai_min_severity() -> String {
-    "high".to_string()
+    "medium".to_string()
 }
 
 impl Default for AiConfig {
@@ -2826,9 +2835,12 @@ approval_ttl_secs = 300
     // -- AI config tests --
 
     #[test]
-    fn ai_parsed_min_severity_defaults_to_high() {
+    fn ai_parsed_min_severity_defaults_to_medium() {
+        // v0.12.4: default floor lowered from "high" to "medium" so AI
+        // triage sees the Medium-severity layer (where most bot campaigns
+        // live). Operators can still set "high" in agent.toml explicitly.
         let cfg = AiConfig::default();
-        assert_eq!(cfg.parsed_min_severity(), Severity::High);
+        assert_eq!(cfg.parsed_min_severity(), Severity::Medium);
     }
 
     #[test]
@@ -2838,6 +2850,8 @@ approval_ttl_secs = 300
         assert_eq!(cfg.parsed_min_severity(), Severity::Low);
         cfg.min_severity = "medium".into();
         assert_eq!(cfg.parsed_min_severity(), Severity::Medium);
+        cfg.min_severity = "high".into();
+        assert_eq!(cfg.parsed_min_severity(), Severity::High);
         cfg.min_severity = "critical".into();
         assert_eq!(cfg.parsed_min_severity(), Severity::Critical);
     }

--- a/testdata/scenarios/04-honeypot-unknown/expected.json
+++ b/testdata/scenarios/04-honeypot-unknown/expected.json
@@ -1,9 +1,9 @@
 {
   "status": "ready",
-  "description": "Honeypot hit on :2222 from an IP with no reputation signals (9.9.9.9). The scenario seeds the honeypot incident directly because a real TCP listener would require root on the CI runner. Stub AI returns Monitor (unknown IP — honeypot lets them in, do not auto-block). Target envelope per spec 024: 1 incident, \u22641 telegram, 0 blocks.",
-  "last_reviewed": "2026-04-18",
+  "description": "Honeypot hit on :2222 from an IP with no reputation signals (9.9.9.9). The scenario seeds the honeypot incident directly because a real TCP listener would require root on the CI runner. Stub AI returns Monitor (unknown IP, honeypot lets them in, do not auto-block) and the Monitor skill auto-executes a packet capture. Target envelope per spec 024: 1 incident, \u22641 telegram, 0 blocks, exactly 1 auto-executed decision (the Monitor capture). Envelope updated in v0.12.4 when ai.min_severity default dropped from 'high' to 'medium'; previously the Medium incident never reached AI, so auto_executed was 0.",
+  "last_reviewed": "2026-04-19",
   "incidents": { "min": 1, "max": 1 },
   "telegram_msgs": { "min": 0, "max": 1 },
   "blocks": { "min": 0, "max": 0 },
-  "decisions_auto_executed": { "min": 0, "max": 0 }
+  "decisions_auto_executed": { "min": 1, "max": 1 }
 }


### PR DESCRIPTION
## Summary

Production audit on 2026-04-15 found **1812 incidents → 0 AI-executed blocks** over three days. Two compounding defects:

1. \`confidence_threshold = 1.01\` in prod (fixed in #183)
2. \`ai.min_severity = "high"\` kept Medium incidents out of AI triage entirely

This PR addresses #2 by lowering the default from \`"high"\` to \`"medium"\`. The AI now sees the Medium-severity layer where most bot campaigns live (port scans, credential stuffing, web scans); Low stays in the noise-gate.

## Impact

**Fresh installs**: more AI calls per day, better autonomous response coverage.

**Existing deployments**: unaffected. serde only uses the default when the field is missing in \`agent.toml\`; every existing config sets it explicitly.

**Cost sensitivity**: operators on OpenAI/Anthropic who want fewer API calls can set \`min_severity = "high"\` in their config. Ollama-local setups pay nothing either way.

## Test plan

- [x] \`cargo test -p innerwarden-agent\` — 1541 pass; \`ai_parsed_min_severity_defaults_to_medium\` updated + now covers \"high\" as an operator override
- [x] \`cargo clippy --workspace -- -D warnings\` clean
- [x] \`cargo fmt --all --check\` clean
- [ ] Post-merge smoke on prod: leave prod config explicit at \"high\" for baseline, then flip to \"medium\" for 24h; compare AI call volume + action decisions vs the baseline. Roll back if AI spend spikes without corresponding block increase.