### PR TITLE
fix(agent): attach spec 029 shadow to Decide slot + honest classifier caps

### DIFF
--- a/crates/agent/src/ai/local_classifier.rs
+++ b/crates/agent/src/ai/local_classifier.rs
@@ -159,16 +159,16 @@ impl AiProvider for LocalClassifier {
         "local_classifier"
     }
 
-    /// Spec 029: declare only the capabilities this classifier truly
-    /// supports. It cannot generate free-form text (no decoder stage
-    /// in MiniLM), cannot explain, cannot simulate a shell. If the
-    /// router ever asks this provider for Generate/Explain/SimulateShell
-    /// the call is routed elsewhere instead.
+    /// Spec 029: only declare `Decide`. The current `Classify`
+    /// call sites (batch triage, ambiguous verification) dispatch
+    /// via `chat()` with a prompt asking for a label, which this
+    /// classifier cannot serve (no decoder). Declaring only `Decide`
+    /// keeps the router honest: Classify requests fall through to
+    /// the llm slot where `chat()` actually works, and this provider
+    /// is only invoked for the one path it was trained for (incident
+    /// triage -> block_ip/monitor/ignore/dismiss).
     fn capabilities(&self) -> super::capability::AiCapabilities {
-        super::capability::AiCapabilities::from_slice(&[
-            super::capability::Capability::Decide,
-            super::capability::Capability::Classify,
-        ])
+        super::capability::AiCapabilities::from_slice(&[super::capability::Capability::Decide])
     }
 
     async fn decide(&self, ctx: &DecisionContext<'_>) -> Result<AiDecision> {

--- a/crates/agent/src/ai/mod.rs
+++ b/crates/agent/src/ai/mod.rs
@@ -364,49 +364,79 @@ fn validate_ai_base_url(url: &str) -> Result<()> {
 }
 
 pub fn build_provider(cfg: &AiConfig) -> Result<Box<dyn AiProvider>> {
-    let primary = build_single(
+    build_single(
         &cfg.provider,
         cfg.resolved_api_key(),
         &cfg.model,
         &cfg.base_url,
         &cfg.api_version,
         cfg.confidence_threshold,
-    )?;
+    )
+}
 
-    if cfg.shadow.enabled {
-        if cfg.shadow.provider.is_empty() {
-            anyhow::bail!("[ai.shadow].enabled is true but provider is empty");
-        }
-        if cfg.shadow.provider == cfg.provider
-            && cfg.shadow.base_url == cfg.base_url
-            && cfg.shadow.model == cfg.model
-        {
-            anyhow::bail!(
-                "[ai.shadow] must differ from [ai] primary (same provider+base_url+model configured)"
-            );
-        }
-        let shadow = build_single(
-            &cfg.shadow.provider,
-            cfg.shadow.resolved_api_key(),
-            &cfg.shadow.model,
-            &cfg.shadow.base_url,
-            &cfg.shadow.api_version,
-            cfg.confidence_threshold,
-        )?;
-        tracing::info!(
-            primary = %cfg.provider,
-            shadow = %cfg.shadow.provider,
-            log_path = %cfg.shadow.log_path,
-            "shadow mode enabled"
-        );
-        return Ok(Box::new(shadow::ShadowProvider::new(
-            primary,
-            shadow,
-            &cfg.shadow.log_path,
-        )));
+/// Build the shadow observer as a standalone provider. Returns `None`
+/// when `[ai.shadow]` is disabled. Errors when enabled but the
+/// resulting provider would duplicate the Decide-serving one (same
+/// provider+base_url+model), which would silently degrade shadow
+/// into a useless self-comparison.
+///
+/// Called by the router after the Decide slot is resolved, so the
+/// "differs from" check compares against whatever provider actually
+/// serves Decide (classifier slot when configured, primary [ai]
+/// otherwise) rather than hardcoding [ai] primary.
+pub fn build_shadow_observer(
+    shadow_cfg: &crate::config::ShadowConfig,
+    decide_provider_provider: &str,
+    decide_provider_base_url: &str,
+    decide_provider_model: &str,
+    confidence_threshold: f32,
+) -> Result<Option<Box<dyn AiProvider>>> {
+    if !shadow_cfg.enabled {
+        return Ok(None);
     }
+    if shadow_cfg.provider.is_empty() {
+        anyhow::bail!("[ai.shadow].enabled is true but provider is empty");
+    }
+    if shadow_cfg.provider == decide_provider_provider
+        && shadow_cfg.base_url == decide_provider_base_url
+        && shadow_cfg.model == decide_provider_model
+    {
+        anyhow::bail!(
+            "[ai.shadow] must differ from the Decide-serving provider (same provider+base_url+model configured)"
+        );
+    }
+    let shadow = build_single(
+        &shadow_cfg.provider,
+        shadow_cfg.resolved_api_key(),
+        &shadow_cfg.model,
+        &shadow_cfg.base_url,
+        &shadow_cfg.api_version,
+        confidence_threshold,
+    )?;
+    Ok(Some(shadow))
+}
 
-    Ok(primary)
+/// Wrap a primary provider with a shadow observer for parallel
+/// Decide auditing. Returns the primary unchanged when shadow is
+/// `None`. Keeps the shadow path a one-liner at call sites so the
+/// router stays easy to read.
+pub fn wrap_with_shadow(
+    primary: Box<dyn AiProvider>,
+    shadow: Option<Box<dyn AiProvider>>,
+    log_path: &str,
+) -> Box<dyn AiProvider> {
+    match shadow {
+        Some(shadow) => {
+            tracing::info!(
+                primary = %primary.name(),
+                shadow = %shadow.name(),
+                log_path = %log_path,
+                "shadow mode enabled"
+            );
+            Box::new(shadow::ShadowProvider::new(primary, shadow, log_path))
+        }
+        None => primary,
+    }
 }
 
 /// Build a single provider from flat parameters. Extracted so the same logic
@@ -702,17 +732,15 @@ mod tests {
     }
 
     #[test]
-    fn build_provider_shadow_enabled_empty_provider_fails() {
-        let cfg = crate::config::AiConfig {
+    fn build_shadow_observer_empty_provider_fails() {
+        let shadow = crate::config::ShadowConfig {
             enabled: true,
-            provider: "stub".into(),
-            shadow: crate::config::ShadowConfig {
-                enabled: true,
-                ..Default::default()
-            },
             ..Default::default()
         };
-        let err = build_provider(&cfg).err().unwrap().to_string();
+        let err = build_shadow_observer(&shadow, "stub", "", "", 0.85)
+            .err()
+            .unwrap()
+            .to_string();
         assert!(
             err.contains("shadow") && err.contains("empty"),
             "expected shadow-empty error, got: {err}"
@@ -720,24 +748,26 @@ mod tests {
     }
 
     #[test]
-    fn build_provider_shadow_enabled_matching_primary_fails() {
-        // Same provider + same base_url + same model as primary must be
-        // rejected; otherwise shadow provides no signal.
-        let cfg = crate::config::AiConfig {
+    fn build_shadow_observer_matching_target_fails() {
+        // Same provider + same base_url + same model as the Decide-serving
+        // slot must be rejected; otherwise shadow provides no signal.
+        let shadow = crate::config::ShadowConfig {
             enabled: true,
             provider: "ollama".into(),
             base_url: "http://localhost:11434".into(),
             model: "llama3.2".into(),
-            shadow: crate::config::ShadowConfig {
-                enabled: true,
-                provider: "ollama".into(),
-                base_url: "http://localhost:11434".into(),
-                model: "llama3.2".into(),
-                ..Default::default()
-            },
             ..Default::default()
         };
-        let err = build_provider(&cfg).err().unwrap().to_string();
+        let err = build_shadow_observer(
+            &shadow,
+            "ollama",
+            "http://localhost:11434",
+            "llama3.2",
+            0.85,
+        )
+        .err()
+        .unwrap()
+        .to_string();
         assert!(
             err.contains("must differ"),
             "expected 'must differ' error, got: {err}"
@@ -745,25 +775,39 @@ mod tests {
     }
 
     #[test]
-    fn build_provider_shadow_enabled_with_distinct_config_succeeds() {
-        // Primary stub + shadow stub-with-different-model is allowed because
-        // the check compares (provider, base_url, model) tuple. Two stubs
-        // distinguish by model here.
-        let cfg = crate::config::AiConfig {
+    fn build_shadow_observer_distinct_config_succeeds() {
+        // Target stub + shadow stub-with-different-model is allowed because
+        // the check compares (provider, base_url, model) tuple.
+        let shadow = crate::config::ShadowConfig {
             enabled: true,
             provider: "stub".into(),
-            shadow: crate::config::ShadowConfig {
-                enabled: true,
-                provider: "stub".into(),
-                model: "different".into(),
-                ..Default::default()
-            },
+            model: "different".into(),
             ..Default::default()
         };
-        let provider = build_provider(&cfg).expect("shadow wrapper must build");
-        // ShadowProvider::name() delegates to primary so existing telemetry
-        // labels stay stable.
-        assert_eq!(provider.name(), "stub");
+        let observer = build_shadow_observer(&shadow, "stub", "", "", 0.85)
+            .expect("shadow observer must build")
+            .expect("enabled shadow must return Some");
+        assert_eq!(observer.name(), "stub");
+    }
+
+    #[test]
+    fn build_shadow_observer_disabled_returns_none() {
+        let shadow = crate::config::ShadowConfig::default();
+        let observer = build_shadow_observer(&shadow, "stub", "", "", 0.85)
+            .expect("disabled shadow must not error");
+        assert!(observer.is_none());
+    }
+
+    #[test]
+    fn wrap_with_shadow_no_shadow_returns_primary_unchanged() {
+        let primary = build_provider(&crate::config::AiConfig {
+            enabled: true,
+            provider: "stub".into(),
+            ..Default::default()
+        })
+        .expect("stub builds");
+        let wrapped = wrap_with_shadow(primary, None, "/tmp/unused.jsonl");
+        assert_eq!(wrapped.name(), "stub");
     }
 
     #[test]

--- a/crates/agent/src/ai/router.rs
+++ b/crates/agent/src/ai/router.rs
@@ -239,13 +239,33 @@ pub fn build_from_config(
     primary: Option<Arc<dyn AiProvider>>,
     classifier_cfg: &crate::config::RoleProviderConfig,
     llm_cfg: &crate::config::RoleProviderConfig,
+    shadow_cfg: Option<&crate::config::ShadowConfig>,
+    confidence_threshold: f32,
     mut on_slot_configured: impl FnMut(&'static str, &str),
     mut on_slot_fallback: impl FnMut(&'static str, &str, &anyhow::Error),
 ) -> AiRouter {
+    // Shadow wraps the Decide-serving slot. When a dedicated
+    // classifier is configured it takes Decide (router rules in
+    // `provider_for`); otherwise Decide falls back to the llm slot.
+    // Pass the shadow config to whichever slot will answer Decide so
+    // the `differs from` guard compares against the right provider.
+    let classifier_shadow = if classifier_cfg.enabled {
+        shadow_cfg
+    } else {
+        None
+    };
+    let llm_shadow = if !classifier_cfg.enabled && llm_cfg.enabled {
+        shadow_cfg
+    } else {
+        None
+    };
+
     let classifier_slot = resolve_slot(
         "classifier",
         &primary,
         classifier_cfg,
+        classifier_shadow,
+        confidence_threshold,
         &mut on_slot_configured,
         &mut on_slot_fallback,
     );
@@ -253,6 +273,8 @@ pub fn build_from_config(
         "llm",
         &primary,
         llm_cfg,
+        llm_shadow,
+        confidence_threshold,
         &mut on_slot_configured,
         &mut on_slot_fallback,
     );
@@ -272,11 +294,15 @@ pub fn build_for_dashboard(
     primary: Option<Arc<dyn AiProvider>>,
     classifier_cfg: &crate::config::RoleProviderConfig,
     llm_cfg: &crate::config::RoleProviderConfig,
+    shadow_cfg: Option<&crate::config::ShadowConfig>,
+    confidence_threshold: f32,
 ) -> AiRouter {
     build_from_config(
         primary,
         classifier_cfg,
         llm_cfg,
+        shadow_cfg,
+        confidence_threshold,
         |slot, provider_name| {
             tracing::info!(
                 slot,
@@ -298,6 +324,8 @@ fn resolve_slot(
     slot_name: &'static str,
     primary: &Option<Arc<dyn AiProvider>>,
     role_cfg: &crate::config::RoleProviderConfig,
+    shadow_cfg: Option<&crate::config::ShadowConfig>,
+    confidence_threshold: f32,
     on_configured: &mut impl FnMut(&'static str, &str),
     on_fallback: &mut impl FnMut(&'static str, &str, &anyhow::Error),
 ) -> Option<Arc<dyn AiProvider>> {
@@ -306,9 +334,29 @@ fn resolve_slot(
     }
     let ai_cfg = role_cfg.to_ai_config();
     match crate::ai::build_provider(&ai_cfg) {
-        Ok(p) => {
+        Ok(primary_box) => {
             on_configured(slot_name, &ai_cfg.provider);
-            Some(Arc::from(p))
+            let wrapped_box = match shadow_cfg {
+                Some(scfg) if scfg.enabled => {
+                    match crate::ai::build_shadow_observer(
+                        scfg,
+                        &ai_cfg.provider,
+                        &ai_cfg.base_url,
+                        &ai_cfg.model,
+                        confidence_threshold,
+                    ) {
+                        Ok(shadow_opt) => {
+                            crate::ai::wrap_with_shadow(primary_box, shadow_opt, &scfg.log_path)
+                        }
+                        Err(e) => {
+                            on_fallback(slot_name, &scfg.provider, &e);
+                            primary_box
+                        }
+                    }
+                }
+                _ => primary_box,
+            };
+            Some(Arc::from(wrapped_box))
         }
         Err(e) => {
             on_fallback(slot_name, &ai_cfg.provider, &e);
@@ -654,6 +702,8 @@ mod tests {
             Some(Arc::clone(&primary)),
             &RoleProviderConfig::default(),
             &RoleProviderConfig::default(),
+            None,
+            0.85_f32,
             move |slot, p| {
                 cfg_configured
                     .lock()
@@ -694,6 +744,8 @@ mod tests {
             Some(Arc::clone(&primary)),
             &classifier_cfg,
             &llm_cfg,
+            None,
+            0.85_f32,
             move |slot, p| {
                 cfg_configured
                     .lock()
@@ -738,6 +790,8 @@ mod tests {
             Some(Arc::clone(&primary)),
             &classifier_cfg,
             &llm_cfg,
+            None,
+            0.85_f32,
             move |slot, p| {
                 cfg_configured
                     .lock()
@@ -786,6 +840,8 @@ mod tests {
             Some(Arc::clone(&primary)),
             &classifier_cfg,
             &llm_cfg,
+            None,
+            0.85_f32,
             move |slot, p| {
                 cfg_configured
                     .lock()
@@ -833,6 +889,8 @@ mod tests {
             Some(Arc::clone(&primary)),
             &classifier_cfg,
             &RoleProviderConfig::default(),
+            None,
+            0.85_f32,
             move |slot, p| {
                 cfg_configured
                     .lock()
@@ -873,6 +931,8 @@ mod tests {
             None,
             &RoleProviderConfig::default(),
             &RoleProviderConfig::default(),
+            None,
+            0.85_f32,
             move |slot, p| {
                 cfg_configured
                     .lock()
@@ -911,6 +971,8 @@ mod tests {
             None, // no primary
             &classifier_cfg,
             &RoleProviderConfig::default(),
+            None,
+            0.85_f32,
             move |slot, p| {
                 cfg_configured
                     .lock()
@@ -940,6 +1002,8 @@ mod tests {
             Some(Arc::clone(&primary)),
             &RoleProviderConfig::default(),
             &RoleProviderConfig::default(),
+            None,
+            0.85_f32,
         );
         assert_eq!(r.decider().unwrap().name(), "legacy");
         assert_eq!(r.any_llm().unwrap().name(), "legacy");
@@ -951,6 +1015,8 @@ mod tests {
             None,
             &RoleProviderConfig::default(),
             &RoleProviderConfig::default(),
+            None,
+            0.85_f32,
         );
         assert!(r.is_disabled());
     }
@@ -967,8 +1033,189 @@ mod tests {
             Some(Arc::clone(&primary)),
             &classifier_cfg,
             &RoleProviderConfig::default(),
+            None,
+            0.85_f32,
         );
         assert_eq!(r.decider().unwrap().name(), "primary");
         assert_eq!(r.any_llm().unwrap().name(), "primary");
+    }
+
+    // ── shadow routing ──────────────────────────────────────────────
+    //
+    // Spec 029: `[ai.shadow]` wraps the Decide-serving slot. When a
+    // dedicated classifier is configured, shadow wraps that.
+
+    #[test]
+    fn shadow_wraps_classifier_when_classifier_is_configured() {
+        use crate::config::ShadowConfig;
+        // Stub classifier + stub shadow with a different model. The
+        // router should wrap the classifier slot with a ShadowProvider.
+        let classifier_cfg = RoleProviderConfig {
+            enabled: true,
+            provider: "stub".into(),
+            model: "clf-model".into(),
+            ..Default::default()
+        };
+        let shadow_cfg = ShadowConfig {
+            enabled: true,
+            provider: "stub".into(),
+            model: "shadow-model".into(),
+            ..Default::default()
+        };
+        let (configured, fallbacks) = record_callbacks();
+        let cfg_configured = configured.clone();
+        let cfg_fallbacks = fallbacks.clone();
+        let r = build_from_config(
+            None,
+            &classifier_cfg,
+            &RoleProviderConfig::default(),
+            Some(&shadow_cfg),
+            0.85,
+            move |slot, p| {
+                cfg_configured
+                    .lock()
+                    .unwrap()
+                    .push((slot.to_string(), p.to_string()))
+            },
+            move |slot, p, e| {
+                cfg_fallbacks
+                    .lock()
+                    .unwrap()
+                    .push((slot.to_string(), p.to_string(), e.to_string()))
+            },
+        );
+        // Decide routes to the classifier slot which is now a
+        // ShadowProvider wrapper. ShadowProvider delegates `name()` to
+        // the primary, so the stub name surfaces through the wrapper.
+        assert_eq!(r.decider().unwrap().name(), "stub");
+        assert!(fallbacks.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn shadow_rejects_identical_target_config() {
+        use crate::config::ShadowConfig;
+        // Classifier config == shadow config. Router must log a fallback
+        // (shadow build rejected) but keep the classifier slot usable.
+        let classifier_cfg = RoleProviderConfig {
+            enabled: true,
+            provider: "stub".into(),
+            ..Default::default()
+        };
+        let shadow_cfg = ShadowConfig {
+            enabled: true,
+            provider: "stub".into(),
+            ..Default::default()
+        };
+        let (configured, fallbacks) = record_callbacks();
+        let cfg_configured = configured.clone();
+        let cfg_fallbacks = fallbacks.clone();
+        let r = build_from_config(
+            None,
+            &classifier_cfg,
+            &RoleProviderConfig::default(),
+            Some(&shadow_cfg),
+            0.85,
+            move |slot, p| {
+                cfg_configured
+                    .lock()
+                    .unwrap()
+                    .push((slot.to_string(), p.to_string()))
+            },
+            move |slot, p, e| {
+                cfg_fallbacks
+                    .lock()
+                    .unwrap()
+                    .push((slot.to_string(), p.to_string(), e.to_string()))
+            },
+        );
+        let fbs = fallbacks.lock().unwrap().clone();
+        assert_eq!(fbs.len(), 1, "expected shadow differs-from fallback");
+        assert!(
+            fbs[0].2.contains("must differ"),
+            "expected 'must differ' in error, got {}",
+            fbs[0].2
+        );
+        // Classifier slot still built successfully without the shadow wrap.
+        assert_eq!(r.decider().unwrap().name(), "stub");
+    }
+
+    #[test]
+    fn shadow_wraps_llm_when_no_classifier_configured() {
+        use crate::config::ShadowConfig;
+        // No classifier, only llm. Decide falls back to llm, so shadow
+        // attaches there.
+        let llm_cfg = RoleProviderConfig {
+            enabled: true,
+            provider: "stub".into(),
+            model: "llm-model".into(),
+            ..Default::default()
+        };
+        let shadow_cfg = ShadowConfig {
+            enabled: true,
+            provider: "stub".into(),
+            model: "shadow-model".into(),
+            ..Default::default()
+        };
+        let (configured, fallbacks) = record_callbacks();
+        let cfg_configured = configured.clone();
+        let cfg_fallbacks = fallbacks.clone();
+        let r = build_from_config(
+            None,
+            &RoleProviderConfig::default(),
+            &llm_cfg,
+            Some(&shadow_cfg),
+            0.85,
+            move |slot, p| {
+                cfg_configured
+                    .lock()
+                    .unwrap()
+                    .push((slot.to_string(), p.to_string()))
+            },
+            move |slot, p, e| {
+                cfg_fallbacks
+                    .lock()
+                    .unwrap()
+                    .push((slot.to_string(), p.to_string(), e.to_string()))
+            },
+        );
+        assert!(fallbacks.lock().unwrap().is_empty());
+        // Decide and any_llm both reach llm, which is shadow-wrapped.
+        assert_eq!(r.decider().unwrap().name(), "stub");
+        assert_eq!(r.any_llm().unwrap().name(), "stub");
+    }
+
+    #[test]
+    fn shadow_disabled_does_not_wrap() {
+        use crate::config::ShadowConfig;
+        let classifier_cfg = RoleProviderConfig {
+            enabled: true,
+            provider: "stub".into(),
+            ..Default::default()
+        };
+        let shadow_cfg = ShadowConfig::default(); // enabled = false
+        let (configured, fallbacks) = record_callbacks();
+        let cfg_configured = configured.clone();
+        let cfg_fallbacks = fallbacks.clone();
+        let r = build_from_config(
+            None,
+            &classifier_cfg,
+            &RoleProviderConfig::default(),
+            Some(&shadow_cfg),
+            0.85,
+            move |slot, p| {
+                cfg_configured
+                    .lock()
+                    .unwrap()
+                    .push((slot.to_string(), p.to_string()))
+            },
+            move |slot, p, e| {
+                cfg_fallbacks
+                    .lock()
+                    .unwrap()
+                    .push((slot.to_string(), p.to_string(), e.to_string()))
+            },
+        );
+        assert!(fallbacks.lock().unwrap().is_empty());
+        assert_eq!(r.decider().unwrap().name(), "stub");
     }
 }

--- a/crates/agent/src/loops/boot.rs
+++ b/crates/agent/src/loops/boot.rs
@@ -366,6 +366,8 @@ pub(crate) async fn run_agent(cli: crate::Cli) -> Result<()> {
             dashboard_ai.as_ref().map(Arc::clone),
             &cfg.ai.classifier,
             &cfg.ai.llm,
+            Some(&cfg.ai.shadow),
+            cfg.ai.confidence_threshold,
         );
         let dashboard_briefing = Arc::new(tokio::sync::Mutex::new(None::<briefing::Briefing>));
         let briefing_hour = cfg.briefing.hour;
@@ -670,6 +672,8 @@ pub(crate) async fn run_agent(cli: crate::Cli) -> Result<()> {
         ai_provider.as_ref().map(Arc::clone),
         &cfg.ai.classifier,
         &cfg.ai.llm,
+        Some(&cfg.ai.shadow),
+        cfg.ai.confidence_threshold,
         |slot, provider_name| {
             info!(
                 slot,


### PR DESCRIPTION
## Summary

First Oracle deploy of spec 029 surfaced two bugs that the existing tests did not cover.

### Bug 1 — Shadow wrapped `[ai]` primary, not the Decide-serving slot

`build_provider()` ran the shadow wrap unconditionally when `[ai.shadow]` was enabled, with the differs check comparing against `[ai]`. Pre-029 that was correct (one primary). With the capability router the Decide path can be served by `[ai.classifier]`, so shadow should track that slot.

Oracle config:

```toml
[ai]               provider = "azure_openai"
[ai.classifier]    provider = "local_classifier"
[ai.shadow]        provider = "azure_openai"   # inverted: Azure audits the classifier
```

Agent refused to boot shadow with `[ai.shadow] must differ from [ai] primary` and the shadow log stayed at 0 bytes.

### Bug 2 — `LocalClassifier` declared `Classify` it cannot serve

`capabilities()` returned `Decide | Classify`. Every `Classify` call site (batch triage + ambiguous verification) dispatches through `chat()`; the ONNX classifier has no decoder so `chat()` returns an error. Observation verification crashed on the first tick.

## Fix

### `build_provider` becomes pure

Returns a plain provider. Shadow handling moved into two small helpers:

- `build_shadow_observer(shadow_cfg, target_provider, target_url, target_model, confidence_threshold)` — builds the observer with the differs check against *whatever slot will be wrapped* (not hardcoded to `[ai]`).
- `wrap_with_shadow(primary, Option<shadow>, log_path)` — one-line helper for readable call sites.

### Router owns the Decide-slot decision

`resolve_slot` takes an optional `shadow_cfg`. `build_from_config` + `build_for_dashboard` gained `shadow_cfg` + `confidence_threshold` parameters and thread shadow into the classifier slot when configured, else into the llm slot (legacy back-compat). Shadow wraps before `Box -> Arc` so `ShadowProvider::new(Box, Box, path)` stays typed as it was.

### `LocalClassifier::capabilities()` only claims `Decide`

Honest declaration. The router now resolves `Classify` to the llm slot (Azure) where `chat()` works. Triage still reaches the classifier because `Decide` is unique to it. No per-call-site patch needed.

## Tests

- 4 new router shadow tests: wraps classifier, wraps llm fallback, rejects identical target, disabled no-op
- 3 old `build_provider_shadow_*` tests moved to target `build_shadow_observer` + `wrap_with_shadow` directly (unchanged assertions, just direct calls)
- All 1701 agent tests pass
- fmt + clippy clean

## Deploy plan after merge

1. Build aarch64 agent with `--features local-classifier` from development
2. Ship binary to Oracle
3. `agent.toml` already has the inverted blocks from the first attempt; no config change needed this round
4. Restart, verify:
   - `AI router ready router=classifier=local_classifier|decide, llm=azure_openai|...`
   - No `[ai.shadow] must differ` warning
   - No `local_classifier does not support free-form chat` errors
   - Shadow log `/var/lib/innerwarden/shadow-decisions.jsonl` starts filling with Azure-shadow-of-classifier entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)