### PR TITLE
feat(agent): spec 029 PR-C.1 - per-role AI config sections

### DIFF
--- a/crates/agent/src/ai/mod.rs
+++ b/crates/agent/src/ai/mod.rs
@@ -5,7 +5,7 @@ pub mod capability;
 mod local_classifier;
 mod ollama;
 mod openai;
-mod router;
+pub mod router;
 mod shadow;
 mod stub;
 

--- a/crates/agent/src/ai/router.rs
+++ b/crates/agent/src/ai/router.rs
@@ -206,6 +206,76 @@ impl AiRouter {
     }
 }
 
+/// Spec 029 PR-C.1: build an `AiRouter` from the primary provider
+/// plus optional per-role config sections. Extracted from
+/// `loops/boot.rs` so the branch logic (per-role build failure
+/// fallback, legacy-only back-compat path, Falco-mode empty config)
+/// is unit-testable without spinning up the whole agent.
+///
+/// Contract:
+/// - If `role_cfg.enabled` is true, build a fresh provider from that
+///   config and put it in the slot. If the build fails, fall back to
+///   `primary` and call `on_slot_fallback` so the caller can log.
+/// - If `role_cfg.enabled` is false, use `primary` for the slot
+///   (back-compat with pre-029 configs).
+/// - Same logic for both classifier and llm roles.
+/// - If both resulting slots are empty, return `AiRouter::disabled()`
+///   instead of the `EmptyRouter` error so the agent can run in
+///   Falco-mode (rules-only detection, no LLM cost).
+///
+/// Side-effect callbacks keep tracing concerns in the caller; this
+/// helper stays pure enough to unit-test without mocking a logger.
+pub fn build_from_config(
+    primary: Option<Arc<dyn AiProvider>>,
+    classifier_cfg: &crate::config::RoleProviderConfig,
+    llm_cfg: &crate::config::RoleProviderConfig,
+    mut on_slot_configured: impl FnMut(&'static str, &str),
+    mut on_slot_fallback: impl FnMut(&'static str, &str, &anyhow::Error),
+) -> AiRouter {
+    let classifier_slot = resolve_slot(
+        "classifier",
+        &primary,
+        classifier_cfg,
+        &mut on_slot_configured,
+        &mut on_slot_fallback,
+    );
+    let llm_slot = resolve_slot(
+        "llm",
+        &primary,
+        llm_cfg,
+        &mut on_slot_configured,
+        &mut on_slot_fallback,
+    );
+
+    match AiRouter::new(classifier_slot, llm_slot) {
+        Ok(r) => r,
+        Err(_) => AiRouter::disabled(),
+    }
+}
+
+fn resolve_slot(
+    slot_name: &'static str,
+    primary: &Option<Arc<dyn AiProvider>>,
+    role_cfg: &crate::config::RoleProviderConfig,
+    on_configured: &mut impl FnMut(&'static str, &str),
+    on_fallback: &mut impl FnMut(&'static str, &str, &anyhow::Error),
+) -> Option<Arc<dyn AiProvider>> {
+    if !role_cfg.enabled {
+        return primary.as_ref().map(Arc::clone);
+    }
+    let ai_cfg = role_cfg.to_ai_config();
+    match crate::ai::build_provider(&ai_cfg) {
+        Ok(p) => {
+            on_configured(slot_name, &ai_cfg.provider);
+            Some(Arc::from(p))
+        }
+        Err(e) => {
+            on_fallback(slot_name, &ai_cfg.provider, &e);
+            primary.as_ref().map(Arc::clone)
+        }
+    }
+}
+
 /// Merge two capability sets. Small helper kept module-local because
 /// it is only used by the router; `AiCapabilities` itself does not
 /// need a public `|` impl yet.
@@ -473,5 +543,310 @@ mod tests {
         assert!(r.provider_for(Capability::Generate).is_none());
         assert!(r.provider_for(Capability::Explain).is_none());
         assert!(r.provider_for(Capability::SimulateShell).is_none());
+    }
+
+    // ── build_from_config ───────────────────────────────────────────
+
+    use crate::config::RoleProviderConfig;
+
+    fn record_callbacks() -> (
+        std::sync::Arc<std::sync::Mutex<Vec<(String, String)>>>,
+        std::sync::Arc<std::sync::Mutex<Vec<(String, String, String)>>>,
+    ) {
+        (
+            std::sync::Arc::new(std::sync::Mutex::new(Vec::new())),
+            std::sync::Arc::new(std::sync::Mutex::new(Vec::new())),
+        )
+    }
+
+    // Spec 029 PR-C.1: legacy config (per-role blocks both disabled).
+    // Primary provider fills both slots; no callback fires because no
+    // per-role provider was constructed.
+    #[test]
+    fn build_from_config_legacy_primary_fills_both_slots() {
+        let primary = arc("legacy", AiCapabilities::ALL);
+        let (configured, fallbacks) = record_callbacks();
+        let cfg_configured = configured.clone();
+        let cfg_fallbacks = fallbacks.clone();
+
+        let r = build_from_config(
+            Some(Arc::clone(&primary)),
+            &RoleProviderConfig::default(),
+            &RoleProviderConfig::default(),
+            move |slot, p| {
+                cfg_configured
+                    .lock()
+                    .unwrap()
+                    .push((slot.to_string(), p.to_string()))
+            },
+            move |slot, p, e| {
+                cfg_fallbacks
+                    .lock()
+                    .unwrap()
+                    .push((slot.to_string(), p.to_string(), e.to_string()))
+            },
+        );
+
+        assert_eq!(r.decider().unwrap().name(), "legacy");
+        assert_eq!(r.any_llm().unwrap().name(), "legacy");
+        assert!(configured.lock().unwrap().is_empty());
+        assert!(fallbacks.lock().unwrap().is_empty());
+    }
+
+    // Spec 029 PR-C.1: classifier enabled + successful build. A
+    // dedicated provider goes in the classifier slot; llm slot still
+    // uses primary because its role_cfg is disabled.
+    #[test]
+    fn build_from_config_classifier_enabled_builds_dedicated_provider() {
+        let primary = arc("primary-llm", AiCapabilities::ALL);
+        let classifier_cfg = RoleProviderConfig {
+            enabled: true,
+            provider: "stub".into(),
+            ..Default::default()
+        };
+        let llm_cfg = RoleProviderConfig::default();
+        let (configured, fallbacks) = record_callbacks();
+        let cfg_configured = configured.clone();
+        let cfg_fallbacks = fallbacks.clone();
+
+        let r = build_from_config(
+            Some(Arc::clone(&primary)),
+            &classifier_cfg,
+            &llm_cfg,
+            move |slot, p| {
+                cfg_configured
+                    .lock()
+                    .unwrap()
+                    .push((slot.to_string(), p.to_string()))
+            },
+            move |slot, p, e| {
+                cfg_fallbacks
+                    .lock()
+                    .unwrap()
+                    .push((slot.to_string(), p.to_string(), e.to_string()))
+            },
+        );
+
+        // Classifier slot now the stub; llm slot still primary.
+        assert_eq!(r.decider().unwrap().name(), "stub");
+        assert_eq!(r.any_llm().unwrap().name(), "primary-llm");
+
+        let configured = configured.lock().unwrap().clone();
+        assert_eq!(configured.len(), 1);
+        assert_eq!(configured[0].0, "classifier");
+        assert_eq!(configured[0].1, "stub");
+        assert!(fallbacks.lock().unwrap().is_empty());
+    }
+
+    // Spec 029 PR-C.1: llm enabled + successful build. Dedicated
+    // provider in the llm slot; classifier slot still primary.
+    #[test]
+    fn build_from_config_llm_enabled_builds_dedicated_provider() {
+        let primary = arc("primary-classifier", AiCapabilities::ALL);
+        let classifier_cfg = RoleProviderConfig::default();
+        let llm_cfg = RoleProviderConfig {
+            enabled: true,
+            provider: "stub".into(),
+            ..Default::default()
+        };
+        let (configured, fallbacks) = record_callbacks();
+        let cfg_configured = configured.clone();
+        let cfg_fallbacks = fallbacks.clone();
+
+        let r = build_from_config(
+            Some(Arc::clone(&primary)),
+            &classifier_cfg,
+            &llm_cfg,
+            move |slot, p| {
+                cfg_configured
+                    .lock()
+                    .unwrap()
+                    .push((slot.to_string(), p.to_string()))
+            },
+            move |slot, p, e| {
+                cfg_fallbacks
+                    .lock()
+                    .unwrap()
+                    .push((slot.to_string(), p.to_string(), e.to_string()))
+            },
+        );
+
+        assert_eq!(r.decider().unwrap().name(), "primary-classifier");
+        assert_eq!(r.any_llm().unwrap().name(), "stub");
+
+        let configured = configured.lock().unwrap().clone();
+        assert_eq!(configured.len(), 1);
+        assert_eq!(configured[0].0, "llm");
+        assert_eq!(configured[0].1, "stub");
+    }
+
+    // Spec 029 PR-C.1: both roles enabled + successful build. Two
+    // distinct providers populate the router.
+    #[test]
+    fn build_from_config_both_roles_enabled() {
+        let primary = arc("primary", AiCapabilities::ALL);
+        let classifier_cfg = RoleProviderConfig {
+            enabled: true,
+            provider: "stub".into(),
+            model: "classifier-model".into(),
+            ..Default::default()
+        };
+        let llm_cfg = RoleProviderConfig {
+            enabled: true,
+            provider: "stub".into(),
+            model: "llm-model".into(),
+            ..Default::default()
+        };
+        let (configured, fallbacks) = record_callbacks();
+        let cfg_configured = configured.clone();
+        let cfg_fallbacks = fallbacks.clone();
+
+        let r = build_from_config(
+            Some(Arc::clone(&primary)),
+            &classifier_cfg,
+            &llm_cfg,
+            move |slot, p| {
+                cfg_configured
+                    .lock()
+                    .unwrap()
+                    .push((slot.to_string(), p.to_string()))
+            },
+            move |slot, p, e| {
+                cfg_fallbacks
+                    .lock()
+                    .unwrap()
+                    .push((slot.to_string(), p.to_string(), e.to_string()))
+            },
+        );
+
+        assert_eq!(r.decider().unwrap().name(), "stub");
+        assert_eq!(r.any_llm().unwrap().name(), "stub");
+        let configured = configured.lock().unwrap().clone();
+        assert_eq!(configured.len(), 2);
+        let slots: std::collections::HashSet<_> =
+            configured.iter().map(|(s, _)| s.clone()).collect();
+        assert!(slots.contains("classifier"));
+        assert!(slots.contains("llm"));
+        assert!(fallbacks.lock().unwrap().is_empty());
+    }
+
+    // Spec 029 PR-C.1: per-role enabled but build fails (unknown
+    // provider + no base_url, which build_provider rejects per SEC-017).
+    // The slot falls back to the primary and on_fallback fires so
+    // operators see a warn line.
+    #[test]
+    fn build_from_config_per_role_build_failure_falls_back() {
+        let primary = arc("primary", AiCapabilities::ALL);
+        let classifier_cfg = RoleProviderConfig {
+            enabled: true,
+            provider: "nonexistent-provider".into(),
+            // base_url empty — unknown providers without base_url fail
+            // per SEC-017.
+            ..Default::default()
+        };
+        let (configured, fallbacks) = record_callbacks();
+        let cfg_configured = configured.clone();
+        let cfg_fallbacks = fallbacks.clone();
+
+        let r = build_from_config(
+            Some(Arc::clone(&primary)),
+            &classifier_cfg,
+            &RoleProviderConfig::default(),
+            move |slot, p| {
+                cfg_configured
+                    .lock()
+                    .unwrap()
+                    .push((slot.to_string(), p.to_string()))
+            },
+            move |slot, p, e| {
+                cfg_fallbacks
+                    .lock()
+                    .unwrap()
+                    .push((slot.to_string(), p.to_string(), e.to_string()))
+            },
+        );
+
+        // Fallback: both slots end up with primary.
+        assert_eq!(r.decider().unwrap().name(), "primary");
+        assert_eq!(r.any_llm().unwrap().name(), "primary");
+        // on_configured never fired because no per-role build succeeded.
+        assert!(configured.lock().unwrap().is_empty());
+        // on_fallback fired for the classifier slot.
+        let fallbacks = fallbacks.lock().unwrap().clone();
+        assert_eq!(fallbacks.len(), 1);
+        assert_eq!(fallbacks[0].0, "classifier");
+        assert_eq!(fallbacks[0].1, "nonexistent-provider");
+        assert!(fallbacks[0].2.contains("unknown AI provider"));
+    }
+
+    // Spec 029 PR-C.1: no primary provider + both per-role blocks
+    // disabled. Router goes into Falco-mode (disabled) instead of
+    // erroring. The agent is explicitly allowed to run without AI.
+    #[test]
+    fn build_from_config_no_primary_and_no_per_role_is_falco_mode() {
+        let (configured, fallbacks) = record_callbacks();
+        let cfg_configured = configured.clone();
+        let cfg_fallbacks = fallbacks.clone();
+
+        let r = build_from_config(
+            None,
+            &RoleProviderConfig::default(),
+            &RoleProviderConfig::default(),
+            move |slot, p| {
+                cfg_configured
+                    .lock()
+                    .unwrap()
+                    .push((slot.to_string(), p.to_string()))
+            },
+            move |slot, p, e| {
+                cfg_fallbacks
+                    .lock()
+                    .unwrap()
+                    .push((slot.to_string(), p.to_string(), e.to_string()))
+            },
+        );
+
+        assert!(r.is_disabled());
+        for c in Capability::all() {
+            assert!(r.provider_for(*c).is_none());
+        }
+    }
+
+    // Spec 029 PR-C.1: per-role build fails AND no primary. The
+    // fallback path returns None for the slot; router has only the
+    // other slot (or disabled).
+    #[test]
+    fn build_from_config_failure_with_no_primary_leaves_slot_empty() {
+        let classifier_cfg = RoleProviderConfig {
+            enabled: true,
+            provider: "nonexistent-provider".into(),
+            ..Default::default()
+        };
+        let (configured, fallbacks) = record_callbacks();
+        let cfg_configured = configured.clone();
+        let cfg_fallbacks = fallbacks.clone();
+
+        let r = build_from_config(
+            None, // no primary
+            &classifier_cfg,
+            &RoleProviderConfig::default(),
+            move |slot, p| {
+                cfg_configured
+                    .lock()
+                    .unwrap()
+                    .push((slot.to_string(), p.to_string()))
+            },
+            move |slot, p, e| {
+                cfg_fallbacks
+                    .lock()
+                    .unwrap()
+                    .push((slot.to_string(), p.to_string(), e.to_string()))
+            },
+        );
+
+        assert!(r.is_disabled());
+        // Fallback callback fired even though the fallback itself
+        // yielded None — operators still see "we tried and failed".
+        assert_eq!(fallbacks.lock().unwrap().len(), 1);
     }
 }

--- a/crates/agent/src/config.rs
+++ b/crates/agent/src/config.rs
@@ -672,6 +672,90 @@ pub struct AiConfig {
     /// before promoting the shadow to primary.
     #[serde(default)]
     pub shadow: ShadowConfig,
+
+    /// Spec 029 PR-C: dedicated provider for the classifier role
+    /// (triage decisions + structured classification). When
+    /// `enabled = false` (default), the primary `[ai]` block fills
+    /// the classifier slot of the router — identical to the pre-029
+    /// behaviour. When `enabled = true`, the router uses this block
+    /// for `Capability::Decide` and `Capability::Classify`. Typical
+    /// production config points this at the local ONNX classifier
+    /// so triage runs without LLM cost.
+    #[serde(default)]
+    pub classifier: RoleProviderConfig,
+
+    /// Spec 029 PR-C: dedicated provider for the LLM role
+    /// (free-form generation, explanation, honeypot shell
+    /// simulation). When `enabled = false` (default), the primary
+    /// `[ai]` block fills the llm slot. When enabled, the router
+    /// uses this block for `Capability::Generate`,
+    /// `Capability::Explain`, and `Capability::SimulateShell`.
+    /// Typical production config points this at a full LLM (Azure
+    /// OpenAI GPT-5.4-mini, Claude, etc.) so operator-facing chat
+    /// and briefings keep working when the classifier role is
+    /// served by a narrow local model.
+    #[serde(default)]
+    pub llm: RoleProviderConfig,
+}
+
+/// Slim per-role provider configuration introduced in spec 029 PR-C.
+/// Shared by `[ai.classifier]` and `[ai.llm]`. Fields are a subset of
+/// `AiConfig` (only what a single provider needs to be constructed);
+/// shared knobs like `confidence_threshold`, `min_severity`, and the
+/// shadow wrapper continue to live on the top-level `[ai]` block.
+#[derive(Debug, Deserialize, Default, Clone)]
+pub struct RoleProviderConfig {
+    /// If false (default), this role is not configured separately
+    /// and the boot path falls back to the primary `[ai]` block.
+    #[serde(default)]
+    pub enabled: bool,
+
+    /// Provider name. Same set of valid values as `[ai].provider`
+    /// (openai, anthropic, ollama, azure_openai, local_classifier,
+    /// stub, or any OpenAI-compatible registered name).
+    #[serde(default)]
+    pub provider: String,
+
+    /// Same semantics as `[ai].api_key`. Empty string means the
+    /// agent reads the provider-specific env var at startup
+    /// (OPENAI_API_KEY, AZURE_OPENAI_API_KEY, etc.).
+    #[serde(default)]
+    pub api_key: String,
+
+    /// Same semantics as `[ai].model`.
+    #[serde(default)]
+    pub model: String,
+
+    /// Same semantics as `[ai].base_url`.
+    #[serde(default)]
+    pub base_url: String,
+
+    /// Same semantics as `[ai].api_version` (used by `azure_openai`).
+    #[serde(default)]
+    pub api_version: String,
+}
+
+impl RoleProviderConfig {
+    /// Project this role config into a full `AiConfig` shell suitable
+    /// for handing to `ai::build_provider`. Reuses the defaults from
+    /// `AiConfig::default()` for all knobs that are not per-role
+    /// (confidence threshold, max calls per tick, etc.). Leaves
+    /// `api_key` as-is on the returned config so the downstream
+    /// `AiConfig::resolved_api_key` env-var fallback fires exactly
+    /// like it does for the primary `[ai]` block — operators set
+    /// `AZURE_OPENAI_API_KEY` once and both the primary and the LLM
+    /// slot pick it up.
+    pub fn to_ai_config(&self) -> AiConfig {
+        AiConfig {
+            enabled: self.enabled,
+            provider: self.provider.clone(),
+            api_key: self.api_key.clone(),
+            model: self.model.clone(),
+            base_url: self.base_url.clone(),
+            api_version: self.api_version.clone(),
+            ..AiConfig::default()
+        }
+    }
 }
 
 /// Shadow provider configuration (subset of AiConfig applied to a second
@@ -777,6 +861,8 @@ impl Default for AiConfig {
             batch_window_secs: default_batch_window_secs(),
             use_structured_subgraph: default_use_structured_subgraph(),
             shadow: ShadowConfig::default(),
+            classifier: RoleProviderConfig::default(),
+            llm: RoleProviderConfig::default(),
         }
     }
 }
@@ -3275,5 +3361,132 @@ detectors_skip_fase3 = ["threat_intel", "sudo_abuse", "suspicious_execution"]
             .detectors_skip_fase3
             .iter()
             .any(|d| d == "threat_intel"));
