### PR TITLE
spec(028) + bundle: incident lifecycle bugs — dashboard + sensor cooldowns + flag stub

### DIFF
--- a/.specify/features/028-incident-lifecycle-bugs/spec.md
+++ b/.specify/features/028-incident-lifecycle-bugs/spec.md
@@ -1,4 +1,4 @@
-# Feature Specification: Incident Lifecycle Bugs — Autonomy Gap 2.0
+# Feature Specification: Incident Lifecycle Bugs - Autonomy Gap 2.0
 
 **Feature Branch**: `028-incident-lifecycle-bugs`
 **Created**: 2026-04-19
@@ -79,17 +79,17 @@ P2 = UI only.
 
 Three IPs that expose bugs #1, #2, #3, #4 in isolation:
 
-- **51.158.205.47 (masscan)**: 32 incidents in 5h, each triggered an AI chat() call that returned "escalate — SUSPICIOUS". Zero blocks. Still Observing.
-- **64.89.163.156 (Distributed SSH botnet)**: HIGH severity, AI said "SUSPICIOUS — botnet scan activity" at 85% confidence. Status "Needs review — no automated response taken". 3 hours later still not blocked.
+- **51.158.205.47 (masscan)**: 32 incidents in 5h, each triggered an AI chat() call that returned "escalate - SUSPICIOUS". Zero blocks. Still Observing.
+- **64.89.163.156 (Distributed SSH botnet)**: HIGH severity, AI said "SUSPICIOUS - botnet scan activity" at 85% confidence. Status "Needs review - no automated response taken". 3 hours later still not blocked.
 - **103.41.247.76 (rule-blocked but shown Observing)**: ssh_bruteforce rule fired a block at 17:00:41 (recorded in decisions). Dashboard still shows this IP under "Observing" rather than "Blocked".
 
 ### Reference files and lines
 
-- `crates/agent/src/narrative_observation_verify.rs:110-126` — escalate branch that only writes to the graph.
-- `crates/agent/src/observation_verify.rs` — the Fase 3 scorer; thresholds in `DEFAULT_ESCALATE_THRESHOLD` = 40.
-- `crates/sensor/src/detectors/user_agent_scanner.rs` — fires `graph_scanner_ua`, no throttle.
-- `crates/sensor/src/detectors/` — most `proto_anomaly:*` detectors; should reject loopback and RFC1918 sources.
-- `crates/agent/src/dashboard.rs` — aggregation of threats into Blocked / Observing / Needs attention buckets.
+- `crates/agent/src/narrative_observation_verify.rs:110-126` - escalate branch that only writes to the graph.
+- `crates/agent/src/observation_verify.rs` - the Fase 3 scorer; thresholds in `DEFAULT_ESCALATE_THRESHOLD` = 40.
+- `crates/sensor/src/detectors/user_agent_scanner.rs` - fires `graph_scanner_ua`, no throttle.
+- `crates/sensor/src/detectors/` - most `proto_anomaly:*` detectors; should reject loopback and RFC1918 sources.
+- `crates/agent/src/dashboard.rs` - aggregation of threats into Blocked / Observing / Needs attention buckets.
 
 ---
 
@@ -97,7 +97,7 @@ Three IPs that expose bugs #1, #2, #3, #4 in isolation:
 
 Organised as four PRs, sequenced by risk vs impact. All PRs sit behind the shadow-mode mechanism introduced in PR #196 (see `crates/agent/src/ai/shadow.rs`) so comparisons against the current behaviour are first-class.
 
-### 028-a — Detector cooldowns and source filters (P1)
+### 028-a - Detector cooldowns and source filters (P1)
 **Fixes**: #1, #5, #9 (partially), #10.
 
 - Add a per-detector `(pivot, window_secs)` throttle in the sensor. `graph_scanner_ua`, `proto_anomaly:SshVersionAnomaly`, `proto_anomaly:SlowConnection`, `proto_anomaly:SshNonStandardPort`, `proto_anomaly:ProtocolMismatch`: one fire per `(source_ip, detector)` per 600s.
@@ -107,7 +107,7 @@ Organised as four PRs, sequenced by risk vs impact. All PRs sit behind the shado
 Risk: low. Only reduces emission volume; does not change decisions.
 Test plan: unit tests on the throttle, replay harness, one week of shadow-mode observation confirming no previously-blocked IPs go un-blocked because the second detector fire was suppressed.
 
-### 028-b — Escalate -> decide() wiring (P0)
+### 028-b - Escalate -> decide() wiring (P0)
 **Fixes**: #2, #6, #7, #8.
 
 - `narrative_observation_verify.rs` escalate branch enqueues the incident into the same queue the main Fase 4 pipeline consumes (whatever the current incident_flow pre-AI queue is).
@@ -117,7 +117,7 @@ Test plan: unit tests on the throttle, replay harness, one week of shadow-mode o
 Risk: medium. Changes what gets blocked autonomously. MUST shadow-mode validate first: with shadow enabled, the local classifier decides on the escalated stream alongside Azure, and we compare the agreement rate for at least 7 days before flipping.
 Test plan: integration test that replays the three UI cases; shadow-mode agreement >= 90% for block_ip on escalated incidents before promoting.
 
-### 028-c — Dashboard bucket fix (P2)
+### 028-c - Dashboard bucket fix (P2)
 **Fixes**: #3, #4.
 
 - Change the Observing/Blocked/Needs-attention classification to look at the latest *effective* state of the IP, not the most recent incident row.
@@ -127,7 +127,7 @@ Test plan: integration test that replays the three UI cases; shadow-mode agreeme
 Risk: low. UI only, no state mutation.
 Test plan: snapshot tests on the classification function with fixtures covering all four transitions.
 
-### 028-d — /24 subnet correlation (P1, optional)
+### 028-d - /24 subnet correlation (P1, optional)
 **Fixes**: #9.
 
 - New correlation rule: if >=3 distinct IPs from the same `/24` trigger any `proto_anomaly:*` or `ssh_bruteforce` detector within 30 min, emit a `subnet_scan_correlation` incident severity High with the /24 as the pivot.
@@ -144,7 +144,7 @@ Risk: medium. A noisy /24 false-positive could accidentally block a whole shared
 3. **028-b (escalate to action)**: ship third. Highest value but also highest risk; requires the shadow-mode agreement window.
 4. **028-d (/24 correlation)**: optional, ship last once the other three are stable.
 
-## Addendum 2026-04-19 — shadow-mode depends on 028-b
+## Addendum 2026-04-19 - shadow-mode depends on 028-b
 
 After enabling shadow-mode in production at 19:43 UTC (`[ai.shadow]` in `/etc/innerwarden/agent.toml` with `provider = "local_classifier"`), the log file `/var/lib/innerwarden/shadow-decisions.jsonl` stayed at 0 bytes for over an hour with zero entries.
 

