### PR TITLE
feat(agent): add dhat-heap feature flag for heap-budget tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "addr2line"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -344,7 +353,7 @@ dependencies = [
  "bytes",
  "libc",
  "log",
- "object",
+ "object 0.36.7",
  "once_cell",
  "thiserror 1.0.69",
  "tokio",
@@ -383,8 +392,23 @@ dependencies = [
  "core-error",
  "hashbrown 0.15.5",
  "log",
- "object",
+ "object 0.36.7",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "backtrace"
+version = "0.3.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object 0.37.3",
+ "rustc-demangle",
+ "windows-link",
 ]
 
 [[package]]
@@ -1103,6 +1127,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "dhat"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98cd11d84628e233de0ce467de10b8633f4ddaecafadefc86e13b84b8739b827"
+dependencies = [
+ "backtrace",
+ "lazy_static",
+ "mintex",
+ "parking_lot",
+ "rustc-hash 1.1.0",
+ "serde",
+ "serde_json",
+ "thousands",
+]
+
+[[package]]
 name = "dialoguer"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1671,6 +1711,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
+
+[[package]]
 name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2090,6 +2136,7 @@ dependencies = [
  "bytes",
  "chrono",
  "clap",
+ "dhat",
  "dotenvy",
  "ed25519-dalek 2.2.0",
  "filetime",
@@ -2811,6 +2858,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "mintex"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c505b3e17ed6b70a7ed2e67fbb2c560ee327353556120d6e72f5232b6880d536"
+
+[[package]]
 name = "mio"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3032,6 +3085,15 @@ dependencies = [
  "crc32fast",
  "hashbrown 0.15.5",
  "indexmap",
+ "memchr",
+]
+
+[[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
  "memchr",
 ]
 
@@ -3555,7 +3617,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "rustls",
  "socket2",
  "thiserror 2.0.18",
@@ -3575,7 +3637,7 @@ dependencies = [
  "lru-slab",
  "rand 0.9.4",
  "ring",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "rustls",
  "rustls-pki-types",
  "slab",
@@ -4049,6 +4111,18 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
 ]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
@@ -4724,6 +4798,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "thousands"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bf63baf9f5039dadc247375c29eb13706706cfde997d0330d05aa63a77d8820"
 
 [[package]]
 name = "thread_local"

--- a/crates/agent/Cargo.toml
+++ b/crates/agent/Cargo.toml
@@ -74,12 +74,27 @@ rustls-pki-types = "1"
 flate2 = "1"
 tempfile = "3"
 
+# Spec 035 PR-A2: DHAT heap profiler, only pulled in under the
+# `dhat-heap` feature (see [features] below). Replaces the global
+# allocator when enabled; must never ship in a production build.
+dhat = { version = "0.3", optional = true }
+
 [features]
 default = []
 # Enables the local ONNX classifier provider. Adds ~50 MB to the binary from
 # the ONNX runtime static link plus the tokenizer; off by default so users
 # without the classifier model installed don't pay the cost.
 local-classifier = ["tract-onnx", "tokenizers"]
+# Spec 035 PR-A2: swaps the global allocator to DHAT's heap profiler
+# for memory-budget tests. DHAT instruments every allocation and is
+# substantially slower than jemalloc; this feature MUST NOT be enabled
+# for production builds. The two `#[global_allocator]` statics in
+# `main.rs` are cfg-gated so that enabling this feature disables the
+# jemalloc allocator on Linux — Rust's "duplicate lang item" error is
+# the last-line compile-time guarantee that the two allocators cannot
+# be linked simultaneously. Invoke via
+# `cargo test -p innerwarden-agent --features dhat-heap ...`.
+dhat-heap = ["dep:dhat"]
 
 [dev-dependencies]
 tower = { version = "0.5", features = ["util"] }

--- a/crates/agent/src/main.rs
+++ b/crates/agent/src/main.rs
@@ -8,9 +8,33 @@
 // Use jemalloc on Linux - the default glibc allocator fragments memory and
 // never returns it to the OS, causing apparent "leaks" under sustained load.
 // jemalloc aggressively returns unused pages via madvise(MADV_DONTNEED).
-#[cfg(not(target_os = "macos"))]
+//
+// Spec 035 PR-A2 phase 1: this allocator is disabled when the
+// `dhat-heap` feature is active so DHAT's allocator can take its
+// place for heap-budget tests. The two `#[global_allocator]` statics
+// below are mutually exclusive by cfg construction:
+//   - jemalloc:  cfg(all(not(target_os = "macos"), not(feature = "dhat-heap")))
+//   - dhat:      cfg(feature = "dhat-heap")
+// These cfg gates cannot both match simultaneously, so only one
+// `#[global_allocator]` ever exists in a given build. If a future
+// refactor breaks this invariant Rust emits "duplicate lang item"
+// and the build fails — that diagnostic IS the compile-time guarantee
+// (an explicit `compile_error!` macro cannot observe the state of
+// another cfg-gated item without producing the same duplicate-lang
+// error first).
+#[cfg(all(not(target_os = "macos"), not(feature = "dhat-heap")))]
 #[global_allocator]
 static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
+// Spec 035 PR-A2 phase 1: DHAT global allocator. Replaces jemalloc
+// (Linux) or the system allocator (macOS) when the `dhat-heap`
+// feature is active. DHAT records every allocation, so this binary
+// runs noticeably slower and MUST NOT ship to production. The feature
+// exists to drive heap-budget regression tests under
+// `cargo test -p innerwarden-agent --features dhat-heap ...`.
+#[cfg(feature = "dhat-heap")]
+#[global_allocator]
+static DHAT_ALLOC: dhat::Alloc = dhat::Alloc;
 
 // Spec 030: embed jemalloc runtime configuration in the binary so
 // operators do not need to set a MALLOC_CONF env var to get


### PR DESCRIPTION
## Summary

**Spec 035 PR-A2 phase 1 of 5** — allocator plumbing only. **No tests added yet. No CI changes yet. No production behavior change.**

Adds a new opt-in `dhat-heap` cargo feature that swaps the agent's global allocator from jemalloc (Linux) / system (macOS) to DHAT's heap profiler. Phases 2-5 (the actual heap-budget tests, calibration, CI gate, and doc updates) ship as separate PRs under operator approval.

## What changes

| File | Delta |
|---|---|
| `crates/agent/Cargo.toml` | +15 lines: optional `dhat = \"0.3\"` dep + `dhat-heap = [\"dep:dhat\"]` feature |
| `crates/agent/src/main.rs` | +26 lines: cfg-gated second `#[global_allocator]` + invariant commentary |
| `Cargo.lock` | +88 lines auto-managed |

## Allocator mutual exclusion

Two `#[global_allocator]` statics with disjoint cfg gates:

```rust
#[cfg(all(not(target_os = \"macos\"), not(feature = \"dhat-heap\")))]
static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;

#[cfg(feature = \"dhat-heap\")]
static DHAT_ALLOC: dhat::Alloc = dhat::Alloc;
```

The gates cannot both match in a single build. If a future edit breaks the invariant and both statics compile simultaneously, Rust emits \"duplicate lang item\" and the build fails — that diagnostic IS the compile-time guarantee the operator asked for. An explicit `compile_error!` macro cannot observe \"both gates matched\" without Rust already having rejected the build; the duplicate-lang-item error from rustc is the correct failure mode. The invariant is documented in-line at both `#[global_allocator]` declarations and in the feature description in `Cargo.toml`.

## Verification (all four operator-specified gates)

| Gate | Result |
|---|---|
| `cargo build -p innerwarden-agent` (default, jemalloc) | ✅ clean |
| `cargo build -p innerwarden-agent --features dhat-heap` (DHAT) | ✅ clean, dhat 0.3.3 linked |
| `cargo test --workspace` (default) | ✅ **4396 pass**, 4 ignored, 0 fail |
| `cargo test -p innerwarden-agent --features dhat-heap` | ✅ **1826 pass**, 1 ignored, 0 fail — every agent test runs cleanly with DHAT as the global allocator (confirms DHAT is functionally transparent, only performance differs) |
| `cargo fmt --all --check` | ✅ clean |
| `cargo clippy --workspace -- -D warnings` (default) | ✅ clean |
| `cargo clippy -p innerwarden-agent --features dhat-heap -- -D warnings` | ✅ clean |

## Why stop here

Keeping plumbing isolated means a regression in any later phase cannot corrupt the allocator path. The operator reviews and merges this phase independently; phases 2-5 proceed only on explicit approval.

## What phases 2-5 will cover (not in this PR)

- **Phase 2**: `save_to_store_under_5MB_per_call` inline test in `knowledge_graph/persistence.rs`.
- **Phase 3**: `slow_loop_tick_under_10MB_per_tick` inline test in `loops/slow_loop.rs`.
- **Phase 4**: `boot_total_alloc_under_500MB` inline test in `loops/boot.rs`.
- **Phase 5**: CI job wiring + `.claude-local/IMPACT.md` baseline documentation + `RECURRING_BUGS.md` anchored-status update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)