### PR TITLE
feat(fuzz): cargo-fuzz harnesses for attacker-facing parsers

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,0 +1,58 @@
+name: Fuzz
+
+on:
+  schedule:
+    # Nightly at 04:00 UTC. Nothing blocks on fuzz results; the workflow
+    # uploads any crash corpus as an artifact so the operator can triage.
+    - cron: "0 4 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  fuzz:
+    name: cargo-fuzz (${{ matrix.target }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - tls_client_hello
+          - core_event_json
+          - core_incident_json
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Install Rust nightly
+        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
+        with:
+          toolchain: nightly
+
+      - name: Install cargo-fuzz
+        run: cargo +nightly install cargo-fuzz --locked --version 0.12.0
+
+      - name: Cache fuzz corpus
+        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4
+        with:
+          path: fuzz/corpus/${{ matrix.target }}
+          key: fuzz-corpus-${{ matrix.target }}-${{ github.sha }}
+          restore-keys: |
+            fuzz-corpus-${{ matrix.target }}-
+
+      - name: Fuzz 5 minutes
+        working-directory: fuzz
+        run: cargo +nightly fuzz run ${{ matrix.target }} -- -max_total_time=300
+
+      - name: Upload crash artifacts
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: fuzz-crash-${{ matrix.target }}
+          path: |
+            fuzz/artifacts/${{ matrix.target }}/
+            fuzz/corpus/${{ matrix.target }}/
+          retention-days: 14

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,11 @@ members = [
   "crates/shield",
   "crates/store",
 ]
-exclude = ["crates/sensor-ebpf"]
-# crates/sensor-ebpf compiles to bpfel-unknown-none target (separate build)
+exclude = ["crates/sensor-ebpf", "fuzz"]
+# crates/sensor-ebpf compiles to bpfel-unknown-none target (separate build).
+# fuzz/ is a cargo-fuzz harness that depends on libfuzzer-sys (nightly-only
+# when using `cargo fuzz`); keeping it out of the workspace avoids polluting
+# stable CI with nightly requirements.
 resolver = "2"
 
 [workspace.package]

--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,19 @@ scenario-qa:
 ops-check:
 	./scripts/ops-check.sh $(DATA_DIR)
 
+# Requires nightly Rust + cargo-fuzz (`cargo install cargo-fuzz`).
+# `fuzz-quick` runs each harness for 60s, enough to catch regressions
+# on a developer machine without burning a build slot. For real
+# coverage, point OSS-Fuzz or a dedicated runner at the targets.
+FUZZ_DURATION ?= 60
+.PHONY: fuzz-quick
+fuzz-quick:
+	@command -v cargo-fuzz >/dev/null 2>&1 || { echo "cargo-fuzz not installed; run: cargo install cargo-fuzz"; exit 1; }
+	@for target in tls_client_hello core_event_json core_incident_json; do \
+		echo "[fuzz] $$target — $(FUZZ_DURATION)s"; \
+		(cd fuzz && cargo +nightly fuzz run $$target -- -max_total_time=$(FUZZ_DURATION)) || exit 1; \
+	done
+
 # ─── Cross-compile for Linux arm64 ───────────────────────────────────────────
 
 .PHONY: build-linux

--- a/crates/sensor/src/lib.rs
+++ b/crates/sensor/src/lib.rs
@@ -1,3 +1,5 @@
-// Library re-exports for integration/property tests.
+// Library re-exports for integration/property tests and for the
+// cargo-fuzz harnesses in fuzz/.
 
+pub mod collectors;
 pub mod detectors;

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,40 @@
+[package]
+name = "innerwarden-fuzz"
+version = "0.0.0"
+edition = "2021"
+license = "Apache-2.0"
+publish = false
+description = "Fuzz harnesses for InnerWarden parsers that consume attacker-controlled input (TLS ClientHello, JSONL event stream, core incident deserialisation). Run with `cargo +nightly fuzz run <target>`."
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+serde_json = "1"
+innerwarden-sensor = { path = "../crates/sensor" }
+innerwarden_core = { path = "../crates/core" }
+
+# Targets are compiled individually; each gets its own [[bin]] entry so
+# `cargo fuzz list` discovers them without a wrapper module.
+
+[[bin]]
+name = "tls_client_hello"
+path = "fuzz_targets/tls_client_hello.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "core_event_json"
+path = "fuzz_targets/core_event_json.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "core_incident_json"
+path = "fuzz_targets/core_incident_json.rs"
+test = false
+doc = false
+bench = false

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -1,0 +1,57 @@
+# InnerWarden fuzz harnesses
+
+Three cargo-fuzz harnesses for the parsers that see attacker-controlled
+input on a live deployment:
+
+- **tls_client_hello** — raw TLS ClientHello bytes. Exercises
+  `sensor::collectors::tls_fingerprint::parse_packet` and the JA3/JA4
+  fingerprint computer.
+- **core_event_json** — JSON → `innerwarden_core::event::Event`. The
+  deserialisation boundary for JSONL replay, redis-stream ingestion, and
+  external sinks.
+- **core_incident_json** — JSON → `innerwarden_core::incident::Incident`.
+  Loaded on startup to rebuild in-memory state; must never panic on a
+  corrupted line.
+
+## Running locally
+
+Requires nightly Rust + cargo-fuzz:
+
+```bash
+rustup toolchain install nightly
+cargo install cargo-fuzz
+```
+
+Run one target for 60 seconds:
+
+```bash
+cd fuzz
+cargo +nightly fuzz run tls_client_hello -- -max_total_time=60
+```
+
+Or run every target through the Makefile:
+
+```bash
+make fuzz-quick               # 60s per target
+FUZZ_DURATION=300 make fuzz-quick  # 5min per target
+```
+
+## CI
+
+`.github/workflows/fuzz.yml` runs each target for 5 minutes every night
+and on manual dispatch. It does not block PRs. Crashes are uploaded as
+workflow artifacts under `fuzz-crash-<target>/` and kept for 14 days so
+the operator can reproduce:
+
+```bash
+cargo +nightly fuzz run <target> fuzz/artifacts/<target>/crash-<hash>
+```
+
+## Adding a target
+
+1. Create `fuzz_targets/<name>.rs` with a `fuzz_target!` entry point.
+2. Add a matching `[[bin]]` section to `fuzz/Cargo.toml`.
+3. Add the target name to `Makefile` `fuzz-quick` and to the workflow
+   matrix in `.github/workflows/fuzz.yml`.
+4. Fuzz harnesses must not panic on any input. Surface deliberate
+   invariants with `assert!` only when the assertion is load-bearing.

--- a/fuzz/fuzz_targets/core_event_json.rs
+++ b/fuzz/fuzz_targets/core_event_json.rs
@@ -1,0 +1,14 @@
+#![no_main]
+//! Fuzz serde_json deserialisation of the `Event` type.
+//!
+//! Every piece of the pipeline that replays JSONL or reads events from
+//! external sinks passes strings through `serde_json::from_slice::<Event>`
+//! or `::from_str`. Adversarial JSON bodies with unexpected types, deep
+//! nesting, or giant fields must not crash the agent; either the parse
+//! returns Err or produces a well-formed Event.
+
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    let _ = serde_json::from_slice::<innerwarden_core::event::Event>(data);
+});

