### PR TITLE
fix(dashboard): journey narrative reads decision action_type

### DIFF
--- a/crates/agent/src/dashboard/frontend/js/journey.js
+++ b/crates/agent/src/dashboard/frontend/js/journey.js
@@ -455,7 +455,12 @@ async function loadJourney(subjectType, subjectValue) {
         // TL;DR — human-readable narrative, mode-aware.
         const incidents = j.entries.filter(e => e.kind === 'incident');
         const decisions = j.entries.filter(e => e.kind === 'decision');
-        const blocks = decisions.filter(e => (e.action||'').includes('block'));
+        // Journey entries serialize decisions as {kind, ts, data:{action_type,...}}.
+        // The legacy read of `e.action` returned undefined for every entry so
+        // `wasBlocked` was always false and the narrative fell through to
+        // "AI decided to monitor" even when a block_ip actually executed.
+        const actionOf = e => ((e && e.data && e.data.action_type) || '');
+        const blocks = decisions.filter(e => actionOf(e).includes('block'));
         if (incidents.length === 0 && decisions.length === 0) return '';
 
         const topIncident = incidents.length > 0 ? incidents[0] : null;
@@ -492,7 +497,9 @@ async function loadJourney(subjectType, subjectValue) {
           if (blocks.length > 1) narrative += ' (' + blocks.length + ' actions)';
           narrative += '. ';
         } else if (decisions.length > 0) {
-          const action = decisions[0].action || 'monitor';
+          // Pair with the actionOf() reader above: decisions carry the
+          // action label on `data.action_type`, not on the entry itself.
+          const action = actionOf(decisions[0]) || 'monitor';
           narrative += 'The AI decided to <strong>' + esc(action.replace(/_/g, ' ')) + '</strong>. ';
         }
         if (isResolved) {


### PR DESCRIPTION
## Summary

The "What happened" narrative on the IP journey page reported `The AI decided to monitor` even when the audit trail recorded a real `block_ip` execution.

## Repro

Oracle London investigating `193.106.245.20` (threat_intel match, AbuseIPDB score 100/100, 2410 reports):

- Narrative text: `The AI decided to monitor. Threat contained. No action needed.`
- Decisions log (`/var/lib/innerwarden/decisions-2026-04-20.jsonl`):
  - `block_ip` confidence 0.95, executed, ufw + Cloudflare + AbuseIPDB
  - `block_ip` confidence 0.92, executed, ufw + AbuseIPDB

The narrative lied about the AI's action.

## Root cause

`journey.js:458` + `:495` read `e.action` on each decision entry. The Rust serializer in `investigation.rs` (lines 911-925) nests the field under `data.action_type`. Every decision carried `action = undefined`, so the `blocks` filter was always empty, `wasBlocked` was always false, and `decisions[0].action || 'monitor'` fell through to the fallback literal.

Same file already used the correct path in three other places (lines 48, 266, 593 — all read `action_type`), only the narrative section had the mis-spelled key.

## Fix

Introduce an `actionOf(e)` helper that reads `e.data.action_type`, use it in both the `blocks` filter and the `decisions[0]` label. Matches the existing Rust test at `dashboard/mod.rs:1577` (`verdict_blocked_outcome_sets_containment_status`) which constructs the same entry shape.

## Tests

No JS test harness in this repo so no unit test added. The existing Rust JourneyEntry schema tests constrain the contract this fix now reads correctly.

After deploy, the narrative for 193.106.245.20 should read `The AI blocked this threat (2 actions).`

🤖 Generated with [Claude Code](https://claude.com/claude-code)