### PR TITLE
feat(agent): spec 029 PR-C.3 - drop legacy AgentState.ai_provider

### DIFF
--- a/crates/agent/src/ai/capability.rs
+++ b/crates/agent/src/ai/capability.rs
@@ -1,9 +1,3 @@
-// Spec 029 PR-B: the types are now consumed transitively via
-// `AgentState.ai_router`, but individual `provider_for` call sites
-// do not yet reach the enum variants. PR-C migrates the ~30 call
-// sites and removes this allow.
-#![allow(dead_code)]
-
 //! AI capability types (spec 029).
 //!
 //! Replaces the single-method-fits-all surface of the old `AiProvider`
@@ -112,7 +106,9 @@ pub struct AiCapabilities(u8);
 impl AiCapabilities {
     /// An empty capability set. Providers that are still under
     /// development can start here without getting routed to for any
-    /// role.
+    /// role. Used by `AiRouter::capabilities()` as the accumulator
+    /// seed and by router tests that build up sets incrementally.
+    #[allow(dead_code)]
     pub const NONE: AiCapabilities = AiCapabilities(0);
 
     /// Every capability set, for providers that fulfil every role
@@ -120,7 +116,9 @@ impl AiCapabilities {
     /// together.
     pub const ALL: AiCapabilities = AiCapabilities(0b0001_1111);
 
-    /// Build from a list of capabilities.
+    /// Build from a list of capabilities. Used by tests and by
+    /// classifier-style providers that declare a narrow subset.
+    #[allow(dead_code)]
     pub fn from_slice(caps: &[Capability]) -> Self {
         let mut bits = 0u8;
         for c in caps {
@@ -135,6 +133,7 @@ impl AiCapabilities {
     }
 
     /// Number of capabilities declared. For diagnostics.
+    #[allow(dead_code)]
     pub fn count(&self) -> usize {
         self.0.count_ones() as usize
     }

--- a/crates/agent/src/ai/router.rs
+++ b/crates/agent/src/ai/router.rs
@@ -1,11 +1,3 @@
-// Spec 029 PR-B: `AiRouter` is now a field on `AgentState` and
-// constructed in `loops/boot.rs`. The router itself is reachable
-// but its per-capability resolver is not called from any pre-PR-C
-// call site, so `provider_for`, `any_llm`, `describe` etc. still
-// appear unused to clippy. PR-C migrates the call sites and removes
-// this allow.
-#![allow(dead_code)]
-
 //! AI capability router (spec 029).
 //!
 //! Replaces `state.ai_provider: Option<Arc<dyn AiProvider>>` with a
@@ -155,8 +147,10 @@ impl AiRouter {
         }
     }
 
-    /// Convenience: provider for `Decide`. Replaces the old
-    /// `state.ai_provider` single-getter.
+    /// Convenience: provider for `Decide`. Kept as a public shorthand
+    /// and exercised by router back-compat tests. Production code
+    /// calls `provider_for(Capability::Decide)` directly.
+    #[allow(dead_code)]
     pub fn decider(&self) -> Option<Arc<dyn AiProvider>> {
         self.provider_for(Capability::Decide)
     }
@@ -181,8 +175,10 @@ impl AiRouter {
             .or_else(|| self.any_llm())
     }
 
-    /// Union of all capabilities this router can serve. For startup
-    /// telemetry and the `/api/diagnostics/ai` endpoint (future).
+    /// Union of all capabilities this router can serve. Consumed by
+    /// router tests and reserved for a future `/api/diagnostics/ai`
+    /// endpoint.
+    #[allow(dead_code)]
     pub fn capabilities(&self) -> AiCapabilities {
         let mut bits = AiCapabilities::NONE;
         if let Some(c) = &self.classifier {
@@ -195,6 +191,9 @@ impl AiRouter {
     }
 
     /// Is the router effectively "Falco mode" (no capabilities)?
+    /// Used by test helpers (`dashboard::state::test_dashboard_state`)
+    /// and router unit tests to assert on construction results.
+    #[allow(dead_code)]
     pub fn is_disabled(&self) -> bool {
         self.classifier.is_none() && self.llm.is_none()
     }
@@ -320,7 +319,9 @@ fn resolve_slot(
 
 /// Merge two capability sets. Small helper kept module-local because
 /// it is only used by the router; `AiCapabilities` itself does not
-/// need a public `|` impl yet.
+/// need a public `|` impl yet. Reachable via `capabilities()` which
+/// is currently test-only.
+#[allow(dead_code)]
 fn merge(a: AiCapabilities, b: AiCapabilities) -> AiCapabilities {
     let mut caps = AiCapabilities::NONE;
     for c in Capability::all() {

--- a/crates/agent/src/bot_actions.rs
+++ b/crates/agent/src/bot_actions.rs
@@ -112,7 +112,7 @@ pub(crate) async fn handle_telegram_action_callback(
             host: inc.host.clone(),
             data_dir: data_dir.to_path_buf(),
             honeypot: honeypot_runtime(cfg),
-            ai_provider: state.ai_provider.clone(),
+            ai_provider: state.ai_router.any_llm(),
         };
 
         let exec_result = skill.execute(&ctx, cfg.responder.dry_run).await;
@@ -188,7 +188,8 @@ pub(crate) async fn handle_telegram_action_callback(
                 // Build SkillContext and execute the honeypot skill
                 if let Some(skill) = state.skill_registry.get("honeypot") {
                     let mut runtime = honeypot_runtime(cfg);
-                    runtime.ai_provider = state.ai_provider.clone();
+                    let skill_ai = state.ai_router.any_llm();
+                    runtime.ai_provider = skill_ai.clone();
                     let ctx = skills::SkillContext {
                         incident: choice.incident.clone(),
                         target_ip: Some(ip.clone()),
@@ -198,7 +199,7 @@ pub(crate) async fn handle_telegram_action_callback(
                         host: host.clone(),
                         data_dir: data_dir.to_path_buf(),
                         honeypot: runtime.clone(),
-                        ai_provider: state.ai_provider.clone(),
+                        ai_provider: skill_ai,
                     };
                     let exec_result = skill.execute(&ctx, cfg.responder.dry_run).await;
                     let msg = if exec_result.success {
@@ -281,7 +282,7 @@ pub(crate) async fn handle_telegram_action_callback(
                         host: host.clone(),
                         data_dir: data_dir.to_path_buf(),
                         honeypot: honeypot_runtime(cfg),
-                        ai_provider: state.ai_provider.clone(),
+                        ai_provider: state.ai_router.any_llm(),
                     };
                     let exec_result = skill.execute(&ctx, cfg.responder.dry_run).await;
                     if exec_result.success {

--- a/crates/agent/src/decision_block_ip.rs
+++ b/crates/agent/src/decision_block_ip.rs
@@ -92,7 +92,7 @@ pub(crate) async fn execute_block_ip_decision(
         host: incident.host.clone(),
         data_dir: data_dir.to_path_buf(),
         honeypot: crate::honeypot_runtime(cfg),
-        ai_provider: state.ai_provider.clone(),
+        ai_provider: state.ai_router.any_llm(),
     };
 
     let mut layers_applied = Vec::new();

--- a/crates/agent/src/decision_honeypot.rs
+++ b/crates/agent/src/decision_honeypot.rs
@@ -15,7 +15,8 @@ pub(crate) async fn execute_honeypot_decision(
     if let Some(skill) = state.skill_registry.get("honeypot") {
         let mut runtime = crate::honeypot_runtime(cfg);
         // Thread the AI provider into the runtime so llm_shell interaction works.
-        runtime.ai_provider = state.ai_provider.clone();
+        let skill_ai = state.ai_router.any_llm();
+        runtime.ai_provider = skill_ai.clone();
         let ctx = skills::SkillContext {
             incident: incident.clone(),
             target_ip: Some(ip.to_string()),
@@ -25,7 +26,7 @@ pub(crate) async fn execute_honeypot_decision(
             host: incident.host.clone(),
             data_dir: data_dir.to_path_buf(),
             honeypot: runtime.clone(),
-            ai_provider: state.ai_provider.clone(),
+            ai_provider: skill_ai,
         };
         let result = skill.execute(&ctx, cfg.responder.dry_run).await;
         if result.success {
@@ -40,7 +41,7 @@ pub(crate) async fn execute_honeypot_decision(
             let post_ip = ip.to_string();
             let post_session_id = session_id.clone();
             let post_data_dir = data_dir.to_path_buf();
-            let post_ai = state.ai_provider.clone();
+            let post_ai = state.ai_router.any_llm();
             let post_tg = state.telegram_client.clone();
             let post_gate_counter = state.telemetry.gate_suppressed_counter();
             let post_responder_enabled = cfg.responder.enabled;

--- a/crates/agent/src/decision_skill_actions.rs
+++ b/crates/agent/src/decision_skill_actions.rs
@@ -23,7 +23,7 @@ pub(crate) async fn execute_simple_action(
                     host: incident.host.clone(),
                     data_dir: data_dir.to_path_buf(),
                     honeypot: crate::honeypot_runtime(cfg),
-                    ai_provider: state.ai_provider.clone(),
+                    ai_provider: state.ai_router.any_llm(),
                 };
                 Some((
                     skill.execute(&ctx, cfg.responder.dry_run).await.message,
@@ -51,7 +51,7 @@ pub(crate) async fn execute_simple_action(
                     host: incident.host.clone(),
                     data_dir: data_dir.to_path_buf(),
                     honeypot: crate::honeypot_runtime(cfg),
-                    ai_provider: state.ai_provider.clone(),
+                    ai_provider: state.ai_router.any_llm(),
                 };
                 Some((
                     skill.execute(&ctx, cfg.responder.dry_run).await.message,
@@ -82,7 +82,7 @@ pub(crate) async fn execute_simple_action(
                     host: incident.host.clone(),
                     data_dir: data_dir.to_path_buf(),
                     honeypot: crate::honeypot_runtime(cfg),
-                    ai_provider: state.ai_provider.clone(),
+                    ai_provider: state.ai_router.any_llm(),
                 };
                 Some((
                     skill.execute(&ctx, cfg.responder.dry_run).await.message,
@@ -113,7 +113,7 @@ pub(crate) async fn execute_simple_action(
                     host: incident.host.clone(),
                     data_dir: data_dir.to_path_buf(),
                     honeypot: crate::honeypot_runtime(cfg),
-                    ai_provider: state.ai_provider.clone(),
+                    ai_provider: state.ai_router.any_llm(),
                 };
                 Some((
                     skill.execute(&ctx, cfg.responder.dry_run).await.message,
@@ -138,7 +138,7 @@ pub(crate) async fn execute_simple_action(
                     host: incident.host.clone(),
                     data_dir: data_dir.to_path_buf(),
                     honeypot: crate::honeypot_runtime(cfg),
-                    ai_provider: state.ai_provider.clone(),
+                    ai_provider: state.ai_router.any_llm(),
                 };
                 Some((
                     skill.execute(&ctx, cfg.responder.dry_run).await.message,

--- a/crates/agent/src/loops/boot.rs
+++ b/crates/agent/src/loops/boot.rs
@@ -643,12 +643,11 @@ pub(crate) async fn run_agent(cli: crate::Cli) -> Result<()> {
         });
     }
 
-    // Build the AI provider once and populate both the legacy
-    // `ai_provider` handle and the spec 029 capability router from it.
-    // During PR-B the router is additive — both slots of the router
-    // hold the same provider so pre-029 call sites (which still use
-    // `state.ai_provider`) see identical behaviour. PR-C migrates the
-    // call sites and introduces the classifier/llm split.
+    // Build the primary AI provider once; it feeds the spec 029
+    // capability router. When `[ai.classifier]` / `[ai.llm]` are not
+    // set, both router slots hold this same provider (legacy
+    // behaviour). When they are set, the router builds dedicated
+    // per-role providers and reserves this primary for fallback.
     let ai_provider: Option<Arc<dyn ai::AiProvider>> = if cfg.ai.enabled {
         match ai::build_provider(&cfg.ai) {
             Ok(p) => Some(Arc::from(p)),
@@ -707,7 +706,6 @@ pub(crate) async fn run_agent(cli: crate::Cli) -> Result<()> {
         } else {
             None
         },
-        ai_provider,
         ai_router,
         // Decision writer is always created — Layer 1/2 decisions are written
         // even without AI. Previously gated on cfg.ai.enabled which caused

--- a/crates/agent/src/main.rs
+++ b/crates/agent/src/main.rs
@@ -374,19 +374,11 @@ struct AgentState {
     correlator: correlation::TemporalCorrelator,
     telemetry: telemetry::TelemetryState,
     telemetry_writer: Option<telemetry::TelemetryWriter>,
-    /// Wrapped in Arc so we can clone a handle for use within a loop iteration
-    /// without holding a borrow of `state` across async calls that need `&mut state`.
-    ai_provider: Option<Arc<dyn ai::AiProvider>>,
-    /// Spec 029 PR-B: capability router. Serves the same provider(s)
-    /// as `ai_provider` today (both populated from the same boot step)
-    /// but exposes them by role so call sites can request by
-    /// capability rather than by "the one provider". PR-C migrates
-    /// the ~30 call sites off `ai_provider` and onto this field;
-    /// during PR-B the router is additive and the legacy field stays
-    /// in place. Back-compat test in `ai::router::back_compat_tests`
-    /// guarantees that a router built from a single legacy provider
-    /// resolves every capability identically to pre-029 code.
-    #[allow(dead_code)] // consumed by call sites in PR-C (spec 029)
+    /// Spec 029: capability router. Call sites resolve providers by
+    /// role (classifier vs llm) via `provider_for(Capability::X)`.
+    /// Back-compat test in `ai::router::back_compat_tests` guarantees
+    /// that a router built from a single legacy provider resolves
+    /// every capability identically to pre-029 code.
     ai_router: ai::AiRouter,
     decision_writer: Option<decisions::DecisionWriter>,
     /// Tracks when the daily narrative was last written so we can enforce a

--- a/crates/agent/src/narrative_observation_verify.rs
+++ b/crates/agent/src/narrative_observation_verify.rs
@@ -1057,8 +1057,8 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let mut state = triage_test_state(tmp.path());
         assert!(
-            state.ai_provider.is_none(),
-            "triage_test_state baseline has no ai_provider"
+            state.ai_router.is_disabled(),
+            "triage_test_state baseline has a disabled router"
         );
         let cfg = AgentConfig::default();
 
@@ -1128,11 +1128,6 @@ mod tests {
         };
         let provider = crate::ai::build_provider(&ai_cfg).expect("stub provider builds");
         let provider_arc: Arc<dyn crate::ai::AiProvider> = Arc::from(provider);
-        state.ai_provider = Some(Arc::clone(&provider_arc));
-        // Spec 029 PR-C.2: promote_escalated_to_decision now reads
-        // from the router, not the legacy field. Populate both slots
-        // with the same provider so the test exercises the same
-        // decide() path as before.
         state.ai_router =
             crate::ai::AiRouter::new(Some(Arc::clone(&provider_arc)), Some(provider_arc))
                 .expect("router with stub provider");
@@ -1356,7 +1351,6 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let mut state = triage_test_state(tmp.path());
         let err_arc: Arc<dyn crate::ai::AiProvider> = Arc::new(ErroringProvider);
-        state.ai_provider = Some(Arc::clone(&err_arc));
         state.ai_router = crate::ai::AiRouter::new(Some(Arc::clone(&err_arc)), Some(err_arc))
             .expect("router with erroring provider");
 
@@ -1423,7 +1417,6 @@ mod tests {
         };
         let provider = crate::ai::build_provider(&ai_cfg).expect("stub builds");
         let provider_arc: Arc<dyn crate::ai::AiProvider> = Arc::from(provider);
-        state.ai_provider = Some(Arc::clone(&provider_arc));
         state.ai_router =
             crate::ai::AiRouter::new(Some(Arc::clone(&provider_arc)), Some(provider_arc))
                 .expect("router with stub");

--- a/crates/agent/src/process/incidents.rs
+++ b/crates/agent/src/process/incidents.rs
@@ -210,11 +210,10 @@ pub(crate) async fn process_incidents(
     // router. This is the Decide path, so we pull from
     // `state.ai_router.provider_for(Capability::Decide)`. When the
     // operator has configured a dedicated classifier via
-    // `[ai.classifier]`, this now routes triage through the
-    // classifier without touching the rest of the decision pipeline.
-    // The legacy `state.ai_provider` field still populates both
-    // router slots during PR-C (removed in PR-C.3), so behaviour is
-    // identical for legacy configs.
+    // `[ai.classifier]`, triage routes through the classifier without
+    // touching the rest of the decision pipeline. Legacy configs
+    // (no `[ai.classifier]` / `[ai.llm]`) populate both slots with the
+    // primary provider, so behaviour is identical.
     let decide_provider = state.ai_router.provider_for(ai::Capability::Decide);
     let ai_enabled = cfg.ai.enabled && decide_provider.is_some() && !circuit_breaker_open;
     let (all_events, skill_infos, ai_provider, provider_name, already_blocked, mut blocked_set) =

--- a/crates/agent/src/process/post_decision.rs
+++ b/crates/agent/src/process/post_decision.rs
@@ -62,7 +62,7 @@ pub(crate) async fn execute_decision(
                     host: incident.host.clone(),
                     data_dir: data_dir.to_path_buf(),
                     honeypot: honeypot_runtime(cfg),
-                    ai_provider: state.ai_provider.clone(),
+                    ai_provider: state.ai_router.any_llm(),
                 };
                 (
                     skill.execute(&ctx, cfg.responder.dry_run).await.message,
@@ -96,7 +96,7 @@ pub(crate) async fn execute_decision(
                     host: incident.host.clone(),
                     data_dir: data_dir.to_path_buf(),
                     honeypot: honeypot_runtime(cfg),
-                    ai_provider: state.ai_provider.clone(),
+                    ai_provider: state.ai_router.any_llm(),
                 };
                 (
                     skill.execute(&ctx, cfg.responder.dry_run).await.message,
@@ -130,7 +130,7 @@ pub(crate) async fn execute_decision(
                     host: incident.host.clone(),
                     data_dir: data_dir.to_path_buf(),
                     honeypot: honeypot_runtime(cfg),
-                    ai_provider: state.ai_provider.clone(),
+                    ai_provider: state.ai_router.any_llm(),
                 };
                 (
                     skill.execute(&ctx, cfg.responder.dry_run).await.message,

--- a/crates/agent/src/tests.rs
+++ b/crates/agent/src/tests.rs
@@ -180,7 +180,6 @@ pub(crate) fn triage_test_state(data_dir: &Path) -> AgentState {
         correlator: correlation::TemporalCorrelator::new(300, 4096),
         telemetry: telemetry::TelemetryState::default(),
         telemetry_writer: None,
-        ai_provider: None,
         ai_router: ai::AiRouter::disabled(),
         decision_writer: Some(decisions::DecisionWriter::new(data_dir).unwrap()),
         last_narrative_at: None,
@@ -467,7 +466,6 @@ async fn golden_path_dry_run_produces_decision_entry() {
         correlator: correlation::TemporalCorrelator::new(300, 4096),
         telemetry: telemetry::TelemetryState::default(),
         telemetry_writer: None,
-        ai_provider: Some(mock.clone() as Arc<dyn ai::AiProvider>),
         ai_router: ai::AiRouter::new(
             Some(mock.clone() as Arc<dyn ai::AiProvider>),
             Some(mock.clone() as Arc<dyn ai::AiProvider>),
@@ -656,7 +654,6 @@ async fn allowed_skills_whitelist_enforced() {
         correlator: correlation::TemporalCorrelator::new(300, 4096),
         telemetry: telemetry::TelemetryState::default(),
         telemetry_writer: None,
-        ai_provider: Some(mock.clone() as Arc<dyn ai::AiProvider>),
         ai_router: ai::AiRouter::new(
             Some(mock.clone() as Arc<dyn ai::AiProvider>),
             Some(mock.clone() as Arc<dyn ai::AiProvider>),
@@ -826,7 +823,6 @@ async fn same_ip_in_same_tick_triggers_single_ai_call() {
         correlator: correlation::TemporalCorrelator::new(300, 4096),
         telemetry: telemetry::TelemetryState::default(),
         telemetry_writer: None,
-        ai_provider: Some(mock.clone() as Arc<dyn ai::AiProvider>),
         ai_router: ai::AiRouter::new(
             Some(mock.clone() as Arc<dyn ai::AiProvider>),
             Some(mock.clone() as Arc<dyn ai::AiProvider>),
@@ -997,7 +993,6 @@ async fn temporal_correlation_context_is_passed_to_ai() {
         correlator: correlation::TemporalCorrelator::new(300, 4096),
         telemetry: telemetry::TelemetryState::default(),
         telemetry_writer: None,
-        ai_provider: Some(mock.clone() as Arc<dyn ai::AiProvider>),
         ai_router: ai::AiRouter::new(
             Some(mock.clone() as Arc<dyn ai::AiProvider>),
             Some(mock.clone() as Arc<dyn ai::AiProvider>),
@@ -1153,7 +1148,6 @@ async fn honeypot_demo_writes_synthetic_decoy_event() {
         correlator: correlation::TemporalCorrelator::new(300, 4096),
         telemetry: telemetry::TelemetryState::default(),
         telemetry_writer: None,
-        ai_provider: Some(mock.clone() as Arc<dyn ai::AiProvider>),
         ai_router: ai::AiRouter::new(
             Some(mock.clone() as Arc<dyn ai::AiProvider>),
             Some(mock.clone() as Arc<dyn ai::AiProvider>),
@@ -1319,7 +1313,6 @@ async fn decision_cooldown_suppresses_repeat() {
         correlator: correlation::TemporalCorrelator::new(300, 4096),
         telemetry: telemetry::TelemetryState::default(),
         telemetry_writer: None,
-        ai_provider: Some(mock.clone() as Arc<dyn ai::AiProvider>),
         ai_router: ai::AiRouter::new(
             Some(mock.clone() as Arc<dyn ai::AiProvider>),
             Some(mock.clone() as Arc<dyn ai::AiProvider>),


### PR DESCRIPTION
## Summary

Final PR in the spec 029 series. Every runtime wrapper that previously cloned `state.ai_provider` now resolves its provider through the capability router. The legacy `AgentState.ai_provider` field is deleted.

## What changed

### Call-site migration

Every `SkillContext` / `HoneypotRuntimeConfig` builder now populates `ai_provider` via `state.ai_router.any_llm()`:

| File | Sites | Flow |
|------|-------|------|
| `bot_actions.rs` | 3 SkillContext + 1 HoneypotRuntime | Telegram quick-block + operator actions |
| `decision_block_ip.rs` | 1 | Block-IP skill chain |
| `decision_honeypot.rs` | 1 SkillContext + 1 HoneypotRuntime + 1 post-session AI | Honeypot divert path |
| `decision_skill_actions.rs` | 5 | Monitor, Suspend, Kill, BlockContainer, KillChainResponse |
| `process/post_decision.rs` | 3 | AI-decided simple actions |

`any_llm()` matches legacy semantics: pre-029 configs put the single primary in every slot, so it returns the primary. New classifier+llm configs return the llm slot (never the classifier), which is what skills want for free-form AI prompts.

### Test migration

`narrative_observation_verify::tests` (3 setups) now populate only the router. The `promote_is_noop_without_provider` test's assertion is flipped from `state.ai_provider.is_none()` to `state.ai_router.is_disabled()`.

`tests.rs::triage_test_state` and 6 mock-state builders no longer initialise the deleted field.

### Field removal

- `AgentState.ai_provider: Option<Arc<dyn AiProvider>>` deleted.
- Module-level `#![allow(dead_code)]` removed from `ai/capability.rs` and `ai/router.rs`.
- Per-item `#[allow(dead_code)]` added to seven public helpers currently exercised only by tests, each with a comment naming its intended future caller (e.g. `is_disabled` is used by the dashboard test helper + router unit tests; `capabilities` is reserved for the planned `/api/diagnostics/ai` endpoint).

## Tests

- 4199 workspace tests pass (1695 in innerwarden-agent alone).
- Net -23 lines of agent code.
- clippy clean (`-D warnings`).
- fmt clean.

## Next

Spec 029 is complete. Ready to cut v0.13 once this merges. Follow-up work moves onto operator-facing features now that per-role providers are wired end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)