### PR TITLE
ci(agent): add Heap Budget workflow for DHAT regression gates

### DIFF
--- a/.github/workflows/heap-budget.yml
+++ b/.github/workflows/heap-budget.yml
@@ -1,0 +1,48 @@
+name: Heap Budget
+
+# Spec 035 PR-A2 phase 5: CI gate for the three DHAT heap-budget
+# anchors. Fails the PR if any of the following allocates more than
+# its baselined budget (baseline × 1.10, rounded up to 100 KiB):
+#
+#   - knowledge_graph::persistence::heap_budget
+#       ::save_to_store_allocates_under_budget
+#   - loops::slow_loop::heap_budget
+#       ::process_narrative_tick_allocates_under_budget
+#   - loops::boot::heap_budget
+#       ::run_agent_once_allocates_under_budget
+#
+# A deliberate raise requires updating the BUDGET_TOTAL_BYTES constant
+# in the relevant module AND the matching line in
+# `.claude-local/IMPACT.md` "Memory layout" in the same PR, with the
+# reason. See the module-level doc comments for the full policy.
+#
+# Runs ~45-60 s wall-clock in CI under DHAT instrumentation (DHAT is
+# ~6× slower than jemalloc). `--test-threads=1` is MANDATORY — DHAT's
+# HeapStats counter is process-global and concurrent tests contaminate
+# the delta.
+
+on:
+  push:
+    branches:
+      - main
+      - develop
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  heap-budget:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
+
+      - name: Cache cargo artifacts
+        uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
+
+      - name: Run heap-budget tests under DHAT
+        run: make heap-budget

--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,19 @@ fuzz-quick:
 		(cd fuzz && cargo +nightly fuzz run $$target -- -max_total_time=$(FUZZ_DURATION)) || exit 1; \
 	done
 
+# Spec 035 PR-A2: heap-budget regression gate via DHAT-instrumented
+# allocator. Runs the three anchors in
+#   crates/agent/src/knowledge_graph/persistence.rs (save_to_store)
+#   crates/agent/src/loops/slow_loop.rs           (narrative tick)
+#   crates/agent/src/loops/boot.rs                (run_agent once-mode)
+# Each asserts cumulative allocation churn (DHAT total_bytes) stays
+# under a baseline-derived budget. `--test-threads=1` is MANDATORY —
+# DHAT's counter is process-global and concurrent tests contaminate
+# the delta (see module-level comments in each file for detail).
+.PHONY: heap-budget
+heap-budget:
+	cargo test -p innerwarden-agent --features dhat-heap heap_budget -- --test-threads=1
+
 # ─── Cross-compile for Linux arm64 ───────────────────────────────────────────
 
 .PHONY: build-linux


### PR DESCRIPTION
## Summary

**Spec 035 PR-A2 phase 5 of 5 — final phase closing the entire spec 035 arc.** Wires the three DHAT heap-budget anchors (from phases 2-4) into CI so regressions block the PR instead of drifting into production.

Public delta: 2 files, 61 lines.

## What ships (public)

- **`Makefile`** — new `heap-budget` target:
  ```
  cargo test -p innerwarden-agent --features dhat-heap heap_budget \\
      -- --test-threads=1
  ```
  Filters to the three `heap_budget` test modules only (runs in 0.27 s after build). `--test-threads=1` is MANDATORY — DHAT's HeapStats counter is process-global, concurrent tests contaminate the delta.
- **`.github/workflows/heap-budget.yml`** — new `Heap Budget` workflow. Triggers on `pull_request` + pushes to `main` / `develop`. Pinned action SHAs matching the repo convention. Invokes `make heap-budget` as its single step.

## What the gate enforces

Three DHAT `total_bytes` budgets, all landed in phases 2-4:

| Anchor | Baseline | Budget | Headroom |
|---|---|---|---|
| `save_to_store_allocates_under_budget` | 2.47 MiB | 2.73 MiB | ~10.7 % |
| `process_narrative_tick_allocates_under_budget` | 0.46 MiB | 0.586 MiB | ~26.5 % |
| `run_agent_once_allocates_under_budget` | 1.61 MiB | 1.86 MiB | ~15.4 % |

Each budget = `ceil(baseline × 1.10 / 100 KiB) × 100 KiB`. Headroom varies above the nominal 10 % where the 100 KiB rounding falls between boundaries.

A deliberate raise requires updating `BUDGET_TOTAL_BYTES` in the relevant module AND the corresponding row in `.claude-local/IMPACT.md` \"Memory layout\", in the same PR, with the reason. Enforced by operator review.

## Known limitation

DHAT `total_bytes` measures cumulative allocator **churn** — blind to **retention** regressions (state that grows without bound while churn stays flat). A `curr_bytes`-at-steady-state gate would catch that; documented as future work in `RECURRING_BUGS.md` but not a spec 035 deliverable.

## Verification

| Gate | Result |
|---|---|
| `make heap-budget` | ✅ 3 pass in 0.27 s (post-build) |
| `cargo build -p innerwarden-agent` (default) | ✅ clean |
| `cargo test --workspace` (default) | ✅ **4396 pass**, 4 ignored, 0 fail |
| `cargo fmt --all --check` | ✅ clean |
| Workflow YAML shape matches `ci.yml` and `fuzz.yml` conventions (pinned SHAs, same cache + toolchain actions) | ✅ |

## Local-only doc updates (gitignored, not in this PR)

- `.claude-local/IMPACT.md` \"Memory layout\" — new sub-section \"DHAT heap-budget CI gate\" with baseline table, raise policy, `--test-threads=1` mandate, jemalloc↔DHAT incompatibility note.
- `.claude-local/RECURRING_BUGS.md` \"Memory regressions on follow-up PRs\" — status flipped from NOT IMPLEMENTED to **ANCHORED** with cross-references.
- `.claude-local/SESSION_LOG.md` — new top entry covering spec 035 closure.
- `.specify/features/035-stabilization-v0-anchors/spec.md` — A2 section rewritten to [LANDED] with 5-phase PR table + 5 documented deviations.

## Spec 035 closure summary

All five A-series anchors now merged:

| PR | Anchor |
|---|---|
| #264 | A1 — count-consistency anchor |
| #265 | A4 — `/metrics` spawn_blocking |
| #266 | A5 — `#[serde(default)]` on `core::Event` + `core::Incident` |
| #267 | A3 — KG ingest never-panic property test + 1M soak |
| #268 | A2 phase 1 — dhat-heap feature + allocator plumbing |
| #269 | A2 phase 2 — `save_to_store` anchor |
| #270 | A2 phase 3 — `process_narrative_tick` anchor |
| #271 | A2 phase 4 — `run_agent` once-mode boot anchor |
| **this PR** | A2 phase 5 — CI workflow + Makefile + docs |

The two recurring-bug classes the operator flagged as the highest-value trust bleed (\"Dashboard count != Site count\" and \"Memory regressions on follow-up PRs\") are now under standing CI gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)