### PR TITLE
chore(security): Scorecard quick wins bundle (Docker pins, SLSA provenance, rand 0.8.6)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,9 @@ jobs:
     runs-on: ubuntu-latest
 
     permissions:
-      contents: write   # needed to create the GitHub Release
+      contents: write         # needed to create the GitHub Release
+      id-token: write         # SLSA provenance: sign the attestation
+      attestations: write     # SLSA provenance: publish the attestation
 
     steps:
       # ── Source ────────────────────────────────────────────────────────────
@@ -202,6 +204,23 @@ jobs:
           fi
           echo "All 13 assets present (6 binaries + 6 SHA-256 sidecars + install.sh)."
 
+      # ── SLSA v1 build provenance attestation ──────────────────────────────
+      # Publishes a cryptographic attestation tying each Linux binary back to
+      # the exact workflow run and commit that produced it. Scorecard's
+      # Signed-Releases check (OpenSSF) reads these attestations via the
+      # GitHub API; without them the check stays partial ("signed but no
+      # provenance"). See https://slsa.dev for the spec.
+      - name: Attest build provenance for Linux binaries
+        uses: actions/attest-build-provenance@96b4a1ef7235a096b17240c259729fdd70c83d45 # v2
+        with:
+          subject-path: |
+            dist/innerwarden-sensor-linux-x86_64
+            dist/innerwarden-agent-linux-x86_64
+            dist/innerwarden-ctl-linux-x86_64
+            dist/innerwarden-sensor-linux-aarch64
+            dist/innerwarden-agent-linux-aarch64
+            dist/innerwarden-ctl-linux-aarch64
+
       # ── Create GitHub Release ─────────────────────────────────────────────
       - name: Create GitHub Release
         uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
@@ -262,7 +281,9 @@ jobs:
     needs: build-release
 
     permissions:
-      contents: write   # needed to upload assets to existing release
+      contents: write         # needed to upload assets to existing release
+      id-token: write         # SLSA provenance: sign the attestation
+      attestations: write     # SLSA provenance: publish the attestation
 
     steps:
       # ── Source ────────────────────────────────────────────────────────────
@@ -347,6 +368,18 @@ jobs:
           " "$binary" > "${binary}.sig"
           done
           rm -f /tmp/sign-key.pem
+
+      # ── SLSA v1 build provenance attestation (macOS) ──────────────────────
+      - name: Attest build provenance for macOS binaries
+        uses: actions/attest-build-provenance@96b4a1ef7235a096b17240c259729fdd70c83d45 # v2
+        with:
+          subject-path: |
+            dist/innerwarden-sensor-macos-x86_64
+            dist/innerwarden-agent-macos-x86_64
+            dist/innerwarden-ctl-macos-x86_64
+            dist/innerwarden-sensor-macos-aarch64
+            dist/innerwarden-agent-macos-aarch64
+            dist/innerwarden-ctl-macos-aarch64
 
       # ── Upload macOS assets to existing release ────────────────────────────
       - name: Upload macOS assets to GitHub Release

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2634,7 +2634,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "smallvec",
 ]
@@ -2789,7 +2789,7 @@ dependencies = [
  "delegate",
  "futures",
  "log",
- "rand 0.8.5",
+ "rand 0.8.6",
  "sha2 0.10.9",
  "thiserror 1.0.69",
  "tokio",
@@ -3204,9 +3204,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",

--- a/docker/Dockerfile.agent
+++ b/docker/Dockerfile.agent
@@ -25,7 +25,7 @@
 #     --config /etc/innerwarden/agent.toml --dashboard --dashboard-bind 0.0.0.0:8787
 
 ARG TARGETARCH
-FROM debian:bookworm-slim AS base
+FROM debian:bookworm-slim@sha256:4724b8cc51e33e398f0e2e15e18d5ec2851ff0c2280647e1310bc1642182655d AS base
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \

--- a/docker/Dockerfile.agent-openclaw
+++ b/docker/Dockerfile.agent-openclaw
@@ -22,7 +22,7 @@
 #   - TELEGRAM_BOT_TOKEN + TELEGRAM_CHAT_ID (optional, for alerts)
 
 # ── Stage 1: OpenClaw build ──────────────────────────────────────
-FROM node:24-bookworm AS openclaw-build
+FROM node:24-bookworm@sha256:33cf7f057918860b043c307751ef621d74ac96f875b79b6724dcebf2dfd0db6d AS openclaw-build
 
 RUN corepack enable
 WORKDIR /openclaw
@@ -39,7 +39,7 @@ RUN OPENCLAW_PREFER_PNPM=1 pnpm ui:build || true
 RUN CI=true pnpm prune --prod
 
 # ── Stage 2: Runtime ─────────────────────────────────────────────
-FROM node:24-bookworm-slim
+FROM node:24-bookworm-slim@sha256:879b21aec4a1ad820c27ccd565e7c7ed955f24b92e6694556154f251e4bdb240
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \


### PR DESCRIPTION
## Summary

Four orthogonal OpenSSF Scorecard improvements in one PR.

### 1. Pin Docker base images by sha256

- `docker/Dockerfile.agent`: `debian:bookworm-slim@sha256:4724b8cc...`
- `docker/Dockerfile.agent-openclaw`: `node:24-bookworm@sha256:33cf7f05...` and `node:24-bookworm-slim@sha256:879b21ae...` (the latter is the exact SHA Scorecard suggested)
- Pinned-Dependencies containerImage count goes from 0/3 to 3/3.

### 2. SLSA v1 build provenance

`actions/attest-build-provenance@v2` steps added after each platform's assets are signed and before the release is created:

- `build-release` job: 6 Linux binaries (sensor/agent/ctl × x86_64/aarch64)
- `build-release-macos` job: 6 macOS binaries (sensor/agent/ctl × x86_64/aarch64)

Both jobs get `id-token: write` and `attestations: write` permissions. Signed-Releases moves from partial (signed, no provenance) to full.

### 3. rand 0.8.5 → 0.8.6

Resolves `RUSTSEC-2026-0097` (rand unsound with a custom logger using rand::rng()). Patched on 0.8.x line at 0.8.6. The 0.9.4 and 0.10.1 copies in the lockfile are already on patched releases. One-crate update, no cascading.

```
cargo update -p rand@0.8.5 --precise 0.8.6
```

`cargo check --workspace` clean after the update.

### 4. CODEOWNERS: no change

`.github/CODEOWNERS` already exists with `@InnerWarden` as owner. Scorecard's "codeowners review required" warn is a branch-protection setting, not a file-level issue — see operator follow-up.

## Operator follow-up after merge

These are repo Settings toggles (no PR can change them). Each closes a separate Scorecard warn:

- **Require review from Code Owners** on `main` branch protection.
- **Require approval of the most recent reviewable push** (last-push-approval) on `main`.
- Keep **required approving review count** at 1. Scorecard prefers 2 but the repo is actively maintained by a single engineer with LLM-assisted review; raising it would block normal flow.

## Out of scope

- pip hash pinning on `pip install -q cryptography` in `release.yml` (lines 137, 353). Tedious per-platform hash bookkeeping; safe to defer.
- Branch-protection settings listed above (UI-only).

## Test plan

- [x] `cargo check --workspace` clean after rand upgrade
- [ ] CI validate + security workflow green on this PR
- [ ] Next release tag (v0.12.5 planned) produces attestations visible at https://github.com/InnerWarden/innerwarden/attestations
- [ ] Docker image pulls still succeed after pin (Docker will verify the digest against the tag content)

🤖 Generated with [Claude Code](https://claude.com/claude-code)