### PR TITLE
fix(agent): delegate ShadowProvider capabilities to wrapped primary

### DIFF
--- a/crates/agent/src/ai/shadow.rs
+++ b/crates/agent/src/ai/shadow.rs
@@ -101,6 +101,17 @@ impl AiProvider for ShadowProvider {
         self.primary.name()
     }
 
+    /// Spec 029: delegate to the wrapped primary. The shadow does not
+    /// add capabilities of its own - it audits whatever the primary
+    /// can do. Without this override the router would see a
+    /// shadow-wrapped classifier as having every capability (trait
+    /// default `ALL`) and route `Classify` or `Generate` calls to the
+    /// wrapper's `chat()`, which forwards to the primary and fails
+    /// because the real classifier has no decoder.
+    fn capabilities(&self) -> crate::ai::capability::AiCapabilities {
+        self.primary.capabilities()
+    }
+
     async fn decide(&self, ctx: &DecisionContext<'_>) -> Result<AiDecision> {
         let incident_id = ctx.incident.incident_id.clone();
 
@@ -385,6 +396,54 @@ mod tests {
             0,
             "chat must not hit shadow provider"
         );
+    }
+
+    #[tokio::test]
+    async fn capabilities_delegates_to_primary() {
+        use crate::ai::capability::{AiCapabilities, Capability};
+
+        // Narrow "classifier-like" primary that only claims Decide.
+        struct DecideOnly;
+        #[async_trait]
+        impl AiProvider for DecideOnly {
+            fn name(&self) -> &'static str {
+                "decide-only"
+            }
+            fn capabilities(&self) -> AiCapabilities {
+                AiCapabilities::from_slice(&[Capability::Decide])
+            }
+            async fn decide(&self, _ctx: &DecisionContext<'_>) -> Result<AiDecision> {
+                Ok(AiDecision {
+                    action: AiAction::Ignore {
+                        reason: "ok".into(),
+                    },
+                    confidence: 0.9,
+                    auto_execute: false,
+                    reason: "t".into(),
+                    alternatives: vec![],
+                    estimated_threat: "low".into(),
+                })
+            }
+            async fn chat(&self, _s: &str, _u: &str) -> Result<String> {
+                anyhow::bail!("DecideOnly has no decoder")
+            }
+        }
+
+        let primary = Box::new(DecideOnly);
+        let shadow = Box::new(FakeProvider {
+            name: "shad",
+            action: AiAction::Ignore { reason: "s".into() },
+            calls: Arc::new(AtomicUsize::new(0)),
+        });
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let sp = ShadowProvider::new(primary, shadow, tmp.path());
+
+        let caps = sp.capabilities();
+        assert!(caps.has(Capability::Decide));
+        assert!(!caps.has(Capability::Classify));
+        assert!(!caps.has(Capability::Generate));
+        assert!(!caps.has(Capability::Explain));
+        assert!(!caps.has(Capability::SimulateShell));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Third bug on Oracle. PR #218 narrowed `LocalClassifier::capabilities()` to `Decide`, but on deploy the router still reported:

    classifier=local_classifier|decide,classify,generate,explain,simulate_shell

The classifier slot is a `ShadowProvider` wrapper, not the `LocalClassifier` directly. `ShadowProvider` never overrode `capabilities()`, so the default `AiCapabilities::ALL` took over and the wrapper advertised every role.

Runtime consequence: `provider_for(Classify)` resolved to the shadow-wrapped classifier, the caller invoked `chat()`, the wrapper forwarded to `primary.chat()`, and the ONNX primary returned `local_classifier does not support free-form chat` — exactly the symptom PR #218 believed it had solved.

## Fix

`ShadowProvider::capabilities()` delegates to `self.primary.capabilities()`. Shadow wraps a provider; it does not add or remove capabilities.

## Tests

- New `capabilities_delegates_to_primary` test with a narrow `DecideOnly` fake primary: asserts the wrapper reports only `Decide`.
- 1702 agent tests pass. fmt + clippy clean.

## Deploy

Same binary build/deploy path as PR #218. Config unchanged. Expected log after restart:

    AI router ready router=classifier=local_classifier|decide, llm=azure_openai|decide,classify,generate,explain,simulate_shell

and no `local_classifier does not support free-form chat` warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)