### PR TITLE
feat(agent): filestore retention + jemalloc heap profiling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2092,6 +2092,7 @@ dependencies = [
  "clap",
  "dotenvy",
  "ed25519-dalek 2.2.0",
+ "filetime",
  "flate2",
  "fs2",
  "futures-core",

--- a/crates/agent/Cargo.toml
+++ b/crates/agent/Cargo.toml
@@ -11,7 +11,13 @@ keywords = ["security", "incident-response", "autonomous-defense", "linux", "rus
 categories = ["command-line-utilities", "network-programming"]
 
 [target.'cfg(not(target_os = "macos"))'.dependencies]
-tikv-jemallocator = "0.6"
+# `profiling` compiles the jemalloc heap profiler into the binary; it
+# is inert at runtime until `MALLOC_CONF=prof:true,...` is set, so
+# there is no steady-state overhead. `unprefixed_malloc_on_supported_platforms`
+# is required for `MALLOC_CONF` and the `malloc_conf` weak symbol to
+# be picked up by the runtime. See docs/heap-profile.md for the
+# on-demand workflow.
+tikv-jemallocator = { version = "0.6", features = ["profiling", "unprefixed_malloc_on_supported_platforms"] }
 
 [dependencies]
 innerwarden_core = { path = "../core" }
@@ -77,3 +83,4 @@ local-classifier = ["tract-onnx", "tokenizers"]
 
 [dev-dependencies]
 tower = { version = "0.5", features = ["util"] }
+filetime = "0.2"

--- a/crates/agent/src/config.rs
+++ b/crates/agent/src/config.rs
@@ -2220,6 +2220,24 @@ pub struct DataRetentionConfig {
     /// compression. (default: 7)
     #[serde(default = "default_data_warm_gzip_days")]
     pub warm_gzip_days: usize,
+
+    /// Retention for `filestore/extracted/<shard>/<sha256>.<ext>`
+    /// files captured by the sensor's HTTP body extractor. These
+    /// dedup-by-hash forensic artifacts have no pruning path of
+    /// their own and grow unbounded (observed 6 GB / 44k files on
+    /// prod). Uses mtime rather than filename-date since filenames
+    /// are content hashes. Set to 0 to disable age-based pruning.
+    /// (default: 30)
+    #[serde(default = "default_data_filestore_keep_days")]
+    pub filestore_keep_days: usize,
+
+    /// Hard size cap for the entire `filestore/extracted/` tree in
+    /// megabytes. After the age-based pass runs, oldest files are
+    /// pruned until the total is under this cap. Protects against
+    /// bursty captures overrunning disk between retention ticks.
+    /// Set to 0 to disable the size cap. (default: 2048)
+    #[serde(default = "default_data_filestore_max_size_mb")]
+    pub filestore_max_size_mb: u64,
 }
 
 impl Default for DataRetentionConfig {
@@ -2232,6 +2250,8 @@ impl Default for DataRetentionConfig {
             reports_keep_days: default_data_reports_keep_days(),
             graph_snapshot_keep_days: default_data_graph_snapshot_keep_days(),
             warm_gzip_days: default_data_warm_gzip_days(),
+            filestore_keep_days: default_data_filestore_keep_days(),
+            filestore_max_size_mb: default_data_filestore_max_size_mb(),
         }
     }
 }
@@ -2256,6 +2276,12 @@ fn default_data_graph_snapshot_keep_days() -> usize {
 }
 fn default_data_warm_gzip_days() -> usize {
     7
+}
+fn default_data_filestore_keep_days() -> usize {
+    30
+}
+fn default_data_filestore_max_size_mb() -> u64 {
+    2048
 }
 
 fn default_telegram_min_severity() -> String {

--- a/crates/agent/src/data_retention.rs
+++ b/crates/agent/src/data_retention.rs
@@ -1,6 +1,7 @@
 use std::fs;
 use std::io::{self, BufRead, BufReader, BufWriter, Read, Write};
 use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime};
 
 use chrono::{Local, NaiveDate};
 use flate2::read::GzDecoder;
@@ -152,6 +153,138 @@ pub fn cleanup(data_dir: &Path, cfg: &DataRetentionConfig) -> usize {
     }
 
     removed
+}
+
+/// Prune `filestore/extracted/<shard>/<sha256>.<ext>` forensic
+/// artifacts captured by the sensor's HTTP body extractor. Files are
+/// content-hashed, so filenames carry no date; age comes from mtime.
+///
+/// Two passes:
+/// 1. Drop every file with `now - mtime > keep_days` (skipped when
+///    `keep_days == 0`).
+/// 2. If the surviving tree still exceeds `max_size_mb`, delete the
+///    oldest files until the total is back under the cap (skipped
+///    when `max_size_mb == 0`).
+///
+/// Empty shard directories are removed at the end. Returns
+/// `(files_removed, bytes_freed)`.
+pub fn cleanup_filestore(data_dir: &Path, cfg: &DataRetentionConfig) -> (usize, u64) {
+    let root = data_dir.join("filestore").join("extracted");
+    if !root.exists() {
+        return (0, 0);
+    }
+
+    let now = SystemTime::now();
+    let keep = Duration::from_secs((cfg.filestore_keep_days as u64).saturating_mul(86400));
+    let cap_bytes = cfg.filestore_max_size_mb.saturating_mul(1024 * 1024);
+
+    // (path, size, mtime) for files that survive pass 1.
+    let mut alive: Vec<(PathBuf, u64, SystemTime)> = Vec::new();
+    let mut files_removed = 0usize;
+    let mut bytes_freed: u64 = 0;
+
+    let shards = match fs::read_dir(&root) {
+        Ok(iter) => iter,
+        Err(e) => {
+            warn!(path = %root.display(), "cleanup_filestore: read_dir failed: {e:#}");
+            return (0, 0);
+        }
+    };
+
+    for shard in shards.flatten() {
+        let shard_path = shard.path();
+        let Ok(md) = shard.metadata() else {
+            continue;
+        };
+        if !md.is_dir() {
+            continue;
+        }
+        let files = match fs::read_dir(&shard_path) {
+            Ok(iter) => iter,
+            Err(e) => {
+                warn!(path = %shard_path.display(), "cleanup_filestore: shard read_dir failed: {e:#}");
+                continue;
+            }
+        };
+        for entry in files.flatten() {
+            let Ok(fmd) = entry.metadata() else { continue };
+            if !fmd.is_file() {
+                continue;
+            }
+            let path = entry.path();
+            let size = fmd.len();
+            let mtime = fmd.modified().unwrap_or(now);
+
+            let should_age_prune = cfg.filestore_keep_days > 0
+                && now.duration_since(mtime).map(|d| d > keep).unwrap_or(false);
+
+            if should_age_prune {
+                match fs::remove_file(&path) {
+                    Ok(()) => {
+                        files_removed += 1;
+                        bytes_freed += size;
+                    }
+                    Err(e) => {
+                        warn!(path = %path.display(), "cleanup_filestore: remove failed: {e:#}");
+                        alive.push((path, size, mtime));
+                    }
+                }
+            } else {
+                alive.push((path, size, mtime));
+            }
+        }
+    }
+
+    // Pass 2: size cap (oldest first).
+    if cap_bytes > 0 {
+        let total: u64 = alive.iter().map(|(_, s, _)| *s).sum();
+        if total > cap_bytes {
+            alive.sort_by_key(|(_, _, mtime)| *mtime);
+            let mut to_free = total - cap_bytes;
+            for (path, size, _) in &alive {
+                if to_free == 0 {
+                    break;
+                }
+                match fs::remove_file(path) {
+                    Ok(()) => {
+                        files_removed += 1;
+                        bytes_freed += size;
+                        to_free = to_free.saturating_sub(*size);
+                    }
+                    Err(e) => {
+                        warn!(path = %path.display(), "cleanup_filestore: cap remove failed: {e:#}");
+                    }
+                }
+            }
+        }
+    }
+
+    // Remove shard dirs that became empty.
+    if files_removed > 0 {
+        if let Ok(iter) = fs::read_dir(&root) {
+            for shard in iter.flatten() {
+                let p = shard.path();
+                let is_empty = fs::read_dir(&p)
+                    .map(|mut it| it.next().is_none())
+                    .unwrap_or(false);
+                if is_empty {
+                    let _ = fs::remove_dir(&p);
+                }
+            }
+        }
+    }
+
+    if files_removed > 0 {
+        debug!(
+            files_removed,
+            bytes_freed,
+            keep_days = cfg.filestore_keep_days,
+            cap_mb = cfg.filestore_max_size_mb,
+            "cleanup_filestore: pruned extracted artifacts"
+        );
+    }
+
+    (files_removed, bytes_freed)
 }
 
 /// Spec 030: compress warm-tier JSONL files older than
