### PR TITLE
feat(agent): spec 029 PR-B - wire AiRouter into AgentState

### DIFF
--- a/crates/agent/src/ai/capability.rs
+++ b/crates/agent/src/ai/capability.rs
@@ -1,9 +1,7 @@
-// Spec 029 PR-A: this module ships the capability type infrastructure.
-// Nothing in the agent consumes it yet — PR-B wires `AiRouter` into
-// `AgentState` and PR-C migrates call sites. During PR-A, clippy
-// (run with -D warnings) flags every item as dead code; the allow
-// covers only this module so the warning stays on for anyone who
-// forgets to hook new items up when PR-B extends it.
+// Spec 029 PR-B: the types are now consumed transitively via
+// `AgentState.ai_router`, but individual `provider_for` call sites
+// do not yet reach the enum variants. PR-C migrates the ~30 call
+// sites and removes this allow.
 #![allow(dead_code)]
 
 //! AI capability types (spec 029).

--- a/crates/agent/src/ai/router.rs
+++ b/crates/agent/src/ai/router.rs
@@ -1,6 +1,9 @@
-// See the matching comment in capability.rs. Nothing in the agent
-// consumes the router yet; PR-B adds `state.ai_router` and PR-C
-// migrates the call sites off `state.ai_provider`.
+// Spec 029 PR-B: `AiRouter` is now a field on `AgentState` and
+// constructed in `loops/boot.rs`. The router itself is reachable
+// but its per-capability resolver is not called from any pre-PR-C
+// call site, so `provider_for`, `any_llm`, `describe` etc. still
+// appear unused to clippy. PR-C migrates the call sites and removes
+// this allow.
 #![allow(dead_code)]
 
 //! AI capability router (spec 029).
@@ -429,5 +432,46 @@ mod tests {
         let r = AiRouter::disabled();
         let d = r.describe();
         assert_eq!(d, "classifier=none, llm=none");
+    }
+
+    // Spec 029 PR-B back-compat guarantee: the agent's boot path
+    // populates both slots with the same provider (because pre-029
+    // config only has one `[ai]` block). The router must resolve
+    // every capability to that same provider. Breaking this would
+    // silently change production behaviour when PR-B lands.
+    #[test]
+    fn back_compat_same_provider_in_both_slots_resolves_every_capability() {
+        let single = arc("legacy-single", AiCapabilities::ALL);
+        let r = AiRouter::new(Some(Arc::clone(&single)), Some(Arc::clone(&single))).unwrap();
+        for c in Capability::all() {
+            assert_eq!(
+                r.provider_for(*c).expect("every cap resolves").name(),
+                "legacy-single",
+                "back-compat break: capability {c:?} did not resolve to the legacy provider"
+            );
+        }
+        // describe() must show the same provider name in both slots.
+        let d = r.describe();
+        assert!(d.contains("classifier=legacy-single|"));
+        assert!(d.contains("llm=legacy-single|"));
+    }
+
+    // Spec 029 PR-B: when the legacy provider declares narrow caps
+    // (LocalClassifier scenario), the router resolves only the caps
+    // the provider actually supports and returns None for the rest.
+    // This is the graceful-degradation path the agent's no-AI code
+    // already handles.
+    #[test]
+    fn back_compat_narrow_provider_returns_none_for_unsupported() {
+        let narrow = arc(
+            "classifier-only",
+            AiCapabilities::from_slice(&[Capability::Decide, Capability::Classify]),
+        );
+        let r = AiRouter::new(Some(Arc::clone(&narrow)), Some(Arc::clone(&narrow))).unwrap();
+        assert!(r.provider_for(Capability::Decide).is_some());
+        assert!(r.provider_for(Capability::Classify).is_some());
+        assert!(r.provider_for(Capability::Generate).is_none());
+        assert!(r.provider_for(Capability::Explain).is_none());
+        assert!(r.provider_for(Capability::SimulateShell).is_none());
     }
 }

--- a/crates/agent/src/loops/boot.rs
+++ b/crates/agent/src/loops/boot.rs
@@ -635,6 +635,43 @@ pub(crate) async fn run_agent(cli: crate::Cli) -> Result<()> {
         });
     }
 