+    }
+
+    // Spec 029 PR-C: RoleProviderConfig default is disabled + empty.
+    // When both per-role blocks are absent from agent.toml the router
+    // falls back to the primary [ai] provider (PR-B back-compat).
+    #[test]
+    fn role_provider_config_default_is_disabled() {
+        let r = RoleProviderConfig::default();
+        assert!(!r.enabled);
+        assert!(r.provider.is_empty());
+        assert!(r.api_key.is_empty());
+        assert!(r.model.is_empty());
+        assert!(r.base_url.is_empty());
+        assert!(r.api_version.is_empty());
+    }
+
+    // Spec 029 PR-C: ai_config defaults keep both per-role blocks
+    // disabled so pre-029 configs auto-use the primary [ai] block.
+    #[test]
+    fn ai_config_default_has_disabled_per_role_blocks() {
+        let cfg = AiConfig::default();
+        assert!(!cfg.classifier.enabled);
+        assert!(!cfg.llm.enabled);
+    }
+
+    // Spec 029 PR-C: to_ai_config maps the per-role fields into a
+    // full AiConfig shell suitable for ai::build_provider. Shared
+    // knobs (confidence_threshold, min_severity, etc.) default.
+    #[test]
+    fn role_provider_to_ai_config_maps_fields() {
+        let role = RoleProviderConfig {
+            enabled: true,
+            provider: "azure_openai".into(),
+            api_key: "explicit".into(),
+            model: "gpt-5.4-mini".into(),
+            base_url: "https://example.openai.azure.com".into(),
+            api_version: "2024-12-01-preview".into(),
+        };
+        let cfg = role.to_ai_config();
+        assert!(cfg.enabled);
+        assert_eq!(cfg.provider, "azure_openai");
+        assert_eq!(cfg.api_key, "explicit");
+        assert_eq!(cfg.model, "gpt-5.4-mini");
+        assert_eq!(cfg.base_url, "https://example.openai.azure.com");
+        assert_eq!(cfg.api_version, "2024-12-01-preview");
+        // Shared knobs come from AiConfig::default().
+        assert!(!cfg.shadow.enabled);
+        assert_eq!(cfg.min_severity, "medium");
+    }
+
+    // Spec 029 PR-C: empty api_key on to_ai_config stays empty so
+    // the downstream AiConfig::resolved_api_key env-var fallback
+    // (OPENAI_API_KEY, AZURE_OPENAI_API_KEY, etc.) fires normally.
+    #[test]
+    fn role_provider_to_ai_config_preserves_empty_api_key() {
+        let role = RoleProviderConfig {
+            enabled: true,
+            provider: "openai".into(),
+            api_key: String::new(),
+            ..Default::default()
+        };
+        let cfg = role.to_ai_config();
+        assert!(cfg.api_key.is_empty());
+    }
+
+    // Spec 029 PR-C: parses the classifier + llm TOML sections.
+    #[test]
+    fn load_parses_classifier_and_llm_sections() {
+        let mut tmp = NamedTempFile::new().unwrap();
+        writeln!(
+            tmp,
+            r#"[ai]
+enabled = true
+provider = "stub"
+
+[ai.classifier]
+enabled = true
+provider = "local_classifier"
+base_url = "/var/lib/innerwarden/models/classifier"
+
+[ai.llm]
+enabled = true
+provider = "azure_openai"
+model = "gpt-5.4-mini"
+base_url = "https://example.openai.azure.com"
+api_version = "2024-12-01-preview"
+"#
+        )
+        .unwrap();
+        let cfg = load(tmp.path()).unwrap();
+
+        assert!(cfg.ai.enabled);
+        assert_eq!(cfg.ai.provider, "stub");
+
+        assert!(cfg.ai.classifier.enabled);
+        assert_eq!(cfg.ai.classifier.provider, "local_classifier");
+        assert_eq!(
+            cfg.ai.classifier.base_url,
+            "/var/lib/innerwarden/models/classifier"
+        );
+
+        assert!(cfg.ai.llm.enabled);
+        assert_eq!(cfg.ai.llm.provider, "azure_openai");
+        assert_eq!(cfg.ai.llm.model, "gpt-5.4-mini");
+        assert_eq!(cfg.ai.llm.api_version, "2024-12-01-preview");
+    }
+
+    // Spec 029 PR-C: legacy `[ai]` only config is still parsed with
+    // classifier/llm blocks defaulting to disabled. Back-compat gate.
+    #[test]
+    fn load_without_per_role_sections_leaves_slots_disabled() {
+        let mut tmp = NamedTempFile::new().unwrap();
+        writeln!(
+            tmp,
+            r#"[ai]
+enabled = true
+provider = "stub"
+model = "legacy"
+"#
+        )
+        .unwrap();
+        let cfg = load(tmp.path()).unwrap();
+        assert_eq!(cfg.ai.provider, "stub");
+        // Per-role blocks default to disabled so the boot path falls
+        // back to the primary [ai] provider for both slots.
+        assert!(!cfg.ai.classifier.enabled);
+        assert!(!cfg.ai.llm.enabled);
     }
 }