@@ -688,5 +821,91 @@ mod tests {
         let reader = open_jsonl_or_gz(&raw).unwrap().expect("fallback found");
         let lines: Vec<String> = reader.lines().collect::<Result<_, _>>().unwrap();
         assert_eq!(lines, vec!["log-line-1", "log-line-2"]);
+    }
+
+    // ── filestore retention ────────────────────────────────────────
+
+    fn write_shard_file(root: &Path, shard: &str, name: &str, bytes: &[u8], age_days: u64) {
+        let dir = root.join(shard);
+        fs::create_dir_all(&dir).unwrap();
+        let path = dir.join(name);
+        fs::write(&path, bytes).unwrap();
+        // `chrono::Duration` shadows `std::time::Duration` inside this
+        // test module, so qualify the std variant explicitly.
+        let mtime = SystemTime::now()
+            - std::time::Duration::from_secs(age_days.saturating_mul(86400).saturating_add(60));
+        filetime::set_file_mtime(&path, filetime::FileTime::from_system_time(mtime)).unwrap();
+    }
+
+    #[test]
+    fn filestore_age_prune_removes_old_files_only() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("filestore").join("extracted");
+
+        write_shard_file(&root, "aa", "aa_old.bin", &[0u8; 1024], 40);
+        write_shard_file(&root, "bb", "bb_fresh.bin", &[0u8; 1024], 5);
+
+        let cfg = DataRetentionConfig {
+            filestore_keep_days: 30,
+            filestore_max_size_mb: 0, // size cap disabled
+            ..Default::default()
+        };
+        let (removed, bytes) = cleanup_filestore(tmp.path(), &cfg);
+
+        assert_eq!(removed, 1);
+        assert_eq!(bytes, 1024);
+        assert!(!root.join("aa").exists(), "empty shard should be pruned");
+        assert!(root.join("bb").join("bb_fresh.bin").exists());
+    }
+
+    #[test]
+    fn filestore_size_cap_evicts_oldest_first() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("filestore").join("extracted");
+
+        // Three 1 MB files, all within keep window. Cap at 2 MB.
+        write_shard_file(&root, "aa", "oldest.bin", &vec![1u8; 1_048_576], 3);
+        write_shard_file(&root, "bb", "middle.bin", &vec![2u8; 1_048_576], 2);
+        write_shard_file(&root, "cc", "newest.bin", &vec![3u8; 1_048_576], 1);
+
+        let cfg = DataRetentionConfig {
+            filestore_keep_days: 0, // age pass disabled
+            filestore_max_size_mb: 2,
+            ..Default::default()
+        };
+        let (removed, _) = cleanup_filestore(tmp.path(), &cfg);
+
+        assert_eq!(removed, 1, "only one file needed to get under 2 MB cap");
+        assert!(
+            !root.join("aa").join("oldest.bin").exists(),
+            "oldest file evicted first"
+        );
+        assert!(root.join("bb").join("middle.bin").exists());
+        assert!(root.join("cc").join("newest.bin").exists());
+    }
+
+    #[test]
+    fn filestore_noop_when_root_missing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cfg = DataRetentionConfig::default();
+        let (removed, bytes) = cleanup_filestore(tmp.path(), &cfg);
+        assert_eq!(removed, 0);
+        assert_eq!(bytes, 0);
+    }
+
+    #[test]
+    fn filestore_zero_values_disable_both_passes() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("filestore").join("extracted");
+        write_shard_file(&root, "aa", "ancient.bin", &[0u8; 1024], 999);
+
+        let cfg = DataRetentionConfig {
+            filestore_keep_days: 0,
+            filestore_max_size_mb: 0,
+            ..Default::default()
+        };
+        let (removed, _) = cleanup_filestore(tmp.path(), &cfg);
+        assert_eq!(removed, 0);
+        assert!(root.join("aa").join("ancient.bin").exists());
     }
 }