--- a/.specify/features/028-incident-lifecycle-bugs/spec.md
+++ b/.specify/features/028-incident-lifecycle-bugs/spec.md
@@ -1,0 +1,158 @@
+# Feature Specification: Incident Lifecycle Bugs — Autonomy Gap 2.0
+
+**Feature Branch**: `028-incident-lifecycle-bugs`
+**Created**: 2026-04-19
+**Status**: Draft
+**Input**: Production audit of the InnerWarden agent on Oracle Cloud London (v0.12.2) surfaced a cluster of bugs where detectors fire, the AI classifies correctly, but no action gets executed. Similar pattern to the autonomy gap fixed in spec 018, but on different code paths.
+
+## Origin
+
+During a 2026-04-19 dashboard review we noticed individual attacker IPs sitting in "Observing" for hours despite high-severity signals and high-confidence AI verdicts. A systematic query against the production sqlite exposed 10 distinct problems that together cause three bad outcomes:
+
+1. **Attacks pass through**: high-severity signals are classified as SUSPICIOUS by the AI but never converted into a block action.
+2. **Money leaks**: a single noisy detector (`proto_anomaly:SshVersionAnomaly`) generated 646 incidents in 24h, each one consuming one AI call on the observation-verify path.
+3. **Operator blind**: the dashboard's "Observing" bucket mixes truly-open incidents with already-dismissed and already-contained ones, so the operator cannot see what genuinely needs attention.
+
+## Problem statement
+
+The agent's triage pipeline has three stages:
+
+```
+Fase 2: detector fires -> incident row
+Fase 3: observation_verify scores 0-100
+  - low score      -> auto-dismiss
+  - high score     -> escalate "to Fase 4"
+  - mid score      -> ask AI via chat(); AI says "dismiss" or "escalate"
+Fase 4: AI provider.decide() -> pick action -> execute skill
+```
+
+The problems below live mostly in the Fase 3 <-> Fase 4 boundary and in the detectors feeding Fase 2.
+
+---
+
+## The 10 bugs
+
+Numbered in order of discovery, classified by severity:
+
+| # | Bug | Severity | Class |
+|---|---|---|---|
+| 1 | `proto_anomaly:SshVersionAnomaly` fires once per SSH connection with no `(IP, detector, window)` dedup. 646 incidents / 24h, up to 71 from the same IP. | P1 | spam |
+| 2 | `VerificationResult::Escalate` in `narrative_observation_verify.rs` only writes an "escalate" label into the knowledge graph and stops. Nothing promotes the incident to the Fase 4 decide() pipeline. | **P0** | leak |
+| 3 | Escalated incidents do not surface in the dashboard's "Needs your attention" bucket, so the operator cannot manually block them either. | **P0** | leak |
+| 4 | Dashboard classifies IPs that are already blocked (e.g. by `auto-rule:ssh_bruteforce`) into the "Observing" bucket. E.g. 103.41.247.76 was blocked at 17:00:41 by the ufw rule-based path but still lists as `Observing`. | P2 | UI |
+| 5 | `proto_anomaly:*` detectors fire on internal/loopback IPs (127.0.0.1, 10.0.0.x, 172.x). 22 SlowConnection incidents and 13 ProtocolMismatch incidents came from 127.x in 24h. Loopback cannot be attacker. | P1 | false positive |
+| 6 | `threat_intel:threat_ip`: 75 incidents in 24h, 31 resulted in a `block_ip` decision. The remaining 44 either deduped silently or had a decision but the action was not block_ip. Threat intel match is a max-confidence signal and must be 100% block. | **P0** | leak |
+| 7 | `suspicious_execution:unknown` and `suspicious_execution:ubuntu` fired 8 incidents combined, zero decisions recorded. Completely un-triaged high-severity detector. | **P0** | leak |
+| 8 | `sudo_abuse:ubuntu` fired 2 incidents, zero decisions. Sudo abuse on a managed server is a max-severity signal. | **P0** | leak |
+| 9 | No cross-IP correlation for /24 subnet scans. 5 IPs in the `92.118.39.0/24` block produced 22-32 "Suspicious connection" LOW incidents each in the past few hours. Same ISP/range pattern is a textbook coordinated scan; nothing blocks it. | P1 | missed correlation |
+| 10 | Duplicate incident rows: the same `incident_id` appears multiple times in the incidents table. Makes correlation/dedup queries noisy, and confuses the Fase 3 scoring which likely computes the same score for each duplicate. | P1 | data integrity |
+
+P0 = attack gets through or high-severity detector produces no decision.
+P1 = cost / noise / reduced signal quality.
+P2 = UI only.
+
+---
+
+## Evidence (gathered 2026-04-19, Oracle London, v0.12.2)
+
+### Query: decisions by detector in last 24h
+
+| Detector | Incidents | Blocked | Dismissed | Monitor | Escalated | No decision |
+|---|---|---|---|---|---|---|
+| proto_anomaly:SshVersionAnomaly | 646 | 0 | 399 | 0 | 0 | 247 |
+| proto_anomaly:SlowConnection | 79 | 9 | 19 | 0 | 0 | 51 |
+| proto_anomaly:SshNonStandardPort | 77 | 8 | 27 | 0 | 0 | 42 |
+| threat_intel:threat_ip | 75 | 31 | 0 | 0 | 0 | 44 |
+| proto_anomaly:ProtocolMismatch | 21 | 2 | 0 | 0 | 0 | 19 |
+| packet_flood:rate_anomaly | 13 | 9 | 0 | 0 | 0 | 6 |
+| ssh_bruteforce:130.250.191.204 | 8 | 2 | 0 | 0 | 0 | 7 |
+| ssh_bruteforce:116.99.173.227 | 6 | 2 | 0 | 0 | 0 | 5 |
+| ssh_bruteforce:209.14.88.118 | 6 | 1 | 2 | 0 | 0 | 4 |
+| suspicious_execution:unknown | 5 | 0 | 0 | 0 | 0 | 5 |
+| ssh_bruteforce:34.123.134.194 | 5 | 1 | 5 | 0 | 0 | 0 |
+| suspicious_execution:ubuntu | 3 | 0 | 0 | 0 | 0 | 3 |
+| sudo_abuse:ubuntu | 2 | 0 | 0 | 0 | 0 | 2 |
+
+(Full set of 25 detectors available in `/var/lib/innerwarden/innerwarden.db` on the prod server. The "no decision" counts can exceed the incident count because of duplicate rows for the same incident_id; bug #10.)
+
+### Representative UI cases
+
+Three IPs that expose bugs #1, #2, #3, #4 in isolation:
+
+- **51.158.205.47 (masscan)**: 32 incidents in 5h, each triggered an AI chat() call that returned "escalate — SUSPICIOUS". Zero blocks. Still Observing.
+- **64.89.163.156 (Distributed SSH botnet)**: HIGH severity, AI said "SUSPICIOUS — botnet scan activity" at 85% confidence. Status "Needs review — no automated response taken". 3 hours later still not blocked.
+- **103.41.247.76 (rule-blocked but shown Observing)**: ssh_bruteforce rule fired a block at 17:00:41 (recorded in decisions). Dashboard still shows this IP under "Observing" rather than "Blocked".
+
+### Reference files and lines
+
+- `crates/agent/src/narrative_observation_verify.rs:110-126` — escalate branch that only writes to the graph.
+- `crates/agent/src/observation_verify.rs` — the Fase 3 scorer; thresholds in `DEFAULT_ESCALATE_THRESHOLD` = 40.
+- `crates/sensor/src/detectors/user_agent_scanner.rs` — fires `graph_scanner_ua`, no throttle.
+- `crates/sensor/src/detectors/` — most `proto_anomaly:*` detectors; should reject loopback and RFC1918 sources.
+- `crates/agent/src/dashboard.rs` — aggregation of threats into Blocked / Observing / Needs attention buckets.
+
+---
+
+## Fixes
+
+Organised as four PRs, sequenced by risk vs impact. All PRs sit behind the shadow-mode mechanism introduced in PR #196 (see `crates/agent/src/ai/shadow.rs`) so comparisons against the current behaviour are first-class.
+
+### 028-a — Detector cooldowns and source filters (P1)
+**Fixes**: #1, #5, #9 (partially), #10.
+
+- Add a per-detector `(pivot, window_secs)` throttle in the sensor. `graph_scanner_ua`, `proto_anomaly:SshVersionAnomaly`, `proto_anomaly:SlowConnection`, `proto_anomaly:SshNonStandardPort`, `proto_anomaly:ProtocolMismatch`: one fire per `(source_ip, detector)` per 600s.
+- Reject loopback (127.0.0.0/8) and RFC1918 (10/8, 172.16/12, 192.168/16) as the source for any `proto_anomaly:*` detector.
+- Dedup the incidents table write path: if an `incident_id` already exists in the last 600s, update the event count on the existing row instead of inserting a new one.
+
+Risk: low. Only reduces emission volume; does not change decisions.
+Test plan: unit tests on the throttle, replay harness, one week of shadow-mode observation confirming no previously-blocked IPs go un-blocked because the second detector fire was suppressed.
+
+### 028-b — Escalate -> decide() wiring (P0)
+**Fixes**: #2, #6, #7, #8.
+
+- `narrative_observation_verify.rs` escalate branch enqueues the incident into the same queue the main Fase 4 pipeline consumes (whatever the current incident_flow pre-AI queue is).
+- Fase 4 calls `ai_provider.decide()` on escalated incidents exactly like it does for incidents that bypass Fase 3.
+- For `threat_intel:threat_ip`, `sudo_abuse:*`, `suspicious_execution:*`: make them skip Fase 3 entirely and go direct to Fase 4. These are high-signal detectors that should never be observation-verified away.
+
+Risk: medium. Changes what gets blocked autonomously. MUST shadow-mode validate first: with shadow enabled, the local classifier decides on the escalated stream alongside Azure, and we compare the agreement rate for at least 7 days before flipping.
+Test plan: integration test that replays the three UI cases; shadow-mode agreement >= 90% for block_ip on escalated incidents before promoting.
+
+### 028-c — Dashboard bucket fix (P2)
+**Fixes**: #3, #4.
+
+- Change the Observing/Blocked/Needs-attention classification to look at the latest *effective* state of the IP, not the most recent incident row.
+- Effective state per IP: `Blocked` if any unexpired block decision exists, `Needs attention` if any escalated incident has no resolving decision yet, `Observing` otherwise.
+- Drop LOW-severity noise-gate-dismissed incidents from the Observing count entirely; keep them reachable via the full log but do not count them in the header.
+
+Risk: low. UI only, no state mutation.
+Test plan: snapshot tests on the classification function with fixtures covering all four transitions.
+
+### 028-d — /24 subnet correlation (P1, optional)
+**Fixes**: #9.
+
+- New correlation rule: if >=3 distinct IPs from the same `/24` trigger any `proto_anomaly:*` or `ssh_bruteforce` detector within 30 min, emit a `subnet_scan_correlation` incident severity High with the /24 as the pivot.
+- The /24 can then be blocked once via the existing block_ip skill (we already support CIDR blocks per the v11 gym logs).
+
+Risk: medium. A noisy /24 false-positive could accidentally block a whole shared-hosting range. Must be manually-opt-in for the first week.
+
+---
+
+## Sequencing
+
+1. **028-c (dashboard)**: ship first. Immediate visibility win, zero risk.
+2. **028-a (cooldowns)**: ship second. Reduces incident volume by an estimated 80% which makes everything else easier to observe.
+3. **028-b (escalate to action)**: ship third. Highest value but also highest risk; requires the shadow-mode agreement window.
+4. **028-d (/24 correlation)**: optional, ship last once the other three are stable.
+
+## Success criteria
+
+- `proto_anomaly:SshVersionAnomaly` volume drops below 100 incidents / 24h (currently 646).
+- Zero incidents in 7 consecutive days where the AI said SUSPICIOUS / escalate and the IP was not actioned by either an autonomous block or an operator review notification.
+- Dashboard "Needs your attention" count is non-zero whenever any incident is in the escalated-but-undecided state.
+- Dashboard "Observing" count excludes already-blocked IPs.
+
+## Out of scope
+
+- Replacing the Azure AI provider with the local classifier. That is the separate flow tracked in PR #196 and spec-026 (Rust ONNX integration). It benefits from 028-b but does not depend on it.
+- Rewriting the Fase 3 scorer. The current scorer is fine; the bug is solely in the escalate branch.
+- Changes to the block-ip skills themselves. All existing skills work correctly; the gap is purely getting the decision to fire.

--- a/.specify/features/028-incident-lifecycle-bugs/spec.md
+++ b/.specify/features/028-incident-lifecycle-bugs/spec.md
@@ -144,6 +144,29 @@ Risk: medium. A noisy /24 false-positive could accidentally block a whole shared
 3. **028-b (escalate to action)**: ship third. Highest value but also highest risk; requires the shadow-mode agreement window.
 4. **028-d (/24 correlation)**: optional, ship last once the other three are stable.
 
+## Addendum 2026-04-19 — shadow-mode depends on 028-b
+
+After enabling shadow-mode in production at 19:43 UTC (`[ai.shadow]` in `/etc/innerwarden/agent.toml` with `provider = "local_classifier"`), the log file `/var/lib/innerwarden/shadow-decisions.jsonl` stayed at 0 bytes for over an hour with zero entries.
+
+Root cause: the shadow wrapper in `crates/agent/src/ai/shadow.rs` only intercepts the `AiProvider::decide()` path. It deliberately does not wrap `AiProvider::chat()` because chat returns free-form text that has no `action` label to compare.
+
+In the current production pipeline, the main `decide()` path is almost never invoked. Most traffic goes through `observation-verify` which uses `chat()` to ask "is this suspicious, dismiss or escalate?", and the `escalate` result dead-ends into a graph label (bug #2 in this spec). Concretely: from 19:43 to 20:50 UTC there were 5 `chat()` calls via observation-verify and zero `decide()` calls through the main pipeline.
+
+This exposes a real dependency:
+
+- **Shadow-mode cannot produce useful parity data until 028-b ships.**
+- Before 028-b, the shadow log is empty by construction because the code path the shadow observes is rarely exercised.
+- Once 028-b is in place, every incident that `observation-verify` escalates will flow into `decide()`, which is what shadow-mode wraps. At that point the shadow log starts populating at the rate that 028-a does not throttle away.
+
+Implication for this spec: the 7-day shadow-agreement window required before promoting the local classifier to primary (referenced in 028-b test plan and in PR #196) cannot start counting down from today. It starts when 028-b lands in production, not when shadow mode is first enabled.
+
+Two workarounds are possible if we want earlier parity data:
+
+- **028-e (optional, not currently scoped)**: wrap `chat()` inside `ShadowProvider` too. The wrapper would send the same message to the shadow provider and log the raw text response. Parity would then be measured as "does the classifier's top action match the action keyword in the chat response text?". Noisier signal but would let us observe earlier. Adds ~50 lines to `shadow.rs`.
+- **Force high-severity traffic**: in a staging environment, replay historical high-severity incidents so they hit the main `decide()` path. Good for ad-hoc testing but does not constitute production validation.
+
+Recommendation: accept the dependency, do not add 028-e, and keep the shadow-mode validation gate on 028-b as specified.
+
 ## Success criteria
 
 - `proto_anomaly:SshVersionAnomaly` volume drops below 100 incidents / 24h (currently 646).

--- a/crates/agent/src/config.rs
+++ b/crates/agent/src/config.rs
@@ -112,6 +112,40 @@ pub struct AgentConfig {
     /// Example: ["threat_intel", "lateral_movement", "persistence"]
     #[serde(default)]
     pub graph_only_detectors: Vec<String>,
+    /// Incident lifecycle flow configuration (spec 028).
+    #[serde(default)]
+    pub incident_flow: IncidentFlowConfig,
+}
+
+/// Incident lifecycle routing knobs (spec 028).
+///
+/// The only knob currently live is the `escalate_to_decide` feature flag. When
+/// true, observation-verify's Escalate branch is expected to forward incidents
+/// into the Fase 4 `ai_provider.decide()` pipeline so attackers that score
+/// above the escalate threshold actually get actioned instead of sitting under
+/// the OBSERVING bucket forever.
+///
+/// Default is `false` because the full wiring (threading the provider + skill
+/// executor + state into narrative_observation_verify) is intentionally
+/// staged: this PR lands the flag + config, the follow-up PR lands the decide
+/// call. See spec 028 section 028-b.
+#[derive(Debug, Deserialize, Default, Clone)]
+pub struct IncidentFlowConfig {
+    /// When true, Escalate from observation-verify should trigger a Fase 4
+    /// decide() call. The wiring itself is a follow-up PR; today the flag
+    /// is read but the code path only logs an intent line. Flip to true in
+    /// /etc/innerwarden/agent.toml after the wiring PR lands.
+    #[serde(default)]
+    pub escalate_to_decide: bool,
+    /// Detector prefixes whose incidents should skip the Fase 3 observation
+    /// verifier entirely and go direct to Fase 4. The spec lists
+    /// `threat_intel:*`, `sudo_abuse:*`, and `suspicious_execution:*` as
+    /// candidates because they are inherently high-signal. Matched via
+    /// prefix (case-sensitive). Empty by default; the skip path is also
+    /// part of the follow-up PR.
+    #[serde(default)]
+    #[allow(dead_code)] // wiring lands in the 028-b follow-up PR
+    pub detectors_skip_fase3: Vec<String>,
 }
 
 #[derive(Debug, Deserialize, Default, Clone)]
@@ -3206,5 +3240,36 @@ log_path = "/tmp/shadow.jsonl"
             ai.provider = provider.into();
             let _ = ai.resolved_api_key();
         }
+    }
+
+    // Spec 028-b: incident_flow config defaults keep the flag off and the
+    // skip-fase3 list empty so bundled deploy changes nothing about decision
+    // behaviour until operator flips the flag explicitly.
+    #[test]
+    fn incident_flow_defaults_are_conservative() {
+        let cfg = IncidentFlowConfig::default();
+        assert!(!cfg.escalate_to_decide);
+        assert!(cfg.detectors_skip_fase3.is_empty());
+    }
+
+    #[test]
+    fn load_parses_incident_flow_section() {
+        let mut tmp = NamedTempFile::new().unwrap();
+        writeln!(
+            tmp,
+            r#"[incident_flow]
+escalate_to_decide = true
+detectors_skip_fase3 = ["threat_intel", "sudo_abuse", "suspicious_execution"]
+"#
+        )
+        .unwrap();
+        let cfg = load(tmp.path()).unwrap();
+        assert!(cfg.incident_flow.escalate_to_decide);
+        assert_eq!(cfg.incident_flow.detectors_skip_fase3.len(), 3);
+        assert!(cfg
+            .incident_flow
+            .detectors_skip_fase3
+            .iter()
+            .any(|d| d == "threat_intel"));
     }
 }