--- a/fuzz/fuzz_targets/core_incident_json.rs
+++ b/fuzz/fuzz_targets/core_incident_json.rs
@@ -1,0 +1,12 @@
+#![no_main]
+//! Fuzz serde_json deserialisation of the `Incident` type.
+//!
+//! The agent reads incident JSONL on startup to rebuild in-memory state,
+//! and via replay/scenario-qa to validate detector output. A malformed
+//! line must produce `Err`, never a panic.
+
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    let _ = serde_json::from_slice::<innerwarden_core::incident::Incident>(data);
+});

--- a/fuzz/fuzz_targets/tls_client_hello.rs
+++ b/fuzz/fuzz_targets/tls_client_hello.rs
@@ -1,0 +1,19 @@
+#![no_main]
+//! Fuzz the TLS ClientHello parser + JA3/JA4 fingerprint computer.
+//!
+//! Input: arbitrary bytes (what an attacker on the wire can send).
+//! Invariants under fuzz:
+//!   - `parse_packet` must return `None` or `Some(hello)`. It must never
+//!     panic on any byte sequence, regardless of length or content.
+//!   - When `parse_packet` succeeds, `compute_fingerprints` must
+//!     terminate in bounded time and must not panic. The resulting
+//!     JA3 / JA4 strings are not asserted (we only care about crashes,
+//!     OOM, and hangs).
+
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    if let Some(hello) = innerwarden_sensor::collectors::tls_fingerprint::parse_packet(data) {
+        let _ = innerwarden_sensor::collectors::tls_fingerprint::compute_fingerprints(&hello);
+    }
+});


### PR DESCRIPTION
## Summary

Closes the OpenSSF Scorecard "Fuzzing: medium" warning and, more importantly, exercises the parsers that read attacker-controlled bytes. Three harnesses to start:

| Target | What it fuzzes | Why |
|---|---|---|
| \`tls_client_hello\` | raw TLS ClientHello bytes → \`parse_packet\` → \`compute_fingerprints\` (JA3/JA4) | Attacker owns 100% of the packet bytes |
| \`core_event_json\` | serde_json → \`innerwarden_core::event::Event\` | Deserialisation boundary for JSONL replay + external sinks |
| \`core_incident_json\` | serde_json → \`innerwarden_core::incident::Incident\` | Read at startup; a corrupt line must never panic |

## Layout

- \`fuzz/\` is **excluded from the workspace** so stable CI stays on stable; cargo-fuzz needs nightly.
- \`make fuzz-quick\` runs each harness 60s locally. \`FUZZ_DURATION=300 make fuzz-quick\` for 5 min.
- \`.github/workflows/fuzz.yml\` runs 5 min per target nightly (04:00 UTC) and on \`workflow_dispatch\`. Crashes upload as artifacts for 14 days. Does not block PRs.
- \`crates/sensor/src/lib.rs\` re-exports \`collectors\` alongside \`detectors\` so the harnesses can reach \`parse_packet\` + \`compute_fingerprints\`.

Why main and not development: Scorecard scans the default branch, so landing here makes the signal visible immediately.

## Follow-ups deliberately out of scope

- HTTP and DNS capture parsers are currently private; promoting them to \`pub\` is one small PR away and would add two more targets.
- Sigma YAML + YARA rule loaders are worth fuzzing once their entry points are \`pub\`.

## Test plan

- [x] \`cargo check --workspace\` clean (fuzz excluded)
- [x] \`cargo clippy --workspace -- -D warnings\` clean
- [x] \`cargo fmt --all --check\` clean
- [ ] Nightly workflow fires once and uploads 0 crash artifacts in the first 24h (if it finds crashes, that is a success — we triage them).