--- a/crates/agent/src/loops/boot.rs
+++ b/crates/agent/src/loops/boot.rs
@@ -452,6 +452,14 @@ pub(crate) async fn run_agent(cli: crate::Cli) -> Result<()> {
     if removed > 0 {
         info!(removed, "data_retention: cleaned up old files on startup");
     }
+    let (fs_removed, fs_bytes) = data_retention::cleanup_filestore(&cli.data_dir, &cfg.data);
+    if fs_removed > 0 {
+        info!(
+            files = fs_removed,
+            bytes = fs_bytes,
+            "data_retention: pruned filestore on startup"
+        );
+    }
 
     // Build shared agent state
     // Pre-populate blocklist + decision cooldowns from recent (today + yesterday)
@@ -1593,6 +1601,15 @@ pub(crate) async fn run_agent(cli: crate::Cli) -> Result<()> {
                     if removed > 0 {
                         info!(removed, "data_retention: cleaned up old files");
                     }
+                    let (fs_removed, fs_bytes) =
+                        data_retention::cleanup_filestore(&cli.data_dir, &cfg.data);
+                    if fs_removed > 0 {
+                        info!(
+                            files = fs_removed,
+                            bytes = fs_bytes,
+                            "data_retention: pruned filestore"
+                        );
+                    }
 
                     // Spec 030: compress warm-tier JSONL files past the
                     // `warm_gzip_days` threshold. Runs alongside the
@@ -2033,6 +2050,15 @@ pub(crate) async fn run_agent(cli: crate::Cli) -> Result<()> {
                     let removed = data_retention::cleanup(&cli.data_dir, &cfg.data);
                     if removed > 0 {
                         info!(removed, "data_retention: cleaned up old files");
+                    }
+                    let (fs_removed, fs_bytes) =
+                        data_retention::cleanup_filestore(&cli.data_dir, &cfg.data);
+                    if fs_removed > 0 {
+                        info!(
+                            files = fs_removed,
+                            bytes = fs_bytes,
+                            "data_retention: pruned filestore"
+                        );
                     }
                     false
                 }


### PR DESCRIPTION
## Context

Prod memory/disk investigation on 2026-04-22 (see commit message for full numbers). Two problems without a clean in-tree fix:

1. **Filestore 6.1 GB / 44k files** under `filestore/extracted/`. Sensor HTTP body extractor dedups by sha256 but has no pruning path. Grows unbounded until disk pressure.
2. **Agent ~490 MB anon heap** with no way to attribute it to allocation sites. Any tuning is a guess until we can see a real heap profile.

Both fixes ship together — filestore retention ends the growth, jemalloc profiling lets us drill into the agent heap next without another rebuild.

## Filestore retention

New `data_retention::cleanup_filestore` in the agent:

- **Age pass**: drops files older than `filestore_keep_days` by mtime (default **30**, 0 disables).
- **Size cap**: if surviving tree > `filestore_max_size_mb` (default **2048**, 0 disables), evicts oldest-first.
- Empty shard dirs get pruned.
- Wired into the existing `cleanup()` call sites (startup + daily slow-loop tick + maintenance tick).
- Structured log: `data_retention: pruned filestore files=N bytes=B`.

On current prod, first run will free ~5 GB (everything older than 30 days plus cap overshoot).

### Tests (4 new, all pass)

- `filestore_age_prune_removes_old_files_only` — mtime boundary + empty shard cleanup
- `filestore_size_cap_evicts_oldest_first` — cap pass with age pass disabled
- `filestore_noop_when_root_missing` — safe when feature never produced files
- `filestore_zero_values_disable_both_passes` — both knobs honored

## Heap profiling build support

`tikv-jemallocator` features `profiling` and `unprefixed_malloc_on_supported_platforms` now enabled. The sampler stays inert until `MALLOC_CONF=prof:true,...` is set, so steady-state overhead is unchanged.

### One-shot workflow

```bash
sudo install -d -o innerwarden -g innerwarden /var/lib/innerwarden/jeprof
sudo systemctl edit innerwarden-agent
```

Add to the drop-in:

```ini
[Service]
Environment=\"MALLOC_CONF=prof:true,prof_active:true,prof_final:true,lg_prof_sample:19,prof_prefix:/var/lib/innerwarden/jeprof/agent\"
```

Then:

```bash
sudo systemctl daemon-reload && sudo systemctl restart innerwarden-agent
# let it run at least 1h for representative sampling
sudo pkill -USR1 innerwarden-agent   # dumps a heap file
jeprof --show_bytes --tree --nodecount=30 \\
    /usr/local/bin/innerwarden-agent \\
    /var/lib/innerwarden/jeprof/agent.<pid>.<seq>.heap
```

Removing the drop-in and restarting returns to zero-overhead mode. `lg_prof_sample:19` = one sample per ~512 KB, ballpark single-digit percent CPU.

## Test plan

- [x] `make check` (clippy `-D warnings` + fmt) passes
- [x] `make test` passes (exit 0; new tests included in filtered suite)
- [ ] CI validates
- [ ] Post-merge, build release, deploy to prod, verify first filestore sweep logs expected GB freed
- [ ] Post-merge, opt in to profiling for 1h, capture heap, share findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)