### PR TITLE
fix(store): lock down data-dir file permissions end-to-end

### DIFF
--- a/crates/store/src/lib.rs
+++ b/crates/store/src/lib.rs
@@ -50,17 +50,27 @@ impl Store {
 
         // Pre-create the DB file with group-writable permissions (0660) so that
         // both sensor (root:innerwarden) and agent (innerwarden:innerwarden) can
-        // write. NOT world-readable — contains security-sensitive data (incidents,
+        // write. NOT world-readable: contains security-sensitive data (incidents,
         // decisions, attacker profiles). SQLite's internal open() uses 0644,
         // ignoring the process UMask.
         if !db_path.exists() {
             if let Ok(f) = std::fs::File::create(&db_path) {
                 drop(f);
-                #[cfg(unix)]
-                {
-                    use std::os::unix::fs::PermissionsExt;
-                    let _ =
-                        std::fs::set_permissions(&db_path, std::fs::Permissions::from_mode(0o660));
+            }
+        }
+        // Enforce 0660 on every open, not only on first-create. Heals existing
+        // deployments where SQLite or an older build left the file at 0644, and
+        // re-applies after any out-of-band chmod. Fail-silent on non-unix or
+        // missing file.
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let _ = std::fs::set_permissions(&db_path, std::fs::Permissions::from_mode(0o660));
+            // SQLite WAL sidecars carry the same sensitive data.
+            for sidecar in ["innerwarden.db-wal", "innerwarden.db-shm"] {
+                let p = data_dir.join(sidecar);
+                if p.exists() {
+                    let _ = std::fs::set_permissions(&p, std::fs::Permissions::from_mode(0o660));
                 }
             }
         }

--- a/crates/store/src/maintenance.rs
+++ b/crates/store/src/maintenance.rs
@@ -361,22 +361,23 @@ impl MaintenanceScheduler {
             Err(e) => warn!("maintenance: verify_hash_chain failed: {e:#}"),
         }
 
-        // DB file permissions check (should be 0660, not world-readable)
+        // Self-heal world-readable files in data_dir. The agent/sensor only
+        // hold security-sensitive artefacts here (incidents, decisions,
+        // attacker profiles, DB, graph snapshots). We strip the world-read
+        // bit on every hourly tick instead of only alerting, so existing
+        // deployments are fixed in place without operator intervention.
+        // New installs are already protected by UMask=0007 in the systemd
+        // units; this path only matters for files rotated in or created
+        // before that change landed.
         #[cfg(unix)]
         {
-            use std::os::unix::fs::PermissionsExt;
-            let db_path = store.data_dir.join("innerwarden.db");
-            if let Ok(meta) = std::fs::metadata(&db_path) {
-                let mode = meta.permissions().mode() & 0o777;
-                if mode & 0o004 != 0 {
-                    let msg = format!(
-                        "DATABASE WORLD-READABLE (mode {:o}). Run: chmod 660 {}",
-                        mode,
-                        db_path.display()
-                    );
-                    warn!("{msg}");
-                    alerts.push(msg);
-                }
+            let healed = heal_world_readable(&store.data_dir);
+            if healed > 0 {
+                info!(
+                    files = healed,
+                    dir = %store.data_dir.display(),
+                    "maintenance: stripped world-read bit from data files"
+                );
             }
         }
 
@@ -471,11 +472,66 @@ impl MaintenanceScheduler {
     }
 }
 
+/// Walk `dir` one level deep, stripping the world-read bit on any regular
+/// file whose mode has `0o004` set. Returns the number of files healed.
+///
+/// Non-recursive and fail-silent: any `io::Error` on a single entry is
+/// swallowed so a transient permission issue doesn't block the rest of
+/// the hourly maintenance tick. The caller logs the aggregate count.
+#[cfg(unix)]
+fn heal_world_readable(dir: &std::path::Path) -> usize {
+    use std::os::unix::fs::PermissionsExt;
+
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return 0;
+    };
+    let mut healed = 0;
+    for entry in entries.flatten() {
+        let Ok(ft) = entry.file_type() else { continue };
+        if !ft.is_file() {
+            continue;
+        }
+        let path = entry.path();
+        let Ok(meta) = entry.metadata() else { continue };
+        let mode = meta.permissions().mode() & 0o777;
+        if mode & 0o004 != 0 {
+            let new_mode = mode & !0o007;
+            if std::fs::set_permissions(&path, std::fs::Permissions::from_mode(new_mode)).is_ok() {
+                healed += 1;
+            }
+        }
+    }
+    healed
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use chrono::Utc;
     use innerwarden_core::event::{Event, Severity};
+
+    #[cfg(unix)]
+    #[test]
+    fn heal_world_readable_strips_other_bits() {
+        use std::os::unix::fs::PermissionsExt;
+        let tmp = tempfile::tempdir().unwrap();
+        let loose = tmp.path().join("loose.json");
+        std::fs::write(&loose, b"x").unwrap();
+        std::fs::set_permissions(&loose, std::fs::Permissions::from_mode(0o644)).unwrap();
+        let tight = tmp.path().join("tight.json");
+        std::fs::write(&tight, b"x").unwrap();
+        std::fs::set_permissions(&tight, std::fs::Permissions::from_mode(0o640)).unwrap();
+
+        assert_eq!(heal_world_readable(tmp.path()), 1);
+        assert_eq!(
+            std::fs::metadata(&loose).unwrap().permissions().mode() & 0o777,
+            0o640
+        );
+        assert_eq!(
+            std::fs::metadata(&tight).unwrap().permissions().mode() & 0o777,
+            0o640
+        );
+    }
 
     #[test]
     fn test_wal_checkpoint() {

--- a/examples/systemd/innerwarden-agent.service
+++ b/examples/systemd/innerwarden-agent.service
@@ -9,6 +9,12 @@ Type=simple
 User=innerwarden
 Group=innerwarden
 SupplementaryGroups=systemd-journal
+# UMask 0007 keeps new files mode 660 and directories 770. Data in
+# /var/lib/innerwarden is security-sensitive (incidents, decisions,
+# attacker profiles, dashboard cert/key, graph snapshots). World bits
+# must be cleared; group members (sensor runs as root:innerwarden)
+# keep read+write for the sensor/agent coordination.
+UMask=0007
 ExecStart=/usr/local/bin/innerwarden-agent --data-dir /var/lib/innerwarden --config /etc/innerwarden/agent.toml --dashboard --dashboard-bind 0.0.0.0:8787
 Restart=on-failure
 RestartSec=5

--- a/examples/systemd/innerwarden-sensor.service
+++ b/examples/systemd/innerwarden-sensor.service
@@ -11,11 +11,13 @@ User=root
 # to write to incidents-*.jsonl without permission conflicts.
 Group=innerwarden
 SupplementaryGroups=adm systemd-journal
-# UMask 0002 makes new files mode 664 (group writable). Combined with
-# Group=innerwarden above, this lets the agent append to files created
-# by the sensor. Without this, killchain_inline incidents are silently
-# lost with "Permission denied" errors.
-UMask=0002
+# UMask 0007 makes new files mode 660 and directories 770. Group write
+# (combined with Group=innerwarden above) lets the agent append to files
+# created by the sensor. Without this, killchain_inline incidents are
+# silently lost with "Permission denied" errors. World bits are cleared
+# because /var/lib/innerwarden holds security-sensitive state (incidents,
+# decisions, attacker profiles, keys) and must not leak to other users.
+UMask=0007
 ExecStart=/usr/local/bin/innerwarden-sensor --config /etc/innerwarden/config.toml
 Restart=on-failure
 RestartSec=5


### PR DESCRIPTION
## Summary

- Files under `/var/lib/innerwarden` were landing at `0644`, tripping the agent's own `DATABASE WORLD-READABLE` alert and leaving graph snapshots, attacker profiles, and rotated JSONL world-readable. Parent dir is `0750` so blast radius is small, but this is defense-in-depth state and should not rely on the parent.
- Three-layer fix so new and existing deployments are both covered:
  1. `crates/store/src/lib.rs`: enforce `0660` on `innerwarden.db` on every `Store::open()` (not only first-create), and chmod the `db-wal` / `db-shm` sidecars.
  2. `crates/store/src/maintenance.rs`: replace the DB-only permissions alert with a self-healing sweep. Hourly maintenance strips the world-read bit from any regular file in `data_dir`, logging an aggregate count. Existing deployments self-heal on the next tick.
  3. `examples/systemd/*.service`: switch `UMask` to `0007` on sensor and agent so new files land at `0660`. Group write preserved so sensor-written files stay appendable by the agent.

## Test plan

- [x] New unit test in `maintenance.rs` covers the self-healing sweep
- [ ] Verify on a deployed host that the next maintenance tick strips `o+r` from pre-existing `0644` files
- [ ] Confirm `DATABASE WORLD-READABLE` alert no longer fires post-deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)