### PR TITLE
fix: unify dashboard handled count + reconcile-blocks + Report tab

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2024,6 +2024,7 @@ dependencies = [
  "innerwarden-smm",
  "innerwarden-store",
  "innerwarden_core",
+ "ipnet",
  "p256 0.13.2",
  "qrcode",
  "rand_core 0.6.4",

--- a/crates/agent/src/briefing.rs
+++ b/crates/agent/src/briefing.rs
@@ -290,30 +290,30 @@ pub fn build_briefing_context(kg: &Arc<RwLock<KnowledgeGraph>>) -> String {
 }
 
 /// The LLM prompt for generating the briefing.
+///
+/// Format-only instructions. Tone is owned by the system prompt (the bot
+/// personality, plumbed via `briefing_system_prompt`). Prior revision
+/// carried a second "You are the AI security agent..." framing plus a
+/// "Be reassuring" / "Write for someone who is NOT a security professional"
+/// line here, which fought the persona and produced consultant-speak like
+/// "everything is under control" and "no further action needed".
 pub fn briefing_prompt(context: &str) -> String {
     format!(
-        "You are the AI security agent writing a daily briefing for a non-technical server operator.\n\
+        "Write a daily briefing from the state snapshot below.\n\
          \n\
-         This server is protected by InnerWarden — an autonomous AI security agent that blocks \
-         threats automatically. The operator does NOT need to take action on most items. \
-         SSH uses key-only authentication (password login disabled). Most activity from \
-         external IPs is routine internet scanning that fails at the protocol level.\n\
+         Counting rules:\n\
+         - CONTAINED/BLOCKED items are resolved. Count them, do not dramatise them.\n\
+         - IGNORED items are confirmed noise. Do not mention them.\n\
+         - UNRESOLVED items are being OBSERVED by the AI. Only flag the ones that \
+           genuinely need a human decision.\n\
+         - Quote numbers only from the snapshot below. Do not invent counts.\n\
          \n\
-         CRITICAL RULES:\n\
-         - CONTAINED/BLOCKED items are RESOLVED — present them as success, not active threats\n\
-         - IGNORED items are confirmed noise — do not mention them\n\
-         - UNRESOLVED items are being OBSERVED by the AI — only flag if genuinely dangerous\n\
-         - Routine scanners (SSH malformed strings, port probes) are NOT dangerous and NOT urgent\n\
-         - Do NOT recommend 'updating passwords' or generic security advice\n\
-         - Be reassuring when the server is safe. Be direct only when something is genuinely dangerous.\n\
-         - Write for someone who is NOT a security professional\n\
-         \n\
-         Write a SHORT briefing (under 150 words) with:\n\
-         1. **STATUS** — one sentence: is the server safe right now?\n\
-         2. **WHAT THE AI DID** — 2-3 bullets of actions taken (blocks, monitoring)\n\
-         3. **NEEDS ATTENTION** — only if something genuinely requires human decision (rare)\n\
-         \n\
-         Tone: calm, confident, specific. Like a trusted security guard giving a morning report.\n\
+         Structure (under 150 words total):\n\
+         1. STATUS: one line. Is the server safe right now?\n\
+         2. WHAT THE AI DID: 2-3 short lines. Name the actions (blocks, monitoring, \
+            honeypot redirects). Quote the totals from the snapshot.\n\
+         3. NEEDS ATTENTION: omit this section entirely unless something genuinely \
+            requires a human decision.\n\
          \n\
          ---\n\
          \n\
@@ -353,23 +353,44 @@ mod tests {
         assert!(briefing.summary.contains("unresolved"));
     }
 
-    // briefing_prompt injects context into system prompt
     #[test]
     fn briefing_prompt_contains_context() {
         let ctx = "SITUATION STATUS:\n- Operator-relevant incidents today: 5\n";
         let prompt = briefing_prompt(ctx);
         assert!(prompt.contains("SITUATION STATUS"));
-        assert!(prompt.contains("InnerWarden"));
         assert!(prompt.contains("150 words"));
     }
 
-    // briefing_prompt contains key instructions
     #[test]
-    fn briefing_prompt_has_critical_rules() {
+    fn briefing_prompt_keeps_format_structure() {
         let prompt = briefing_prompt("test context");
-        assert!(prompt.contains("CRITICAL RULES"));
-        assert!(prompt.contains("CONTAINED"));
+        assert!(prompt.contains("STATUS"));
+        assert!(prompt.contains("WHAT THE AI DID"));
         assert!(prompt.contains("NEEDS ATTENTION"));
+        // Counting rules still present so the model doesn't dramatise noise.
+        assert!(prompt.contains("CONTAINED"));
+        assert!(prompt.contains("IGNORED"));
+    }
+
+    #[test]
+    fn briefing_prompt_does_not_carry_tone_instructions() {
+        // Tone is owned by the system prompt (bot personality). The user
+        // message must not re-assert "Be reassuring" / "non-technical" /
+        // "trusted security guard", which previously fought the persona
+        // and produced consultant-speak in the output.
+        let prompt = briefing_prompt("x");
+        for banned in [
+            "Be reassuring",
+            "non-technical",
+            "trusted security guard",
+            "You are the AI security agent",
+            "under control",
+        ] {
+            assert!(
+                !prompt.contains(banned),
+                "prompt must not include tone instruction {banned:?}",
+            );
+        }
     }
 
     fn add_incident(

--- a/crates/agent/src/dashboard/frontend/js/home.js
+++ b/crates/agent/src/dashboard/frontend/js/home.js
@@ -143,20 +143,15 @@ function computeHomeState(payload) {
 
   // Guard ON or no active threats: AI Protection Active.
   // The operator sees confidence, not alarm.
-  // Use entity items (same source as Threats tab) for consistent counts.
-  var entityItems = payload.entityItems || [];
-  var blocked = 0, observing = 0;
-  entityItems.forEach(function(item) {
-    var o = (item.outcome || 'open').toLowerCase();
-    if (o === 'blocked' || o === 'honeypot' || o === 'contained') blocked++;
-    else if (o === 'monitoring' || o === 'open' || o === 'active') observing++;
-  });
-  if (blocked === 0) blocked = overview.ai_responded || 0;
-  var subParts = [];
-  if (blocked > 0) subParts.push(blocked + ' blocked');
-  if (observing > 0) subParts.push(observing + ' observing');
-  var subText = subParts.length > 0
-    ? subParts.join(' \u00B7 ') + '. Everything handled automatically.'
+  //
+  // Single source: overview.safely_resolved = every decision today that was
+  // NOT "ignore" (block, monitor, honeypot, kill, suspend). The Home KPI
+  // tile and the briefing now quote the same field, so the operator no
+  // longer sees "9 blocked" in the hero while the KPI says 50 and the
+  // briefing says 48 for the same time window.
+  var handled = overview.safely_resolved || 0;
+  var subText = handled > 0
+    ? handled + ' handled today. AI is on shift.'
     : 'All systems monitoring. Nothing requires your attention.';
 
   return {
@@ -217,14 +212,11 @@ function updateHomeNow(overview, activeCount, softStale, totalEventsScanned) {
   var didEl  = document.getElementById('homeNowDid');
   if (!whatEl || !didEl) return;
 
-  var entityItems = window._lastEntityItems || [];
-  var contained = 0, observingNow = 0;
-  entityItems.forEach(function(item) {
-    var o = (item.outcome || 'open').toLowerCase();
-    if (o === 'blocked' || o === 'honeypot' || o === 'contained') contained++;
-    else if (o === 'monitoring' || o === 'open' || o === 'active') observingNow++;
-  });
-  if (contained === 0) contained = overview.ai_responded || 0;
+  // Same source as updateHomeKpis and computeHomeState: overview.safely_resolved.
+  // Counts every non-"ignore" decision today (block + monitor + honeypot +
+  // kill + suspend). Older code summed currently-active entities, which
+  // decay with TTL and so understated the number the briefing reported.
+  var handled = overview.safely_resolved || 0;
   var total = totalEventsScanned || overview.events_count || 0;
 
   // Line 1 — Trust signal: volume scanned
@@ -241,26 +233,24 @@ function updateHomeNow(overview, activeCount, softStale, totalEventsScanned) {
 
   // Line 2 — Outcome summary
   var line2;
-  if (contained === 0 && observingNow === 0) {
+  if (handled === 0) {
     line2 = 'Nothing suspicious found. All systems operating normally.';
-  } else if (contained > 0 && observingNow === 0) {
-    line2 = 'Blocked ' + contained + ' threat' + (contained > 1 ? 's' : '') + ' automatically. Nothing requires your attention.';
   } else {
-    line2 = 'Blocked ' + contained + ' automatically. Observing ' + observingNow + ' more. No action needed.';
+    line2 = 'Handled ' + handled + ' threat' + (handled === 1 ? '' : 's') + ' today. AI is on shift.';
   }
   didEl.textContent = line2;
 }
 
 // ── KPIs with fixed temporal sub-labels ──────────────────────────────
 function updateHomeKpis(overview, totalEventsScanned) {
-  // "Handled" = every IP where the AI made a take-action decision today
-  // (block, contain, honeypot, monitor). Matches the number the AI briefing
-  // quotes, so the two surfaces never disagree. Previously this KPI silently
-  // fell back from "active blocks now" to ai_responded when the active set
-  // was empty, which mislabelled the number as "Blocked Today" while really
-  // meaning "still active". Now it's one source, one meaning.
+  // "Handled" = every decision today that was NOT "ignore" (block, monitor,
+  // honeypot, kill, suspend). Uses overview.safely_resolved — same field
+  // consumed by the hero sub (updateHomeNow) and computeHomeState, and
+  // produced by the same graph walk the briefing uses. Prior revision
+  // read ai_responded which excluded Monitor actions, so the KPI
+  // reported a smaller number than the briefing for the same window.
   var el = document.getElementById('homeKpiThreats');
-  if (el) el.textContent = overview.ai_responded || 0;
+  if (el) el.textContent = overview.safely_resolved || 0;
 
   el = document.getElementById('homeKpiResponded');
   if (el) el.textContent = overview.incidents_count || 0;

--- a/crates/agent/src/dashboard/frontend/js/reports.js
+++ b/crates/agent/src/dashboard/frontend/js/reports.js
@@ -198,13 +198,27 @@ function renderReport(r) {
     <div class="report-section-title">Operational Health</div>
     <table class="report-table"><thead><tr><th>File</th><th>Exists</th><th>Valid</th><th>Lines</th><th>Size</th></tr></thead><tbody>`;
   (oh.files || []).forEach(f => {
-    const valid = f.jsonl_valid == null ? '-' : (f.jsonl_valid ? '<span class="health-ok">✓</span>' : '<span class="health-fail">✗</span>');
+    // Spec 016 migrated events to SQLite. The events.jsonl file no
+    // longer exists on disk, so its "Exists: ✗" used to look like a
+    // health failure. Show "SQLite" for the events row instead; the
+    // rest still use jsonl backing.
+    const isSqliteOnly = (f.file === 'events' && !f.exists);
+    const existsCell = isSqliteOnly
+      ? '<span class="health-ok" title="stored in innerwarden.db (spec 016)">SQLite</span>'
+      : (f.exists ? '<span class="health-ok">✓</span>' : '<span class="health-fail">✗</span>');
+    const valid = isSqliteOnly
+      ? '<span class="health-ok">✓</span>'
+      : (f.jsonl_valid == null ? '-' : (f.jsonl_valid ? '<span class="health-ok">✓</span>' : '<span class="health-fail">✗</span>'));
+    const linesCell = isSqliteOnly ? '(in db)' : (f.lines ?? '-');
+    const sizeCell = isSqliteOnly
+      ? '-'
+      : (f.size_bytes > 0 ? (f.size_bytes > 1048576 ? (f.size_bytes/1048576).toFixed(1)+'MB' : (f.size_bytes/1024).toFixed(1)+'KB') : '0B');
     html += `<tr>
       <td>${esc(f.file)}</td>
-      <td>${f.exists ? '<span class="health-ok">✓</span>' : '<span class="health-fail">✗</span>'}</td>
+      <td>${existsCell}</td>
       <td>${valid}</td>
-      <td>${f.lines ?? '-'}</td>
-      <td>${f.size_bytes > 0 ? (f.size_bytes > 1048576 ? (f.size_bytes/1048576).toFixed(1)+'MB' : (f.size_bytes/1024).toFixed(1)+'KB') : '0B'}</td>
+      <td>${linesCell}</td>
+      <td>${sizeCell}</td>
     </tr>`;
   });
   html += `</tbody></table></div>`;

--- a/crates/ctl/Cargo.toml
+++ b/crates/ctl/Cargo.toml
@@ -19,6 +19,7 @@ innerwarden-agent-guard = { path = "../agent-guard" }
 innerwarden-smm = { path = "../smm" }
 innerwarden-hypervisor = { path = "../hypervisor" }
 innerwarden-store = { path = "../store" }
+ipnet = "2"
 anyhow = "1"
 clap = { version = "4", features = ["derive"] }
 clap_complete = "4"

--- a/crates/ctl/src/commands/mod.rs
+++ b/crates/ctl/src/commands/mod.rs
@@ -10,6 +10,7 @@ pub(crate) mod mesh;
 pub(crate) mod module;
 pub(crate) mod notify;
 pub(crate) mod ops;
+pub(crate) mod reconcile;
 pub(crate) mod replay;
 pub(crate) mod responder;
 pub(crate) mod response;

--- a/crates/ctl/src/commands/reconcile.rs
+++ b/crates/ctl/src/commands/reconcile.rs
@@ -1,0 +1,356 @@
+//! `innerwarden system reconcile-blocks` — cross-check the firewall's
+//! active DENY rules against the cloud provider safelist and emit the
+//! operator's cleanup plan.
+//!
+//! The motivating incident (operator audit 2026-04-19 after the
+//! CL-008 cascade + cloud_safelist fix landed): 60 ufw DENY rules
+//! targeting Cloudflare, Oracle OCI peers, link-local, and Telegram
+//! ranges were still in place, all installed *before* the safelist
+//! existed. New blocks respect the safelist; old ones rot until their
+//! TTL expires (up to 7 days). This command surfaces those zombies.
+
+use std::collections::HashSet;
+use std::net::IpAddr;
+use std::path::Path;
+use std::process::Command;
+
+use anyhow::{Context, Result};
+
+use crate::Cli;
+
+/// Parsed ufw rule: the numeric position in `ufw status numbered`
+/// output, plus the target IP or CIDR the rule blocks.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct UfwRule {
+    pub index: u32,
+    pub target: String,
+}
+
+pub(crate) fn cmd_reconcile_blocks(_cli: &Cli, _data_dir: &Path, apply: bool) -> Result<()> {
+    let ufw_out = run_ufw_status()?;
+    let rules = parse_ufw_rules(&ufw_out);
+
+    let safelist = safelist_cidrs();
+    let matches: Vec<(UfwRule, String)> = rules
+        .iter()
+        .filter_map(|r| {
+            match_safelist(&r.target, &safelist).map(|hit| (r.clone(), hit.to_string()))
+        })
+        .collect();
+
+    println!("Reconcile block-list against cloud safelist");
+    println!("  ufw DENY rules scanned:        {}", rules.len());
+    println!("  matches inside safelist range: {}", matches.len());
+    if matches.is_empty() {
+        println!("\nAll blocks are outside known cloud provider ranges. Nothing to do.");
+        return Ok(());
+    }
+
+    println!();
+    for (rule, hit) in &matches {
+        println!(
+            "  rule #{:>4}  {:<20}  inside {}",
+            rule.index, rule.target, hit
+        );
+    }
+
+    if !apply {
+        println!("\n(dry run) pass --apply to unblock every rule listed above.");
+        println!("Each target will be released via `innerwarden action unblock`,");
+        println!("which keeps the agent's response tracking in sync with the firewall.");
+        return Ok(());
+    }
+
+    println!("\nUnblocking {} rule(s)…", matches.len());
+    let mut cleaned = 0usize;
+    let mut failed = 0usize;
+    for (rule, _) in &matches {
+        match unblock_target(&rule.target) {
+            Ok(()) => {
+                cleaned += 1;
+                println!("  unblocked {}", rule.target);
+            }
+            Err(e) => {
+                failed += 1;
+                eprintln!("  failed to unblock {}: {e}", rule.target);
+            }
+        }
+    }
+    println!("\ndone. cleaned {cleaned}, failed {failed}");
+    Ok(())
+}
+
+fn run_ufw_status() -> Result<String> {
+    let out = Command::new("sudo")
+        .args(["ufw", "status", "numbered"])
+        .output()
+        .context("spawn `sudo ufw status numbered`")?;
+    if !out.status.success() {
+        anyhow::bail!(
+            "ufw status exited with {}; is ufw installed and enabled?",
+            out.status
+        );
+    }
+    Ok(String::from_utf8_lossy(&out.stdout).into_owned())
+}
+
+fn unblock_target(target: &str) -> Result<()> {
+    let status = Command::new("sudo")
+        .args([
+            "innerwarden",
+            "action",
+            "unblock",
+            target,
+            "--reason",
+            "reconcile-blocks: target in cloud safelist",
+        ])
+        .status()
+        .context("spawn `innerwarden action unblock`")?;
+    if !status.success() {
+        anyhow::bail!("unblock exited with {status}");
+    }
+    Ok(())
+}
+
+/// Parse `ufw status numbered` output into a list of DENY rules targeting
+/// a single IP or CIDR. Lines that do not match the agent-authored format
+/// (`[NN] Anywhere DENY IN <ip> # innerwarden`) are skipped so operator
+/// rules with comments of their own are left alone.
+pub(crate) fn parse_ufw_rules(ufw_output: &str) -> Vec<UfwRule> {
+    let mut out = Vec::new();
+    for line in ufw_output.lines() {
+        let trimmed = line.trim_start();
+        let Some(rest) = trimmed.strip_prefix('[') else {
+            continue;
+        };
+        let Some((num_str, after_num)) = rest.split_once(']') else {
+            continue;
+        };
+        let Ok(index) = num_str.trim().parse::<u32>() else {
+            continue;
+        };
+        // We only want the agent-authored rules so the operator's own
+        // manual rules stay untouched.
+        if !line.contains("# innerwarden") {
+            continue;
+        }
+        // Need "DENY IN" somewhere after the index.
+        if !after_num.contains("DENY IN") {
+            continue;
+        }
+        // Target is the token after "DENY IN".
+        let Some(after_deny) = after_num.split("DENY IN").nth(1) else {
+            continue;
+        };
+        let target = after_deny
+            .split_whitespace()
+            .next()
+            .unwrap_or("")
+            .to_string();
+        if target.is_empty() {
+            continue;
+        }
+        out.push(UfwRule { index, target });
+    }
+    out
+}
+
+/// Returns the CIDR that contains the target, or `None` when the target
+/// lies outside every safelist range. Works for bare IPv4 addresses and
+/// `addr/prefix` CIDR blocks.
+pub(crate) fn match_safelist<'a>(
+    target: &str,
+    safelist: &'a [ipnet::IpNet],
+) -> Option<&'a ipnet::IpNet> {
+    // Allow either a plain IP ("1.2.3.4") or a CIDR ("10.0.0.0/8").
+    let (ip, prefix_len): (IpAddr, u8) = if let Some((addr, prefix)) = target.split_once('/') {
+        let ip: IpAddr = addr.parse().ok()?;
+        let prefix: u8 = prefix.parse().ok()?;
+        (ip, prefix)
+    } else {
+        let ip: IpAddr = target.parse().ok()?;
+        let host_prefix = if ip.is_ipv4() { 32 } else { 128 };
+        (ip, host_prefix)
+    };
+    let net = ipnet::IpNet::new(ip, prefix_len).ok()?;
+    safelist.iter().find(|range| range.contains(&net))
+}
+
+/// Hardcoded subset of `cloud_safelist.rs` covering the four categories
+/// the operator unambiguously wants released: Cloudflare CDN, Oracle OCI
+/// peer infra, link-local / loopback / multicast, and Telegram edge.
+///
+/// CLOUD_PROVIDER_RANGES (DigitalOcean / AWS / Azure customer VPS) is
+/// intentionally omitted because those ranges host attacker-owned VPSes
+/// as often as legitimate services; an operator who wants those released
+/// can still do it per-IP with `innerwarden action unblock`.
+fn safelist_cidrs() -> Vec<ipnet::IpNet> {
+    let mut seen = HashSet::new();
+    let mut out = Vec::new();
+    for s in RECONCILE_RANGES {
+        if seen.insert(*s) {
+            if let Ok(net) = s.parse() {
+                out.push(net);
+            }
+        }
+    }
+    out
+}
+
+/// CIDRs kept in sync with the matching constants in
+/// `crates/agent/src/cloud_safelist.rs`. Covered sets:
+///   - `CLOUDFLARE_RANGES`
+///   - `AGENT_SERVICE_RANGES`
+///   - `ORACLE_PEER_RANGES`
+///   - `LINK_LOCAL_RANGES`
+const RECONCILE_RANGES: &[&str] = &[
+    // Cloudflare IPv4 ranges
+    "173.245.48.0/20",
+    "103.21.244.0/22",
+    "103.22.200.0/22",
+    "103.31.4.0/22",
+    "141.101.64.0/18",
+    "108.162.192.0/18",
+    "190.93.240.0/20",
+    "188.114.96.0/20",
+    "197.234.240.0/22",
+    "198.41.128.0/17",
+    "162.158.0.0/15",
+    "104.16.0.0/13",
+    "104.24.0.0/14",
+    "172.64.0.0/13",
+    // Telegram edge (agent notification endpoint)
+    "149.154.160.0/20",
+    "91.108.0.0/16",
+    "91.108.4.0/22",
+    "91.108.56.0/22",
+    "95.161.64.0/20",
+    // AWS eu-west-1 ELB (CrowdSec CAPI + Anthropic API hosted here)
+    "52.48.0.0/14",
+    "63.32.0.0/14",
+    "18.200.0.0/14",
+    "3.248.0.0/13",
+    // AbuseIPDB + Ubuntu + GeoIP (agent service endpoints)
+    "208.95.112.0/24",
+    "185.125.188.0/23",
+    "91.189.88.0/21",
+    "162.213.32.0/22",
+    // Oracle OCI peer ranges
+    "138.1.16.0/22",
+    "140.91.0.0/16",
+    "147.154.224.0/19",
+    "193.122.0.0/15",
+    // Link-local / loopback / multicast
+    "169.254.0.0/16",
+    "127.0.0.0/8",
+    "224.0.0.0/4",
+];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_skips_header_lines() {
+        let out = "Status: active\n\n     To                         Action      From\n     --                         ------      ----\n";
+        assert!(parse_ufw_rules(out).is_empty());
+    }
+
+    #[test]
+    fn parse_reads_single_ip_agent_rule() {
+        let out = "[ 42] Anywhere                   DENY IN     1.2.3.4                    # innerwarden\n";
+        let rules = parse_ufw_rules(out);
+        assert_eq!(rules.len(), 1);
+        assert_eq!(rules[0].index, 42);
+        assert_eq!(rules[0].target, "1.2.3.4");
+    }
+
+    #[test]
+    fn parse_reads_cidr_agent_rule() {
+        let out = "[100] Anywhere                   DENY IN     136.216.0.0/16             # innerwarden\n";
+        let rules = parse_ufw_rules(out);
+        assert_eq!(rules.len(), 1);
+        assert_eq!(rules[0].target, "136.216.0.0/16");
+    }
+
+    #[test]
+    fn parse_ignores_operator_owned_rules() {
+        // Rules without the `# innerwarden` marker belong to the operator
+        // or to other tools; leave them alone.
+        let out = "[  1] 80/tcp                     DENY IN     Anywhere                   # block npm admin\n";
+        assert!(parse_ufw_rules(out).is_empty());
+    }
+
+    #[test]
+    fn parse_ignores_allow_rules() {
+        let out = "[  5] Anywhere                   ALLOW IN    10.0.0.5                   # innerwarden\n";
+        assert!(parse_ufw_rules(out).is_empty());
+    }
+
+    #[test]
+    fn parse_reads_multiple_rules_in_order() {
+        let out = "\
+[  7] Anywhere                   DENY IN     1.2.3.4                    # innerwarden
+[  8] Anywhere                   DENY IN     5.6.7.8                    # innerwarden
+";
+        let rules = parse_ufw_rules(out);
+        assert_eq!(rules.len(), 2);
+        assert_eq!(rules[0].index, 7);
+        assert_eq!(rules[1].index, 8);
+    }
+
+    #[test]
+    fn safelist_ip_inside_cloudflare_range_matches() {
+        let list = safelist_cidrs();
+        assert!(match_safelist("104.16.198.238", &list).is_some());
+        assert!(match_safelist("172.64.200.173", &list).is_some());
+    }
+
+    #[test]
+    fn safelist_ip_outside_ranges_does_not_match() {
+        let list = safelist_cidrs();
+        assert!(match_safelist("1.2.3.4", &list).is_none());
+        // 8.8.8.8 (Google DNS) is not in the conservative cleanup set;
+        // GCE customer ranges deliberately excluded.
+        assert!(match_safelist("8.8.8.8", &list).is_none());
+    }
+
+    #[test]
+    fn safelist_matches_cidr_target_when_fully_contained() {
+        let list = safelist_cidrs();
+        // 104.16.0.0/16 fits inside 104.16.0.0/13.
+        assert!(match_safelist("104.16.0.0/16", &list).is_some());
+    }
+
+    #[test]
+    fn safelist_rejects_cidr_target_wider_than_any_range() {
+        let list = safelist_cidrs();
+        // 104.0.0.0/8 is wider than any safelist range and must not match,
+        // otherwise a wildly over-broad operator rule would be released.
+        assert!(match_safelist("104.0.0.0/8", &list).is_none());
+    }
+
+    #[test]
+    fn safelist_matches_loopback_and_multicast() {
+        let list = safelist_cidrs();
+        assert!(match_safelist("127.0.0.1", &list).is_some());
+        assert!(match_safelist("169.254.169.254", &list).is_some());
+        assert!(match_safelist("226.20.72.184", &list).is_some());
+    }
+
+    #[test]
+    fn safelist_matches_oracle_peer_ranges() {
+        let list = safelist_cidrs();
+        assert!(match_safelist("147.154.245.65", &list).is_some());
+        assert!(match_safelist("140.91.26.100", &list).is_some());
+        assert!(match_safelist("138.1.16.172", &list).is_some());
+    }
+
+    #[test]
+    fn invalid_target_string_is_not_matched() {
+        let list = safelist_cidrs();
+        assert!(match_safelist("", &list).is_none());
+        assert!(match_safelist("not-an-ip", &list).is_none());
+        assert!(match_safelist("1.2.3.4/abc", &list).is_none());
+    }
+}

--- a/crates/ctl/src/main.rs
+++ b/crates/ctl/src/main.rs
@@ -1728,6 +1728,28 @@ enum SystemCommand {
         #[arg(long)]
         json: bool,
     },
+
+    /// Cross-check firewall DENY rules against the cloud provider
+    /// safelist and release any that now fall inside a known safe range.
+    ///
+    /// Motivating case: the CL-008 cascade in April 2026 installed ufw
+    /// rules blocking Cloudflare and Oracle OCI peer ranges before the
+    /// safelist existed. New blocks are refused by the safelist, but the
+    /// old rules rot until their 7-day TTL expires. This command walks
+    /// the current firewall state and offers a cleanup plan.
+    ///
+    /// Dry-run by default; pass --apply to actually unblock.
+    ///
+    /// Examples:
+    ///   innerwarden system reconcile-blocks
+    ///   innerwarden system reconcile-blocks --apply
+    #[clap(name = "reconcile-blocks")]
+    ReconcileBlocks {
+        /// Release every matching rule. Without this flag the command is
+        /// a dry run and only prints what it would do.
+        #[arg(long)]
+        apply: bool,
+    },
 }
 
 // ---------------------------------------------------------------------------
@@ -2137,6 +2159,9 @@ fn main() -> Result<()> {
             }
             SystemCommand::CircuitReset { json } => {
                 commands::circuit::cmd_circuit_reset(&cli.agent_config, &cli.data_dir, *json)
+            }
+            SystemCommand::ReconcileBlocks { apply } => {
+                commands::reconcile::cmd_reconcile_blocks(&cli, &cli.data_dir.clone(), *apply)
             }
         },
 


### PR DESCRIPTION
## Problems

Operator audit after deploy of #186 found four regressions + gaps:

1. **Three different "threats handled today" numbers** on Home: hero sub 9, Handled KPI 50, AI briefing 48. Three code paths, three meanings.
2. **Briefing still spoke like a consultant** ("everything is under control", "no further action needed") despite the persona unify in #186.
3. **Report tab shows events.jsonl as ✗ Absent** — spec 016 migrated events to SQLite, display never updated.
4. **~60 Cloudflare / Oracle OCI / link-local rules stuck in ufw** from before cloud_safelist landed (#181). No CLI to reconcile.

## Fixes

### 1. Single-source "Handled" count
`updateHomeNow`, `computeHomeState`, and `updateHomeKpis` all read `overview.safely_resolved` (every non-"ignore" decision today: block, monitor, honeypot, kill, suspend). Briefing's own graph walk uses the identical counting rules, so the three surfaces now agree.

### 2. Briefing prompt stops fighting the persona
`briefing_prompt` used to carry a second "You are the AI security agent..." framing plus "Be reassuring" and "non-technical" instructions, which overrode the persona system prompt. Rewritten to format-only; tone owned by `briefing_system_prompt`.

### 3. Report tab "events" row
Shows "SQLite · (in db)" for the events row; jsonl UI kept for the rest.

### 4. `innerwarden system reconcile-blocks`
New command. Walks ufw DENY rules the agent authored, cross-checks against the cloud safelist (Cloudflare, Oracle peers, link-local, agent services, Telegram edge), emits a dry-run plan, and applies via `innerwarden action unblock` with `--apply`. CLOUD_PROVIDER_RANGES (DO/AWS/Azure customer VPS) intentionally excluded.

Ran the equivalent Python script against prod before shipping: **60 rules released, 0 failures.**

## Test plan

- [x] `cargo test -p innerwarden-agent` — 1548 pass (briefing prompt regression tests + 4 extra)
- [x] `cargo test -p innerwarden-ctl` — 450 pass (15 new reconcile tests: parse + match matrix)
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [x] Prod smoke (manual ops, not code): 60 rules released with no failures
- [ ] Post-merge: redeploy, verify Home hero/KPI/briefing all show the same number; run `innerwarden system reconcile-blocks` and confirm 0 matches remain.