### PR TITLE
chore: gitignore .claude-local/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,8 @@ CLAUDE.md
 **/CLAUDE.md
 .claude/
 **/.claude/
+.claude-local/
+**/.claude-local/
 
 # Project docs live in the GitHub wiki, not the repo
 docs/


### PR DESCRIPTION
## Summary

Adds `.claude-local/` (and `**/.claude-local/`) to `.gitignore`. The directory holds operator-private notes that must persist across context resets but never reach the repo:

- Component dependency map
- Canonical sources for operator-visible numbers
- Recurring-bug ledger with required permanent anchors
- Per-session deltas the operator can read at a glance

The directive to read these files at the start of every conversation lives in the (already gitignored) `crates-root/.claude/CLAUDE.md` and the auto-memory index — no other repo file is touched by this change.

## Test plan

- [x] `git check-ignore .claude-local/IMPACT.md` returns ignored
- [x] `git status` does not show any .claude-local entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)