--- a/crates/agent/src/dashboard/helpers.rs
+++ b/crates/agent/src/dashboard/helpers.rs
@@ -659,6 +659,53 @@ mod tests {
         assert_eq!(determine_outcome_for_ips(&decisions, &ips, true), "active");
     }
 
+    // Spec 028-c: aggregating across multiple IPs, escalated wins over
+    // monitoring/honeypot/dismissed as long as no blocked IP is present.
+    #[test]
+    fn test_determine_outcome_for_ips_escalated_wins_over_monitoring() {
+        let escalated = DecisionEntry {
+            ts: chrono::Utc::now(),
+            incident_id: "x".into(),
+            host: "h".into(),
+            ai_provider: "observation-verify".into(),
+            action_type: "escalate".into(),
+            target_ip: Some("1.2.3.4".into()),
+            target_user: None,
+            skill_id: None,
+            confidence: 0.8,
+            auto_executed: true,
+            dry_run: false,
+            reason: "r".into(),
+            estimated_threat: "medium".into(),
+            execution_result: "pending-fase4".into(),
+            prev_hash: None,
+        };
+        let monitor = DecisionEntry {
+            ts: chrono::Utc::now(),
+            incident_id: "y".into(),
+            host: "h".into(),
+            ai_provider: "mock".into(),
+            action_type: "monitor".into(),
+            target_ip: Some("5.6.7.8".into()),
+            target_user: None,
+            skill_id: None,
+            confidence: 0.7,
+            auto_executed: true,
+            dry_run: false,
+            reason: "r".into(),
+            estimated_threat: "low".into(),
+            execution_result: "ok".into(),
+            prev_hash: None,
+        };
+        let mut ips = BTreeSet::new();
+        ips.insert("1.2.3.4".into());
+        ips.insert("5.6.7.8".into());
+        assert_eq!(
+            determine_outcome_for_ips(&[escalated, monitor], &ips, true),
+            "escalated"
+        );
+    }
+
     #[test]
     fn test_format_duration_scale() {
         assert_eq!(format_duration(0), "0s");

--- a/crates/agent/src/dashboard/helpers.rs
+++ b/crates/agent/src/dashboard/helpers.rs
@@ -146,6 +146,7 @@ pub(super) fn determine_outcome_for_ips(
     ips: &BTreeSet<String>,
     has_incident: bool,
 ) -> String {
+    let mut has_escalated = false;
     let mut has_monitoring = false;
     let mut has_honeypot = false;
     let mut has_dismissed = false;
@@ -154,6 +155,7 @@ pub(super) fn determine_outcome_for_ips(
     for ip in ips {
         match determine_outcome(decisions, ip, has_incident).as_str() {
             "blocked" => return "blocked".to_string(),
+            "escalated" => has_escalated = true,
             "honeypot" => has_honeypot = true,
             "monitoring" => has_monitoring = true,
             "dismissed" => has_dismissed = true,
@@ -162,6 +164,12 @@ pub(super) fn determine_outcome_for_ips(
         }
     }
 
+    // Spec 028-c: escalated wins over monitoring/honeypot/dismissed when
+    // aggregating across multiple IPs because escalate-without-resolution is
+    // the strongest "still needs action" signal short of a permanent block.
+    if has_escalated {
+        return "escalated".to_string();
+    }
     if has_honeypot {
         return "honeypot".to_string();
     }
@@ -182,6 +190,15 @@ pub(super) fn determine_outcome_for_ips(
 
 /// Determine the outcome for an IP given the full decisions list and whether
 /// it has at least one incident.
+///
+/// Precedence: blocked (permanent) > escalated (needs attention) > monitoring >
+/// honeypot > dismissed > active > unknown.
+///
+/// Spec 028-c added `escalated`: IPs whose most impactful decision is an
+/// "escalate" label (written by observation-verify when the Fase 3 scorer
+/// returns VerificationResult::Escalate) surface as their own outcome rather
+/// than sitting under `active`, so the dashboard can route them to the "needs
+/// attention" bucket.
 pub(super) fn determine_outcome(
     decisions: &[DecisionEntry],
     ip: &str,
@@ -199,6 +216,14 @@ pub(super) fn determine_outcome(
             && (d.execution_result.contains("ok") || d.execution_result.starts_with("Blocked"))
         {
             return "blocked".to_string();
+        }
+    }
+    // Spec 028-c: escalate wins over monitor/honeypot/dismiss because an
+    // escalated incident without a resolving decision is explicitly the
+    // "needs your attention" state. Only a real block (above) supersedes.
+    for d in &ip_decisions {
+        if d.action_type == "escalate" {
+            return "escalated".to_string();
         }
     }
     for d in &ip_decisions {

--- a/crates/agent/src/dashboard/mod.rs
+++ b/crates/agent/src/dashboard/mod.rs
@@ -1464,6 +1464,76 @@ mod tests {
         assert_eq!(determine_outcome(&[], "1.2.3.4", false), "unknown");
     }
 
+    // Spec 028-c: escalate decisions route the IP to the "escalated" outcome,
+    // which status_determination maps to "needs_attention" on the dashboard.
+    #[test]
+    fn outcome_escalated_surfaces_needs_attention() {
+        let escalated = DecisionEntry {
+            ts: Utc::now(),
+            incident_id: "x".to_string(),
+            host: "h".to_string(),
+            ai_provider: "observation-verify".to_string(),
+            action_type: "escalate".to_string(),
+            target_ip: Some("1.2.3.4".to_string()),
+            target_user: None,
+            skill_id: None,
+            confidence: 0.8,
+            auto_executed: true,
+            dry_run: false,
+            reason: "obs-verify score 55/100".to_string(),
+            estimated_threat: "medium".to_string(),
+            execution_result: "pending-fase4".to_string(),
+            prev_hash: None,
+        };
+        assert_eq!(
+            determine_outcome(&[escalated], "1.2.3.4", true),
+            "escalated"
+        );
+    }
+
+    // Spec 028-c: a later block_ip supersedes an earlier escalate.
+    #[test]
+    fn outcome_block_wins_over_escalate() {
+        let escalated = DecisionEntry {
+            ts: Utc::now(),
+            incident_id: "x".to_string(),
+            host: "h".to_string(),
+            ai_provider: "observation-verify".to_string(),
+            action_type: "escalate".to_string(),
+            target_ip: Some("1.2.3.4".to_string()),
+            target_user: None,
+            skill_id: None,
+            confidence: 0.8,
+            auto_executed: true,
+            dry_run: false,
+            reason: "obs-verify".to_string(),
+            estimated_threat: "medium".to_string(),
+            execution_result: "pending-fase4".to_string(),
+            prev_hash: None,
+        };
+        let block = DecisionEntry {
+            ts: Utc::now(),
+            incident_id: "x".to_string(),
+            host: "h".to_string(),
+            ai_provider: "mock".to_string(),
+            action_type: "block_ip".to_string(),
+            target_ip: Some("1.2.3.4".to_string()),
+            target_user: None,
+            skill_id: None,
+            confidence: 0.95,
+            auto_executed: true,
+            dry_run: false,
+            reason: "r".to_string(),
+            estimated_threat: "high".to_string(),
+            execution_result: "ok".to_string(),
+            prev_hash: None,
+        };
+        assert_eq!(
+            determine_outcome(&[escalated, block], "1.2.3.4", true),
+            "blocked"
+        );
+    }
+
     // ── D3 tests ────────────────────────────────────────────────────────
 
     #[test]

--- a/crates/agent/src/dashboard/types.rs
+++ b/crates/agent/src/dashboard/types.rs
@@ -497,7 +497,10 @@ pub(crate) fn status_determination(outcome: &str) -> &'static str {
         "blocked" | "killed" => "contained",
         "monitoring" | "monitored" => "observing",
         "honeypot" | "diverted" => "contained",
-        "active" | "open" => "needs_attention",
+        // Spec 028-c: "escalated" routes to the "needs your attention" bucket
+        // explicitly so operators can see obs-verify escalates that have no
+        // resolving decision yet.
+        "escalated" | "active" | "open" => "needs_attention",
         "dismissed" | "ignored" => "observing",
         _ => "needs_attention",
     }
@@ -548,6 +551,10 @@ mod tests {
         assert_eq!(status_determination("monitoring"), "observing");
         assert_eq!(status_determination("dismissed"), "observing");
         assert_eq!(status_determination("active"), "needs_attention");
+        // Spec 028-c: escalated items need operator attention, same bucket
+        // as active/open.
+        assert_eq!(status_determination("escalated"), "needs_attention");
+        assert_eq!(status_determination("ESCALATED"), "needs_attention");
         assert_eq!(status_determination("unknown"), "needs_attention");
     }
 

--- a/crates/agent/src/narrative_observation_verify.rs
+++ b/crates/agent/src/narrative_observation_verify.rs
@@ -65,7 +65,7 @@ pub(crate) fn verify_observing_incidents(
     );
 
     // Collect undecided incident data from the graph (read lock)
-    let undecided: Vec<(String, String, String, serde_json::Value)> = {
+    let undecided: Vec<(String, String, String, serde_json::Value, Option<String>)> = {
         let graph = state.knowledge_graph.read().unwrap();
         collect_undecided_incidents(&graph)
     };
@@ -78,7 +78,7 @@ pub(crate) fn verify_observing_incidents(
     let mut escalated = 0u32;
     let mut ambiguous_items = Vec::new();
 
-    for (incident_id, detector, title, evidence) in undecided {
+    for (incident_id, detector, title, evidence, primary_ip) in undecided {
         let (result, breakdown) = observation_verify::behaviour_score(
             &evidence,
             operator_active,
@@ -108,16 +108,65 @@ pub(crate) fn verify_observing_incidents(
                 );
             }
             VerificationResult::Escalate { score, reason } => {
-                let mut graph = state.knowledge_graph.write().unwrap();
-                graph.ingest_decision(
-                    &incident_id,
-                    "escalate",
-                    None,
-                    0.8,
-                    &format!("obs-verify score {score}/100: {reason}"),
-                    true,
-                    chrono::Utc::now(),
-                );
+                // Spec 028-c: also record the escalate decision in the decisions
+                // JSONL via state.decision_writer so dashboard bucketing (which
+                // reads decisions, not the graph) can classify the IP as "needs
+                // attention" instead of leaving it in "observing".
+                //
+                // The graph write and the JSONL write are kept separate scopes
+                // so the graph write lock is released before we grab the
+                // decision_writer (separate fields, but easier reasoning).
+                {
+                    let mut graph = state.knowledge_graph.write().unwrap();
+                    graph.ingest_decision(
+                        &incident_id,
+                        "escalate",
+                        primary_ip.as_deref(),
+                        0.8,
+                        &format!("obs-verify score {score}/100: {reason}"),
+                        true,
+                        chrono::Utc::now(),
+                    );
+                }
+                if let Some(writer) = state.decision_writer.as_mut() {
+                    let entry = crate::decisions::DecisionEntry {
+                        ts: chrono::Utc::now(),
+                        incident_id: incident_id.clone(),
+                        host: String::new(),
+                        ai_provider: "observation-verify".to_string(),
+                        action_type: "escalate".to_string(),
+                        target_ip: primary_ip.clone(),
+                        target_user: None,
+                        skill_id: None,
+                        confidence: 0.8,
+                        auto_executed: true,
+                        dry_run: false,
+                        reason: format!("obs-verify score {score}/100: {reason}"),
+                        estimated_threat: "medium".to_string(),
+                        execution_result: "pending-fase4".to_string(),
+                        prev_hash: None,
+                    };
+                    if let Err(e) = writer.write(&entry) {
+                        // Don't propagate; the graph already has the decision.
+                        tracing::warn!(
+                            incident_id = %incident_id,
+                            error = %e,
+                            "observation-verify: failed to write escalate decision to JSONL"
+                        );
+                    }
+                }
+                // Spec 028-b stub: the flag is read here so operators can
+                // already toggle it in agent.toml, but the actual forwarding
+                // into Fase 4 is a follow-up PR. Once the provider + skill
+                // executor are threaded through this function (async
+                // conversion required), replace this log with the real call.
+                if cfg.incident_flow.escalate_to_decide {
+                    tracing::info!(
+                        incident_id = %incident_id,
+                        target_ip = ?primary_ip,
+                        "observation-verify: spec 028-b flag on - decide() call pending (follow-up PR threading)"
+                    );
+                }
                 escalated += 1;
                 debug!(
                     incident_id,
@@ -152,9 +201,14 @@ pub(crate) fn verify_observing_incidents(
 }
 
 /// Collect undecided incident data from the knowledge graph.
+///
+/// The last tuple element is the primary IP entity connected to the incident,
+/// if any. Spec 028-c uses this so the escalate decision written below can
+/// link back to a target IP and the dashboard can bucket the IP as "needs
+/// attention" instead of "observing".
 fn collect_undecided_incidents(
     graph: &KnowledgeGraph,
-) -> Vec<(String, String, String, serde_json::Value)> {
+) -> Vec<(String, String, String, serde_json::Value, Option<String>)> {
     graph
         .nodes_of_type(NodeType::Incident)
         .iter()
@@ -181,13 +235,20 @@ fn collect_undecided_incidents(
                     "summary": summary,
                 });
 
-                // Enrich evidence from connected graph nodes
+                // Enrich evidence from connected graph nodes.
+                // Track the first IP entity we see as the primary attacker IP.
+                let mut primary_ip: Option<String> = None;
                 for edge in graph.edges_slice() {
                     if edge.from != id && edge.to != id {
                         continue;
                     }
                     let other_id = if edge.from == id { edge.to } else { edge.from };
                     if let Some(node) = graph.get_node(other_id) {
+                        if primary_ip.is_none() {
+                            if let Node::Ip { addr, .. } = node {
+                                primary_ip = Some(addr.clone());
+                            }
+                        }
                         enrich_evidence_from_node(&mut evidence, node, graph);
                     }
                 }
@@ -197,6 +258,7 @@ fn collect_undecided_incidents(
                     detector.clone(),
                     title.clone(),
                     evidence,
+                    primary_ip,
                 ))
             } else {
                 None

--- a/crates/agent/src/narrative_observation_verify.rs
+++ b/crates/agent/src/narrative_observation_verify.rs
@@ -129,44 +129,24 @@ pub(crate) fn verify_observing_incidents(
                     );
                 }
                 if let Some(writer) = state.decision_writer.as_mut() {
-                    let entry = crate::decisions::DecisionEntry {
-                        ts: chrono::Utc::now(),
-                        incident_id: incident_id.clone(),
-                        host: String::new(),
-                        ai_provider: "observation-verify".to_string(),
-                        action_type: "escalate".to_string(),
-                        target_ip: primary_ip.clone(),
-                        target_user: None,
-                        skill_id: None,
-                        confidence: 0.8,
-                        auto_executed: true,
-                        dry_run: false,
-                        reason: format!("obs-verify score {score}/100: {reason}"),
-                        estimated_threat: "medium".to_string(),
-                        execution_result: "pending-fase4".to_string(),
-                        prev_hash: None,
-                    };
-                    if let Err(e) = writer.write(&entry) {
-                        // Don't propagate; the graph already has the decision.
-                        tracing::warn!(
-                            incident_id = %incident_id,
-                            error = %e,
-                            "observation-verify: failed to write escalate decision to JSONL"
-                        );
-                    }
+                    write_escalate_decision(
+                        writer,
+                        &incident_id,
+                        primary_ip.as_deref(),
+                        score,
+                        &reason,
+                    );
                 }
                 // Spec 028-b stub: the flag is read here so operators can
                 // already toggle it in agent.toml, but the actual forwarding
                 // into Fase 4 is a follow-up PR. Once the provider + skill
                 // executor are threaded through this function (async
                 // conversion required), replace this log with the real call.
-                if cfg.incident_flow.escalate_to_decide {
-                    tracing::info!(
-                        incident_id = %incident_id,
-                        target_ip = ?primary_ip,
-                        "observation-verify: spec 028-b flag on - decide() call pending (follow-up PR threading)"
-                    );
-                }
+                log_escalate_to_decide_intent(
+                    cfg.incident_flow.escalate_to_decide,
+                    &incident_id,
+                    primary_ip.as_deref(),
+                );
                 escalated += 1;
                 debug!(
                     incident_id,
@@ -320,6 +300,66 @@ fn find_process_comm_by_pid(graph: &KnowledgeGraph, pid: u32) -> Option<String> 
         }
     }
     None
+}
+
+/// Write an escalate decision to the decisions JSONL (spec 028-c).
+///
+/// Extracted so the Escalate match arm stays short and so the JSONL-write
+/// path can be unit tested without spinning up a full AgentState. Failures
+/// are logged at warn! level but never propagated; the knowledge graph
+/// already carries the decision, so a JSONL write failure is a visibility
+/// regression, not a correctness one.
+fn write_escalate_decision(
+    writer: &mut crate::decisions::DecisionWriter,
+    incident_id: &str,
+    primary_ip: Option<&str>,
+    score: u8,
+    reason: &str,
+) {
+    let entry = crate::decisions::DecisionEntry {
+        ts: chrono::Utc::now(),
+        incident_id: incident_id.to_string(),
+        host: String::new(),
+        ai_provider: "observation-verify".to_string(),
+        action_type: "escalate".to_string(),
+        target_ip: primary_ip.map(|s| s.to_string()),
+        target_user: None,
+        skill_id: None,
+        confidence: 0.8,
+        auto_executed: true,
+        dry_run: false,
+        reason: format!("obs-verify score {score}/100: {reason}"),
+        estimated_threat: "medium".to_string(),
+        execution_result: "pending-fase4".to_string(),
+        prev_hash: None,
+    };
+    if let Err(e) = writer.write(&entry) {
+        tracing::warn!(
+            incident_id = %incident_id,
+            error = %e,
+            "observation-verify: failed to write escalate decision to JSONL"
+        );
+    }
+}
+
+/// Log intent when the 028-b feature flag is on (spec 028-b stub).
+///
+/// Extracted from the Escalate match arm both for readability and so the
+/// flag-read branch is trivially exercisable by a unit test. The flag
+/// default is false, so in production this is a no-op until an operator
+/// explicitly flips it in agent.toml.
+fn log_escalate_to_decide_intent(
+    escalate_to_decide: bool,
+    incident_id: &str,
+    primary_ip: Option<&str>,
+) {
+    if escalate_to_decide {
+        tracing::info!(
+            incident_id = %incident_id,
+            target_ip = ?primary_ip,
+            "observation-verify: spec 028-b flag on - decide() call pending (follow-up PR threading)"
+        );
+    }
 }
 
 /// AI batch verification for ambiguous items (spec 021 Phase C).
@@ -517,6 +557,88 @@ mod tests {
         let graph = KnowledgeGraph::new();
         let result = collect_undecided_incidents(&graph);
         assert!(result.is_empty());
+    }
+
+    // Spec 028-c: write_escalate_decision must land a line in the decisions
+    // JSONL shaped so the dashboard's determine_outcome can bucket the IP
+    // into "escalated" → "needs_attention".
+    #[test]
+    fn write_escalate_decision_emits_jsonl_line() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut writer = crate::decisions::DecisionWriter::new(tmp.path()).unwrap();
+
+        write_escalate_decision(
+            &mut writer,
+            "test-incident-1",
+            Some("203.0.113.42"),
+            55,
+            "masscan fingerprint",
+        );
+        drop(writer); // flush buffer
+
+        let today = chrono::Local::now()
+            .date_naive()
+            .format("%Y-%m-%d")
+            .to_string();
+        let mut found = false;
+        for entry in std::fs::read_dir(tmp.path()).unwrap() {
+            let path = entry.unwrap().path();
+            if path
+                .file_name()
+                .and_then(|n| n.to_str())
+                .is_some_and(|n| n.contains(&today))
+            {
+                let content = std::fs::read_to_string(&path).unwrap();
+                assert!(content.contains("\"action_type\":\"escalate\""));
+                assert!(content.contains("\"target_ip\":\"203.0.113.42\""));
+                assert!(content.contains("\"ai_provider\":\"observation-verify\""));
+                assert!(content.contains("\"execution_result\":\"pending-fase4\""));
+                assert!(content.contains("masscan fingerprint"));
+                assert!(content.contains("55/100"));
+                found = true;
+            }
+        }
+        assert!(found, "decisions JSONL file must exist for today");
+    }
+
+    // Spec 028-c: target_ip is optional (incident may lack an IP entity).
+    // The writer still produces a valid line with target_ip = null.
+    #[test]
+    fn write_escalate_decision_handles_missing_ip() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut writer = crate::decisions::DecisionWriter::new(tmp.path()).unwrap();
+
+        write_escalate_decision(&mut writer, "test-incident-2", None, 45, "no ip");
+        drop(writer);
+
+        let today = chrono::Local::now()
+            .date_naive()
+            .format("%Y-%m-%d")
+            .to_string();
+        for entry in std::fs::read_dir(tmp.path()).unwrap() {
+            let path = entry.unwrap().path();
+            if path
+                .file_name()
+                .and_then(|n| n.to_str())
+                .is_some_and(|n| n.contains(&today))
+            {
+                let content = std::fs::read_to_string(&path).unwrap();
+                assert!(content.contains("\"target_ip\":null"));
+                return;
+            }
+        }
+        panic!("decisions JSONL file must exist for today");
+    }
+
+    // Spec 028-b stub: the intent-log branch reads the flag without side
+    // effects. Flag-off and flag-on are both tested here for coverage; the
+    // real assertion is that the helper does not panic and compiles in both
+    // shapes.
+    #[test]
+    fn log_escalate_to_decide_intent_is_side_effect_free() {
+        log_escalate_to_decide_intent(false, "id-off", None);
+        log_escalate_to_decide_intent(true, "id-on", Some("198.51.100.1"));
+        log_escalate_to_decide_intent(true, "id-on-no-ip", None);
     }
 
     #[test]

--- a/crates/agent/src/narrative_observation_verify.rs
+++ b/crates/agent/src/narrative_observation_verify.rs
@@ -108,44 +108,14 @@ pub(crate) fn verify_observing_incidents(
                 );
             }
             VerificationResult::Escalate { score, reason } => {
-                // Spec 028-c: also record the escalate decision in the decisions
-                // JSONL via state.decision_writer so dashboard bucketing (which
-                // reads decisions, not the graph) can classify the IP as "needs
-                // attention" instead of leaving it in "observing".
-                //
-                // The graph write and the JSONL write are kept separate scopes
-                // so the graph write lock is released before we grab the
-                // decision_writer (separate fields, but easier reasoning).
-                {
-                    let mut graph = state.knowledge_graph.write().unwrap();
-                    graph.ingest_decision(
-                        &incident_id,
-                        "escalate",
-                        primary_ip.as_deref(),
-                        0.8,
-                        &format!("obs-verify score {score}/100: {reason}"),
-                        true,
-                        chrono::Utc::now(),
-                    );
-                }
-                if let Some(writer) = state.decision_writer.as_mut() {
-                    write_escalate_decision(
-                        writer,
-                        &incident_id,
-                        primary_ip.as_deref(),
-                        score,
-                        &reason,
-                    );
-                }
-                // Spec 028-b stub: the flag is read here so operators can
-                // already toggle it in agent.toml, but the actual forwarding
-                // into Fase 4 is a follow-up PR. Once the provider + skill
-                // executor are threaded through this function (async
-                // conversion required), replace this log with the real call.
-                log_escalate_to_decide_intent(
+                apply_escalate(
+                    &state.knowledge_graph,
+                    state.decision_writer.as_mut(),
                     cfg.incident_flow.escalate_to_decide,
                     &incident_id,
                     primary_ip.as_deref(),
+                    score,
+                    &reason,
                 );
                 escalated += 1;
                 debug!(
@@ -300,6 +270,45 @@ fn find_process_comm_by_pid(graph: &KnowledgeGraph, pid: u32) -> Option<String> 
         }
     }
     None
+}
+
+/// Apply the Escalate branch of observation-verify (spec 028-b/c).
+///
+/// Writes the escalate label to the knowledge graph, writes the escalate
+/// decision to the decisions JSONL (if a writer is configured), and reads
+/// the 028-b feature flag to log intent for the future decide() call. The
+/// extraction keeps the verify_observing_incidents match arm short and
+/// makes the whole Escalate side effect unit-testable without constructing
+/// a full AgentState.
+fn apply_escalate(
+    graph: &std::sync::Arc<std::sync::RwLock<KnowledgeGraph>>,
+    decision_writer: Option<&mut crate::decisions::DecisionWriter>,
+    escalate_to_decide: bool,
+    incident_id: &str,
+    primary_ip: Option<&str>,
+    score: u8,
+    reason: &str,
+) {
+    {
+        let mut g = graph.write().unwrap();
+        g.ingest_decision(
+            incident_id,
+            "escalate",
+            primary_ip,
+            0.8,
+            &format!("obs-verify score {score}/100: {reason}"),
+            true,
+            chrono::Utc::now(),
+        );
+    }
+    if let Some(writer) = decision_writer {
+        write_escalate_decision(writer, incident_id, primary_ip, score, reason);
+    }
+    // Spec 028-b stub: the flag is read here so operators can already
+    // toggle it in agent.toml, but the actual forwarding into Fase 4 is a
+    // follow-up PR (needs provider + skill_executor threading + async
+    // conversion).
+    log_escalate_to_decide_intent(escalate_to_decide, incident_id, primary_ip);
 }
 
 /// Write an escalate decision to the decisions JSONL (spec 028-c).
@@ -639,6 +648,152 @@ mod tests {
         log_escalate_to_decide_intent(false, "id-off", None);
         log_escalate_to_decide_intent(true, "id-on", Some("198.51.100.1"));
         log_escalate_to_decide_intent(true, "id-on-no-ip", None);
+    }
+
+    // Spec 028-c: apply_escalate writes to graph + JSONL in one call. The
+    // graph must be seeded with the incident node first because
+    // ingest_decision silently no-ops when find_by_incident returns None.
+    // This test exercises the whole Escalate side effect directly with a
+    // seeded graph and DecisionWriter, bypassing the behaviour_score layer
+    // that is tested elsewhere.
+    #[test]
+    fn apply_escalate_writes_graph_and_jsonl() {
+        use innerwarden_core::entities::EntityRef;
+        use innerwarden_core::event::Severity;
+        use innerwarden_core::incident::Incident;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let graph = std::sync::Arc::new(std::sync::RwLock::new(KnowledgeGraph::new()));
+        let incident = Incident {
+            ts: chrono::Utc::now(),
+            host: "h".into(),
+            incident_id: "proto_anomaly:SshVersionAnomaly:198.51.100.77:apply-escalate-test".into(),
+            severity: Severity::Medium,
+            title: "t".into(),
+            summary: "s".into(),
+            evidence: serde_json::json!({}),
+            recommended_checks: vec![],
+            tags: vec![],
+            entities: vec![EntityRef::ip("198.51.100.77".to_string())],
+        };
+        {
+            let mut g = graph.write().unwrap();
+            g.ingest_incident(&incident);
+        }
+        let mut writer = crate::decisions::DecisionWriter::new(tmp.path()).unwrap();
+
+        apply_escalate(
+            &graph,
+            Some(&mut writer),
+            false,
+            &incident.incident_id,
+            Some("198.51.100.77"),
+            35,
+            "low confidence signal",
+        );
+        drop(writer);
+
+        // Graph side: the incident node now carries decision="escalate".
+        {
+            let g = graph.read().unwrap();
+            let mut saw_escalate = false;
+            for &id in &g.nodes_of_type(NodeType::Incident) {
+                if let Some(Node::Incident {
+                    decision: Some(d), ..
+                }) = g.get_node(id)
+                {
+                    if d == "escalate" {
+                        saw_escalate = true;
+                    }
+                }
+            }
+            assert!(saw_escalate, "incident node must carry decision=escalate");
+        }
+
+        // JSONL side: one line shaped like a dashboard-consumable entry.
+        let today = chrono::Local::now()
+            .date_naive()
+            .format("%Y-%m-%d")
+            .to_string();
+        let mut saw = false;
+        for entry in std::fs::read_dir(tmp.path()).unwrap() {
+            let path = entry.unwrap().path();
+            let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+            if name.contains(&today) && name.ends_with(".jsonl") {
+                let content = std::fs::read_to_string(&path).unwrap();
+                if content.contains("\"action_type\":\"escalate\"")
+                    && content.contains("\"target_ip\":\"198.51.100.77\"")
+                    && content.contains("\"ai_provider\":\"observation-verify\"")
+                    && content.contains("low confidence signal")
+                {
+                    saw = true;
+                    break;
+                }
+            }
+        }
+        assert!(saw, "apply_escalate must write the escalate line to JSONL");
+    }
+
+    // Spec 028-c: apply_escalate tolerates a missing writer and a missing
+    // incident in the graph (ingest_decision no-ops). Assertion: no panic.
+    #[test]
+    fn apply_escalate_tolerates_missing_writer_and_node() {
+        let graph = std::sync::Arc::new(std::sync::RwLock::new(KnowledgeGraph::new()));
+        apply_escalate(&graph, None, false, "id-no-writer", None, 20, "r");
+    }
+
+    // Spec 028-b stub: flag on/off must produce the same persistent side
+    // effects. Running apply_escalate twice with identical inputs apart
+    // from the flag must yield identical JSONL output and graph state.
+    #[test]
+    fn apply_escalate_flag_toggle_is_observational() {
+        let tmp = tempfile::tempdir().unwrap();
+        let graph = std::sync::Arc::new(std::sync::RwLock::new(KnowledgeGraph::new()));
+        let mut writer = crate::decisions::DecisionWriter::new(tmp.path()).unwrap();
+
+        apply_escalate(
+            &graph,
+            Some(&mut writer),
+            false,
+            "flag-test-off",
+            Some("198.51.100.88"),
+            30,
+            "reason",
+        );
+        apply_escalate(
+            &graph,
+            Some(&mut writer),
+            true,
+            "flag-test-on",
+            Some("198.51.100.88"),
+            30,
+            "reason",
+        );
+        drop(writer);
+
+        let today = chrono::Local::now()
+            .date_naive()
+            .format("%Y-%m-%d")
+            .to_string();
+        let mut lines_off = 0;
+        let mut lines_on = 0;
+        for entry in std::fs::read_dir(tmp.path()).unwrap() {
+            let path = entry.unwrap().path();
+            let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+            if name.contains(&today) && name.ends_with(".jsonl") {
+                let content = std::fs::read_to_string(&path).unwrap();
+                for line in content.lines() {
+                    if line.contains("flag-test-off") {
+                        lines_off += 1;
+                    }
+                    if line.contains("flag-test-on") {
+                        lines_on += 1;
+                    }
+                }
+            }
+        }
+        assert_eq!(lines_off, 1, "flag=false path must emit exactly one line");
+        assert_eq!(lines_on, 1, "flag=true path must emit exactly one line");
     }
 
     #[test]

--- a/crates/sensor/src/detectors/proto_anomaly.rs
+++ b/crates/sensor/src/detectors/proto_anomaly.rs
@@ -295,7 +295,21 @@ impl ProtoAnomalyDetector {
         now: DateTime<Utc>,
         severity: Severity,
     ) -> Option<Incident> {
-        let key = format!("{:?}:{}:{}", anomaly_type, src_ip, dst_port);
+        // Spec 028-a: reject loopback + RFC1918 as source. Internal addresses
+        // cannot be remote attackers; firing on them produces noise. The helper
+        // covers 127/8, 10/8, 172.16/12, 192.168/16, link-local, and broadcast.
+        if super::is_internal_ip(src_ip) {
+            return None;
+        }
+
+        // Spec 028-a: throttle per (source_ip, detector_kind) with the
+        // configured cooldown (default 600s). Previously the key also included
+        // dst_port, which defeats the throttle whenever attackers scan a range
+        // of ports — each port gets its own fire. SshVersionAnomaly and the
+        // other SSH-bound anomalies all target dst_port 22, so dropping the
+        // port from the key is safe for those and correct for the port-scan
+        // cases too.
+        let key = format!("{:?}:{}", anomaly_type, src_ip);
 
         if let Some(&last) = self.alerted.get(&key) {
             if now - last < self.cooldown {
@@ -426,6 +440,11 @@ mod tests {
             .any(|i| i.title.contains("double encoding")));
     }
 
+    // Spec 028-a enforces public-source filtering, so this test uses a public
+    // src_ip. 8.8.8.8 is chosen because it falls outside every std::Ipv4Addr
+    // predicate (not loopback, private, link-local, broadcast, documentation,
+    // or unspecified). Note: 203.0.113.0/24 IS documentation range and would
+    // be filtered out.
     #[test]
     fn test_smb_non_standard_port() {
         let mut det = ProtoAnomalyDetector::new("host1", 300);
@@ -433,7 +452,7 @@ mod tests {
             "tcp_stream.smb",
             serde_json::json!({
                 "app_proto": "smb",
-                "src_ip": "10.0.0.5",
+                "src_ip": "8.8.8.8",
                 "dst_ip": "10.0.0.10",
                 "dst_port": 8445,
                 "signals": [],
@@ -493,5 +512,79 @@ mod tests {
             entities: Vec::new(),
         };
         assert!(det.process(&ev).is_empty());
+    }
+
+    // Spec 028-a: rejects loopback as source (cannot be a remote attacker).
+    #[test]
+    fn test_rejects_loopback_source() {
+        let mut det = ProtoAnomalyDetector::new("host1", 300);
+        let ev = make_stream_event(
+            "tcp_stream.ssh",
+            serde_json::json!({
+                "app_proto": "ssh",
+                "src_ip": "127.0.0.1",
+                "dst_ip": "10.0.0.1",
+                "dst_port": 22,
+                "client_version": "EXPLOIT-TOOL-v1",
+                "signals": [],
+            }),
+        );
+        assert!(
+            det.process(&ev).is_empty(),
+            "loopback source must not produce an incident"
+        );
+    }
+
+    // Spec 028-a: rejects RFC1918 as source.
+    #[test]
+    fn test_rejects_rfc1918_source() {
+        let mut det = ProtoAnomalyDetector::new("host1", 300);
+        for src in ["10.0.0.5", "172.16.1.2", "192.168.1.50"] {
+            let ev = make_stream_event(
+                "tcp_stream.ssh",
+                serde_json::json!({
+                    "app_proto": "ssh",
+                    "src_ip": src,
+                    "dst_ip": "8.8.8.8",
+                    "dst_port": 22,
+                    "client_version": "EXPLOIT-TOOL-v1",
+                    "signals": [],
+                }),
+            );
+            assert!(
+                det.process(&ev).is_empty(),
+                "RFC1918 src {src} must not produce an incident"
+            );
+        }
+    }
+
+    // Spec 028-a: single IP hitting multiple dst_ports in the cooldown window
+    // produces one incident, not one per port. Previously the key included
+    // dst_port, so a scanner probing ports 22,2222,22022 emitted three times
+    // even for the same SshNonStandardPort anomaly.
+    #[test]
+    fn test_cooldown_across_ports_from_same_source() {
+        let mut det = ProtoAnomalyDetector::new("host1", 300);
+        let mk = |port: u16| {
+            make_stream_event(
+                "tcp_stream.ssh",
+                serde_json::json!({
+                    "app_proto": "ssh",
+                    "src_ip": "1.2.3.4",
+                    "dst_ip": "8.8.8.8",
+                    "dst_port": port,
+                    "client_version": "SSH-2.0-Foo",
+                    "signals": [],
+                }),
+            )
+        };
+        let first = det.process(&mk(2222));
+        let second = det.process(&mk(22022));
+        let third = det.process(&mk(42424));
+        let total = first.len() + second.len() + third.len();
+        assert_eq!(
+            total, 1,
+            "same src across different dst_ports should be throttled"
+        );
     }
 }

--- a/crates/sensor/src/main.rs
+++ b/crates/sensor/src/main.rs
@@ -688,7 +688,10 @@ async fn main() -> Result<()> {
         }),
         proto_anomaly: Some({
             info!("proto_anomaly detector enabled (protocol violation detection)");
-            detectors::proto_anomaly::ProtoAnomalyDetector::new(&cfg.agent.host_id, 300)
+            // Spec 028-a: bumped 300 → 600 so the per-(src_ip, anomaly_type)
+            // throttle covers the 10-minute window the spec targets (cuts
+            // SshVersionAnomaly volume).
+            detectors::proto_anomaly::ProtoAnomalyDetector::new(&cfg.agent.host_id, 600)
         }),
     };
 


### PR DESCRIPTION
## Summary

Spec 028 documents 10 production bugs grouped as the "autonomy gap 2.0". This PR ships the spec doc alongside a bundled minimal implementation so tomorrow's deploy can start reducing noise and exposing escalated items immediately, while leaving the biggest fix (full escalate → decide wiring) for a conservative follow-up.

## What ships

- **Spec doc** (`.specify/features/028-incident-lifecycle-bugs/spec.md`) - 181 lines catalogued, 4 sub-PRs sequenced, addendum documenting the shadow-mode / 028-b interdependency. Em dashes swept for plain-text rendering.
- **028-a (sensor)** - proto_anomaly loopback + RFC1918 filter at the top of `emit()`, cooldown key widened from `(anomaly, src_ip, dst_port)` to `(anomaly, src_ip)` so port scanners stop bypassing the throttle, and the per-detector cooldown bumped 300s → 600s in `main.rs`. Three new tests plus one updated fixture (public src_ip required now).
- **028-c (dashboard)** - `narrative_observation_verify` now also writes the escalate decision into the decisions JSONL with the incident's primary attacker IP resolved from the graph. `determine_outcome` / `determine_outcome_for_ips` gain an `"escalated"` outcome that `status_determination` maps to the `"needs_attention"` frontend bucket. Precedence: blocked > escalated > monitoring > honeypot > dismissed > active > unknown.
- **028-b (stub)** - `IncidentFlowConfig { escalate_to_decide: bool, detectors_skip_fase3: Vec<String> }`, both conservative defaults. The flag is read in the Escalate branch and logs intent when true; the actual `decide()` call is the follow-up PR (needs provider + skill_executor threaded through + async conversion).

## Deploy / validate plan

1. Merge this PR into `development`.
2. Deploy `development` to Oracle London.
3. Observe overnight:
   - 028-a: `proto_anomaly:SshVersionAnomaly` volume should drop toward the <100/24h target.
   - 028-c: escalated incidents on the dashboard should land in the "Needs your attention" bucket instead of "Observing".
   - 028-b: flag stays off, zero behavioural change.
4. If green by tomorrow morning, tag v0.12.5 and promote to `main`.
5. Follow-up PR handles the full 028-b wiring (async threading + decide call) under the already-landed flag.

## Test plan

- [x] `cargo test --workspace` - 3899 pass, 3 ignored (pre-existing).
- [x] `cargo test -p innerwarden-sensor proto_anomaly` - 20 pass.
- [x] `cargo test -p innerwarden-agent dashboard::` - 168 pass.
- [x] `cargo test -p innerwarden-agent narrative_observation_verify::` - 20 pass.
- [x] `cargo test -p innerwarden-agent incident_flow` - 11 pass.
- [x] `make check` (clippy `-D warnings` + fmt) - clean.

## Out of scope (explicit)

- The full 028-b escalate-to-decide wiring. Config lands here; execution path is follow-up.
- 028-a incidents-table dedup (requires schema migration).
- 028-d /24 subnet correlation. Optional per spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)