--- a/crates/agent/src/loops/boot.rs
+++ b/crates/agent/src/loops/boot.rs
@@ -652,23 +652,65 @@ pub(crate) async fn run_agent(cli: crate::Cli) -> Result<()> {
     } else {
         None
     };
-    let ai_router = match &ai_provider {
-        Some(p) => {
-            // Same provider in both slots: router resolves every
-            // capability the provider declares. General-purpose LLMs
-            // default to ALL, narrow providers (LocalClassifier) cover
-            // Decide + Classify only — the router still routes
-            // correctly because `provider_for` consults `capabilities()`.
-            let shared = Arc::clone(p);
-            match ai::AiRouter::new(Some(Arc::clone(&shared)), Some(shared)) {
-                Ok(r) => r,
-                Err(_) => {
-                    warn!("AI router refused both-none config; falling back to disabled");
-                    ai::AiRouter::disabled()
-                }
+
+    // Spec 029 PR-C: per-role providers. When `[ai.classifier].enabled`
+    // is true, build a separate provider for the classifier slot;
+    // otherwise the primary `[ai]` provider fills that slot (PR-B
+    // back-compat behaviour). Same for `[ai.llm]`. This is where an
+    // operator can run a local ONNX classifier for triage and keep
+    // Azure for briefings without touching any call site.
+    let classifier_slot: Option<Arc<dyn ai::AiProvider>> = if cfg.ai.classifier.enabled {
+        let role_cfg = cfg.ai.classifier.to_ai_config();
+        match ai::build_provider(&role_cfg) {
+            Ok(p) => {
+                info!(
+                    provider = role_cfg.provider.as_str(),
+                    "AI router: classifier slot configured"
+                );
+                Some(Arc::from(p))
+            }
+            Err(e) => {
+                warn!(
+                    provider = role_cfg.provider.as_str(),
+                    "failed to build [ai.classifier] provider, falling back to primary: {e:#}"
+                );
+                ai_provider.as_ref().map(Arc::clone)
             }
         }
-        None => ai::AiRouter::disabled(),
+    } else {
+        ai_provider.as_ref().map(Arc::clone)
+    };
+
+    let llm_slot: Option<Arc<dyn ai::AiProvider>> = if cfg.ai.llm.enabled {
+        let role_cfg = cfg.ai.llm.to_ai_config();
+        match ai::build_provider(&role_cfg) {
+            Ok(p) => {
+                info!(
+                    provider = role_cfg.provider.as_str(),
+                    "AI router: llm slot configured"
+                );
+                Some(Arc::from(p))
+            }
+            Err(e) => {
+                warn!(
+                    provider = role_cfg.provider.as_str(),
+                    "failed to build [ai.llm] provider, falling back to primary: {e:#}"
+                );
+                ai_provider.as_ref().map(Arc::clone)
+            }
+        }
+    } else {
+        ai_provider.as_ref().map(Arc::clone)
+    };
+
+    let ai_router = match ai::AiRouter::new(classifier_slot, llm_slot) {
+        Ok(r) => r,
+        Err(_) => {
+            // Both slots empty. Happens when [ai] is disabled and
+            // neither per-role block was enabled. The agent runs in
+            // Falco-mode: rules-only detection, zero LLM cost.
+            ai::AiRouter::disabled()
+        }
     };
     info!(router = %ai_router.describe(), "AI router ready");
 

--- a/crates/agent/src/loops/boot.rs
+++ b/crates/agent/src/loops/boot.rs
@@ -653,65 +653,31 @@ pub(crate) async fn run_agent(cli: crate::Cli) -> Result<()> {
         None
     };
 
-    // Spec 029 PR-C: per-role providers. When `[ai.classifier].enabled`
+    // Spec 029 PR-C.1: per-role providers. When `[ai.classifier].enabled`
     // is true, build a separate provider for the classifier slot;
     // otherwise the primary `[ai]` provider fills that slot (PR-B
-    // back-compat behaviour). Same for `[ai.llm]`. This is where an
-    // operator can run a local ONNX classifier for triage and keep
-    // Azure for briefings without touching any call site.
-    let classifier_slot: Option<Arc<dyn ai::AiProvider>> = if cfg.ai.classifier.enabled {
-        let role_cfg = cfg.ai.classifier.to_ai_config();
-        match ai::build_provider(&role_cfg) {
-            Ok(p) => {
-                info!(
-                    provider = role_cfg.provider.as_str(),
-                    "AI router: classifier slot configured"
-                );
-                Some(Arc::from(p))
-            }
-            Err(e) => {
-                warn!(
-                    provider = role_cfg.provider.as_str(),
-                    "failed to build [ai.classifier] provider, falling back to primary: {e:#}"
-                );
-                ai_provider.as_ref().map(Arc::clone)
-            }
-        }
-    } else {
-        ai_provider.as_ref().map(Arc::clone)
-    };
-
-    let llm_slot: Option<Arc<dyn ai::AiProvider>> = if cfg.ai.llm.enabled {
-        let role_cfg = cfg.ai.llm.to_ai_config();
-        match ai::build_provider(&role_cfg) {
-            Ok(p) => {
-                info!(
-                    provider = role_cfg.provider.as_str(),
-                    "AI router: llm slot configured"
-                );
-                Some(Arc::from(p))
-            }
-            Err(e) => {
-                warn!(
-                    provider = role_cfg.provider.as_str(),
-                    "failed to build [ai.llm] provider, falling back to primary: {e:#}"
-                );
-                ai_provider.as_ref().map(Arc::clone)
-            }
-        }
-    } else {
-        ai_provider.as_ref().map(Arc::clone)
-    };
-
-    let ai_router = match ai::AiRouter::new(classifier_slot, llm_slot) {
-        Ok(r) => r,
-        Err(_) => {
-            // Both slots empty. Happens when [ai] is disabled and
-            // neither per-role block was enabled. The agent runs in
-            // Falco-mode: rules-only detection, zero LLM cost.
-            ai::AiRouter::disabled()
-        }
-    };
+    // back-compat). Same for `[ai.llm]`. Branch logic lives in the
+    // unit-testable `ai::router::build_from_config`; this block just
+    // wires tracing callbacks.
+    let ai_router = ai::router::build_from_config(
+        ai_provider.as_ref().map(Arc::clone),
+        &cfg.ai.classifier,
+        &cfg.ai.llm,
+        |slot, provider_name| {
+            info!(
+                slot,
+                provider = provider_name,
+                "AI router: per-role slot configured"
+            );
+        },
+        |slot, provider_name, err| {
+            warn!(
+                slot,
+                provider = provider_name,
+                "failed to build per-role provider, falling back to primary: {err:#}"
+            );
+        },
+    );
     info!(router = %ai_router.describe(), "AI router ready");
 
     let mut state = AgentState {


### PR DESCRIPTION
## Summary

Third in the spec 029 series. Adds \`[ai.classifier]\` and \`[ai.llm]\` config sections with back-compat. Zero behavioural change for legacy configs. Routes are populated in boot but not yet consumed by call sites — PR-C.2 does the ~30-site migration.

## Config surface

\`\`\`toml
[ai]
enabled = true
provider = "azure_openai"  # primary / fallback for either slot

[ai.classifier]
enabled = true
provider = "local_classifier"
base_url = "/var/lib/innerwarden/models/classifier"

[ai.llm]
enabled = true
provider = "azure_openai"
model = "gpt-5.4-mini"
base_url = "https://<resource>.openai.azure.com"
api_version = "2024-12-01-preview"
\`\`\`

Back-compat: when either \`[ai.classifier]\` or \`[ai.llm]\` is absent (or \`enabled = false\`), that slot falls back to the primary \`[ai]\` block. Legacy configs work identically to pre-029.

## Boot UX

Per-slot info line when a dedicated provider is configured:
\`\`\`
AI router: classifier slot configured provider=local_classifier
AI router: llm slot configured provider=azure_openai
AI router ready router=classifier=local_classifier|decide,classify, llm=azure_openai|decide,classify,generate,explain,simulate_shell
\`\`\`

If a per-role provider fails to build (bad config, missing env key), the slot falls back to the primary provider instead of crashing. Warn line emitted with the error cause so operators can see what went wrong without touching the binary.

## Tests

6 new:
- Default behaviour locked (both per-role disabled by default)
- Field mapping to \`AiConfig\` works correctly
- Empty api_key preserved so env-var fallback still fires
- TOML round-trip for both sections
- Back-compat regression guard (legacy \`[ai]\` only)

Full workspace: **4179 pass**, 3 ignored. \`make check\` clean.

## Next (PR-C.2)

Migrate the ~30 call sites to \`state.ai_router.provider_for(Capability::X)\`. After that ships, this config shape starts actually shaping runtime behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)