### PR TITLE
fix(dashboard): Threats tab stuck on Loading after #188 removed hidden spans

### DIFF
--- a/crates/agent/src/dashboard/frontend/js/threats.js
+++ b/crates/agent/src/dashboard/frontend/js/threats.js
@@ -440,6 +440,10 @@ async function refreshLeftLive() {
 
     const list = document.getElementById('attackerList');
     const newItems = items.filter(it => !state.knownItemValues.has(it.value));
+    // SSE refresh can fire while Threats view is hidden; the list node
+    // may be absent if the tab was not yet opened. Bail early in that
+    // case so the live path never throws on null.innerHTML.
+    if (!list) return;
     if (newItems.length > 0) {
       // Rebuild grouped list when new items arrive
       list.innerHTML = buildGroupedList(items);
@@ -513,36 +517,50 @@ async function refreshLeft(forceRefreshJourney = false) {
       else if (o === 'needs_attention') kpiAttention++;
       else if (o === 'monitoring') kpiObserving++;
     });
-    document.getElementById('kpi-confirmed').textContent = kpiBlocked;
-    document.getElementById('kpi-responded').textContent = kpiObserving;
-    document.getElementById('kpi-noise').textContent     = kpiAttention;
-    document.getElementById('kpi-events').textContent    = ov.events_count;
-    document.getElementById('kpi-incidents').textContent = ov.incidents_count;
-    const kpiAtt = document.getElementById('kpi-attackers');
-    if (kpiAtt) kpiAtt.textContent = items.length;
+    // #188 removed four elements from the Threats left panel that this
+    // handler still writes to: kpi-events, kpi-incidents, kpi-attackers
+    // (hidden spans), clusterList + topDetectors divs (dead UI). Without
+    // a null guard the first null.textContent throws and aborts the
+    // whole refreshLeft before attackerList.innerHTML runs — the list
+    // then sticks on "Loading..." forever. Guard every write.
+    var setText = function(id, value) {
+      var el = document.getElementById(id);
+      if (el) el.textContent = value;
+    };
+    var setHtml = function(id, value) {
+      var el = document.getElementById(id);
+      if (el) el.innerHTML = value;
+    };
+    setText('kpi-confirmed', kpiBlocked);
+    setText('kpi-responded', kpiObserving);
+    setText('kpi-noise', kpiAttention);
+    setText('kpi-events', ov.events_count);
+    setText('kpi-incidents', ov.incidents_count);
+    setText('kpi-attackers', items.length);
 
     const list = document.getElementById('attackerList');
-    if (items.length === 0) {
-      list.innerHTML = '<div class="empty">No records for the selected filters.</div>';
-      state.knownItemValues.clear();
-    } else {
-      list.innerHTML = buildGroupedList(items);
-      state.knownItemValues = new Set(items.map(it => it.value));
+    if (list) {
+      if (items.length === 0) {
+        list.innerHTML = '<div class="empty">No records for the selected filters.</div>';
+        state.knownItemValues.clear();
+      } else {
+        list.innerHTML = buildGroupedList(items);
+        state.knownItemValues = new Set(items.map(it => it.value));
+      }
     }
 
-    const clusterList = document.getElementById('clusterList');
     if (!state.clusters.length) {
-      clusterList.innerHTML = '<div class="empty">No clusters for current filters.</div>';
+      setHtml('clusterList', '<div class="empty">No clusters for current filters.</div>');
     } else {
-      clusterList.innerHTML = state.clusters.map(renderClusterCard).join('');
+      setHtml('clusterList', state.clusters.map(renderClusterCard).join(''));
     }
 
     if (ov.top_detectors && ov.top_detectors.length) {
-      document.getElementById('topDetectors').innerHTML = ov.top_detectors.map(d =>
+      setHtml('topDetectors', ov.top_detectors.map(d =>
         `<div class="det-row"><span>${esc(d.detector)}</span><span class="det-count">${d.count}</span></div>`
-      ).join('');
+      ).join(''));
     } else {
-      document.getElementById('topDetectors').innerHTML = '<div class="empty">No detectors fired.</div>';
+      setHtml('topDetectors', '<div class="empty">No detectors fired.</div>');
     }
 
     if (state.selected.value) {


### PR DESCRIPTION
## Problem

Regression from #188. Operator reported Threats tab showing \"Attackers (IP): Loading...\" forever even though the KPIs above (Blocked/Observing/Needs attention) updated correctly.

## Root cause

#188 removed dead UI from the Threats left panel: the hidden \`kpi-events\`, \`kpi-incidents\`, \`kpi-attackers\` spans and the \`clusterList\` + \`topDetectors\` divs (never populated, audit flagged them as dead code).

But \`threats.js refreshLeft\` still wrote to those ids directly:

\`\`\`js
document.getElementById('kpi-events').textContent    = ov.events_count;     // null now
document.getElementById('kpi-incidents').textContent = ov.incidents_count;  // null now
...
document.getElementById('clusterList').innerHTML = ...;                    // null now
document.getElementById('topDetectors').innerHTML = ...;                   // null now
\`\`\`

The first \`null.textContent\` threw, the outer try/catch swallowed it, and the \`attackerList.innerHTML = buildGroupedList(...)\` call three lines later never ran. The list sat on \"Loading...\" forever.

\`refreshLeftLive\` has the same shape but already funnels KPI writes through \`updateKpi\` (which guards with \`if (!el) return\`). Only the attackerList rebuild at the end needed a null check.

## Fix

Minimal surgical guards: wrap every left-panel dashboard-element write through \`setText\` / \`setHtml\` helpers that no-op when the node is absent. Zero behaviour change when the elements exist. Same style as the textContent guards shipped earlier in #189.

## Test plan

- [x] \`cargo test -p innerwarden-agent\` — 1559 pass, nothing depends on those dead ids
- [x] \`cargo clippy --workspace -- -D warnings\` clean
- [x] \`cargo fmt --all --check\` clean
- [ ] Post-merge on prod: open Threats tab, confirm list renders instead of stuck on Loading. Hero KPIs should match (they already worked).