+    // Build the AI provider once and populate both the legacy
+    // `ai_provider` handle and the spec 029 capability router from it.
+    // During PR-B the router is additive — both slots of the router
+    // hold the same provider so pre-029 call sites (which still use
+    // `state.ai_provider`) see identical behaviour. PR-C migrates the
+    // call sites and introduces the classifier/llm split.
+    let ai_provider: Option<Arc<dyn ai::AiProvider>> = if cfg.ai.enabled {
+        match ai::build_provider(&cfg.ai) {
+            Ok(p) => Some(Arc::from(p)),
+            Err(e) => {
+                warn!("failed to create AI provider: {e:#}");
+                None
+            }
+        }
+    } else {
+        None
+    };
+    let ai_router = match &ai_provider {
+        Some(p) => {
+            // Same provider in both slots: router resolves every
+            // capability the provider declares. General-purpose LLMs
+            // default to ALL, narrow providers (LocalClassifier) cover
+            // Decide + Classify only — the router still routes
+            // correctly because `provider_for` consults `capabilities()`.
+            let shared = Arc::clone(p);
+            match ai::AiRouter::new(Some(Arc::clone(&shared)), Some(shared)) {
+                Ok(r) => r,
+                Err(_) => {
+                    warn!("AI router refused both-none config; falling back to disabled");
+                    ai::AiRouter::disabled()
+                }
+            }
+        }
+        None => ai::AiRouter::disabled(),
+    };
+    info!(router = %ai_router.describe(), "AI router ready");
+
     let mut state = AgentState {
         skill_registry: skills::SkillRegistry::default_builtin(),
         blocklist: startup_blocklist,
@@ -654,17 +691,8 @@ pub(crate) async fn run_agent(cli: crate::Cli) -> Result<()> {
         } else {
             None
         },
-        ai_provider: if cfg.ai.enabled {
-            match ai::build_provider(&cfg.ai) {
-                Ok(p) => Some(Arc::from(p)),
-                Err(e) => {
-                    warn!("failed to create AI provider: {e:#}");
-                    None
-                }
-            }
-        } else {
-            None
-        },
+        ai_provider,
+        ai_router,
         // Decision writer is always created — Layer 1/2 decisions are written
         // even without AI. Previously gated on cfg.ai.enabled which caused
         // zero audit trail when AI was disabled or during agent restarts.

--- a/crates/agent/src/main.rs
+++ b/crates/agent/src/main.rs
@@ -377,6 +377,17 @@ struct AgentState {
     /// Wrapped in Arc so we can clone a handle for use within a loop iteration
     /// without holding a borrow of `state` across async calls that need `&mut state`.
     ai_provider: Option<Arc<dyn ai::AiProvider>>,
+    /// Spec 029 PR-B: capability router. Serves the same provider(s)
+    /// as `ai_provider` today (both populated from the same boot step)
+    /// but exposes them by role so call sites can request by
+    /// capability rather than by "the one provider". PR-C migrates
+    /// the ~30 call sites off `ai_provider` and onto this field;
+    /// during PR-B the router is additive and the legacy field stays
+    /// in place. Back-compat test in `ai::router::back_compat_tests`
+    /// guarantees that a router built from a single legacy provider
+    /// resolves every capability identically to pre-029 code.
+    #[allow(dead_code)] // consumed by call sites in PR-C (spec 029)
+    ai_router: ai::AiRouter,
     decision_writer: Option<decisions::DecisionWriter>,
     /// Tracks when the daily narrative was last written so we can enforce a
     /// minimum interval and avoid rewriting on every 30-second tick.

--- a/crates/agent/src/tests.rs
+++ b/crates/agent/src/tests.rs
@@ -181,6 +181,7 @@ pub(crate) fn triage_test_state(data_dir: &Path) -> AgentState {
         telemetry: telemetry::TelemetryState::default(),
         telemetry_writer: None,
         ai_provider: None,
+        ai_router: ai::AiRouter::disabled(),
         decision_writer: Some(decisions::DecisionWriter::new(data_dir).unwrap()),
         last_narrative_at: None,
         last_daily_summary_telegram: None,
@@ -466,7 +467,12 @@ async fn golden_path_dry_run_produces_decision_entry() {
         correlator: correlation::TemporalCorrelator::new(300, 4096),
         telemetry: telemetry::TelemetryState::default(),
         telemetry_writer: None,
-        ai_provider: Some(mock as Arc<dyn ai::AiProvider>),
+        ai_provider: Some(mock.clone() as Arc<dyn ai::AiProvider>),
+        ai_router: ai::AiRouter::new(
+            Some(mock.clone() as Arc<dyn ai::AiProvider>),
+            Some(mock.clone() as Arc<dyn ai::AiProvider>),
+        )
+        .expect("test router with mock provider"),
         decision_writer: Some(decisions::DecisionWriter::new(dir.path()).unwrap()),
         last_narrative_at: None,
         last_daily_summary_telegram: None,
@@ -650,7 +656,12 @@ async fn allowed_skills_whitelist_enforced() {
         correlator: correlation::TemporalCorrelator::new(300, 4096),
         telemetry: telemetry::TelemetryState::default(),
         telemetry_writer: None,
-        ai_provider: Some(mock as Arc<dyn ai::AiProvider>),
+        ai_provider: Some(mock.clone() as Arc<dyn ai::AiProvider>),
+        ai_router: ai::AiRouter::new(
+            Some(mock.clone() as Arc<dyn ai::AiProvider>),
+            Some(mock.clone() as Arc<dyn ai::AiProvider>),
+        )
+        .expect("test router with mock provider"),
         decision_writer: Some(decisions::DecisionWriter::new(dir.path()).unwrap()),
         last_narrative_at: None,
         last_daily_summary_telegram: None,
@@ -815,7 +826,12 @@ async fn same_ip_in_same_tick_triggers_single_ai_call() {
         correlator: correlation::TemporalCorrelator::new(300, 4096),
         telemetry: telemetry::TelemetryState::default(),
         telemetry_writer: None,
-        ai_provider: Some(mock as Arc<dyn ai::AiProvider>),
+        ai_provider: Some(mock.clone() as Arc<dyn ai::AiProvider>),
+        ai_router: ai::AiRouter::new(
+            Some(mock.clone() as Arc<dyn ai::AiProvider>),
+            Some(mock.clone() as Arc<dyn ai::AiProvider>),
+        )
+        .expect("test router with mock provider"),
         decision_writer: Some(decisions::DecisionWriter::new(dir.path()).unwrap()),
         last_narrative_at: None,
         last_daily_summary_telegram: None,
@@ -981,7 +997,12 @@ async fn temporal_correlation_context_is_passed_to_ai() {
         correlator: correlation::TemporalCorrelator::new(300, 4096),
         telemetry: telemetry::TelemetryState::default(),
         telemetry_writer: None,
-        ai_provider: Some(mock as Arc<dyn ai::AiProvider>),
+        ai_provider: Some(mock.clone() as Arc<dyn ai::AiProvider>),
+        ai_router: ai::AiRouter::new(
+            Some(mock.clone() as Arc<dyn ai::AiProvider>),
+            Some(mock.clone() as Arc<dyn ai::AiProvider>),
+        )
+        .expect("test router with mock provider"),
         decision_writer: Some(decisions::DecisionWriter::new(dir.path()).unwrap()),
         last_narrative_at: None,
         last_daily_summary_telegram: None,
@@ -1132,7 +1153,12 @@ async fn honeypot_demo_writes_synthetic_decoy_event() {
         correlator: correlation::TemporalCorrelator::new(300, 4096),
         telemetry: telemetry::TelemetryState::default(),
         telemetry_writer: None,
-        ai_provider: Some(mock as Arc<dyn ai::AiProvider>),
+        ai_provider: Some(mock.clone() as Arc<dyn ai::AiProvider>),
+        ai_router: ai::AiRouter::new(
+            Some(mock.clone() as Arc<dyn ai::AiProvider>),
+            Some(mock.clone() as Arc<dyn ai::AiProvider>),
+        )
+        .expect("test router with mock provider"),
         decision_writer: Some(decisions::DecisionWriter::new(dir.path()).unwrap()),
         last_narrative_at: None,
         last_daily_summary_telegram: None,
@@ -1293,7 +1319,12 @@ async fn decision_cooldown_suppresses_repeat() {
         correlator: correlation::TemporalCorrelator::new(300, 4096),
         telemetry: telemetry::TelemetryState::default(),
         telemetry_writer: None,
-        ai_provider: Some(mock as Arc<dyn ai::AiProvider>),
+        ai_provider: Some(mock.clone() as Arc<dyn ai::AiProvider>),
+        ai_router: ai::AiRouter::new(
+            Some(mock.clone() as Arc<dyn ai::AiProvider>),
+            Some(mock.clone() as Arc<dyn ai::AiProvider>),
+        )
+        .expect("test router with mock provider"),
         decision_writer: Some(decisions::DecisionWriter::new(dir.path()).unwrap()),
         last_narrative_at: None,
         last_daily_summary_telegram: None,


### PR DESCRIPTION
## Summary

Second of three PRs for spec 029. Adds \`ai_router: AiRouter\` to \`AgentState\` and populates it in boot + 7 test construction sites. Zero behavioural change — the router is built from the same provider that populates \`ai_provider\`, and every existing call site still reads the legacy field. PR-C migrates call sites and lands the \`[ai.classifier]\` / \`[ai.llm]\` config split.

## What changed

- \`main.rs\`: new \`ai_router: ai::AiRouter\` field on \`AgentState\`
- \`loops/boot.rs\`: let-binding refactor so provider is built once, both the legacy handle and the router construct from the same Arc
- \`tests.rs\`: all 7 AgentState construction sites populate the new field — \`triage_test_state\` uses \`AiRouter::disabled()\`, mock-injecting sites clone the mock into both router slots
- \`ai/router.rs\`: 2 new back-compat tests locking the PR-B contract

## Operator UX improvement

Boot now emits one info line describing the router at startup:

\`\`\`
AI router ready router=classifier=azure_openai|decide,classify,generate,explain,simulate_shell, llm=azure_openai|decide,classify,generate,explain,simulate_shell
\`\`\`

Grep-able from \`journalctl -u innerwarden-agent\` without opening \`agent.toml\`. Answers \"which provider is doing what?\" directly.

## Test plan

- [x] 2 new router back-compat tests (20 total, was 18)
- [x] All AgentState construction sites compile with new field
- [x] \`cargo test --workspace\`: 4171 pass, 3 ignored
- [x] \`make check\` clean

## Intentionally NOT in this PR

- Call site migration (PR-C)
- \`[ai.classifier]\` / \`[ai.llm]\` TOML split (PR-C)
- Removal of legacy \`ai_provider\` field (PR-C)

🤖 Generated with [Claude Code](https://claude.com/claude-code)