### PR TITLE
feat(agent): add TaskGroup primitive for graceful shutdown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2143,6 +2143,7 @@ dependencies = [
  "flate2",
  "fs2",
  "futures-core",
+ "futures-util",
  "hkdf 0.12.4",
  "hmac 0.12.1",
  "innerwarden-agent-guard",
@@ -2173,6 +2174,7 @@ dependencies = [
  "tokenizers",
  "tokio",
  "tokio-stream",
+ "tokio-util",
  "toml 1.1.2+spec-1.1.0",
  "tower",
  "tower-http",
@@ -4980,6 +4982,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "futures-util",
  "pin-project-lite",
  "tokio",
 ]

--- a/crates/agent/Cargo.toml
+++ b/crates/agent/Cargo.toml
@@ -39,7 +39,17 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["full"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
+# Spec 036 (I-04 graceful shutdown) — TaskTracker for joinable task
+# registration, CancellationToken for cooperative cancel. The "rt"
+# feature pulls in `task::TaskTracker`; the default features cover
+# `sync::CancellationToken`.
+tokio-util = { version = "0.7", features = ["rt"] }
 futures-core = "0.3"
+# Spec 036 — `FutureExt::catch_unwind` for per-task panic isolation
+# in `TaskGroup::spawn`. Used to log the panic via tracing::error!
+# with the task name before re-raising (preserves JoinError::is_panic
+# for explicit handlers).
+futures-util = "0.3"
 axum = { version = "0.7", features = ["json"] }
 tower-http = { version = "0.6", features = ["cors"] }
 argon2 = "0.5"

--- a/crates/agent/src/main.rs
+++ b/crates/agent/src/main.rs
@@ -155,6 +155,12 @@ mod slack;
 #[allow(dead_code)]
 mod soc_checks;
 mod state_store;
+// Spec 036 (audit I-04) PR-1: TaskGroup primitive. All items are
+// `pub(crate)` and unused during this PR; the `dead_code` allowance
+// goes away with the first migration (decision_writer / telegram
+// batcher / pcap_capture) in the follow-up PR.
+#[allow(dead_code)]
+mod task_group;
 mod telegram;
 mod telemetry;
 mod telemetry_tick;

--- a/crates/agent/src/task_group.rs
+++ b/crates/agent/src/task_group.rs
@@ -1,0 +1,526 @@
+//! TaskGroup — unified graceful shutdown for the agent's tokio tasks.
+//!
+//! Spec 036 (audit I-04) step 1 of N: this PR ships the PRIMITIVE only.
+//! No existing `tokio::spawn` call site is migrated in this PR. The
+//! first migration batch (decision_writer + telegram batcher +
+//! pcap_capture) lands in the follow-up PR.
+//!
+//! # Why this exists
+//!
+//! Before this primitive, the agent had ~59 raw `tokio::spawn` calls
+//! across 59 files. SIGTERM at the wrong instant could kill:
+//!   - decision_writer mid-flush (corrupts the audit trail hash chain),
+//!   - telegram batcher mid-send (drops the last 60 s of alerts),
+//!   - pcap_capture mid-write (produces a truncated pcap file),
+//!   - skill executor mid-block (leaves ufw/iptables state divergent
+//!     from the agent's in-memory `xdp_block_times` map).
+//!
+//! Combined with the "three-place writes" pattern documented as audit
+//! I-02 (graph snapshots written to SQLite + JSON + in-memory caches
+//! without a cross-store transaction), a mid-write SIGTERM is exactly
+//! how the two recurring bug classes in `.claude-local/RECURRING_BUGS.md`
+//! ("Dashboard count != Site count" and "Memory regressions on
+//! follow-up PRs") actually recur. The anchors shipped in spec 035
+//! catch divergence AFTER the fact; `TaskGroup` is the infrastructure
+//! that stops producing divergence in the first place.
+//!
+//! # API summary
+//!
+//! ```ignore
+//! let tg = TaskGroup::new();
+//!
+//! // Register a task. The task's JoinHandle is tracked; on graceful
+//! // shutdown the group waits for it with a deadline.
+//! let handle = tg.spawn("decision-writer", async move {
+//!     let token = tg.token();
+//!     loop {
+//!         tokio::select! {
+//!             _ = token.cancelled() => break,
+//!             work = next_work() => do_work(work).await,
+//!         }
+//!     }
+//! })?;
+//!
+//! // Signal cancel + join with deadline.
+//! let report = tg.shutdown(Duration::from_secs(5)).await;
+//! if report.timed_out > 0 {
+//!     tracing::warn!(
+//!         timed_out = report.timed_out,
+//!         "TaskGroup shutdown abandoned tasks past deadline"
+//!     );
+//! }
+//! ```
+//!
+//! # Panic semantics (the operator's hard requirement)
+//!
+//! A task that panics must not be silently dropped. This primitive
+//! guarantees three things:
+//!
+//!   1. **Panic does not kill sibling tasks.** Every task runs in
+//!      its own tokio task slot; tokio already isolates panics there,
+//!      and `TaskGroup::spawn` does not change that. Anchored by
+//!      `panic_in_one_task_does_not_affect_others`.
+//!
+//!   2. **Panic is visible to callers via JoinHandle.** The spawned
+//!      future is wrapped in `futures_util::FutureExt::catch_unwind`
+//!      so the panic is captured, logged, and then re-raised via
+//!      `std::panic::resume_unwind`. `JoinHandle::await` returns
+//!      `Err(JoinError)` with `is_panic() == true`; callers that
+//!      explicitly poll the handle can detect and escalate. Anchored
+//!      by `panic_surfaces_via_join_handle_not_silently_dropped`.
+//!
+//!   3. **Panic is logged with the task name via `tracing::error!`.**
+//!      Before the panic is re-raised, the wrapper emits an
+//!      `ERROR task=<name> panic=<message>` event so the operator
+//!      log stream shows the failure without any caller having to
+//!      observe the JoinHandle. Verified during implementation;
+//!      programmatic capture of the log event is deferred to a
+//!      follow-up dev-tools PR (the essential invariant — panic is
+//!      not silently dropped — is anchored by JoinHandle test above).
+
+use std::future::Future;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use futures_util::FutureExt;
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
+use tokio_util::task::TaskTracker;
+use tracing::error;
+
+/// Reasons a `TaskGroup` operation can fail.
+///
+/// The only failure mode today is attempting to `spawn` after the
+/// group has been shut down. Adding a variant is a **breaking
+/// change** for callers that match on the enum — flag it in the
+/// PR that introduces the new variant.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum TaskGroupError {
+    /// The TaskGroup has already been shut down. New spawns are
+    /// rejected; callers must decide whether to log, propagate, or
+    /// recreate the group.
+    Closed,
+}
+
+impl std::fmt::Display for TaskGroupError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Closed => {
+                write!(f, "cannot spawn: TaskGroup has been shut down")
+            }
+        }
+    }
+}
+
+impl std::error::Error for TaskGroupError {}
+
+/// Report returned from `TaskGroup::shutdown`. Counts are snapshots
+/// from the moment `shutdown` entered — tasks that finished AFTER
+/// the shutdown signal but BEFORE the deadline are `joined`; tasks
+/// that were still running when the deadline elapsed are `timed_out`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ShutdownReport {
+    /// Tasks alive at the moment `shutdown` was called.
+    pub total: usize,
+    /// Tasks that completed within the deadline (panics count as
+    /// completed — the panic was logged and the slot is freed).
+    pub joined: usize,
+    /// Tasks still running when the deadline elapsed. Operator log +
+    /// alert territory.
+    pub timed_out: usize,
+}
+
+/// A group of tokio tasks with unified graceful shutdown.
+///
+/// Cheap to clone — the backing state is `Arc`-wrapped, so every
+/// clone observes the same tracker and cancellation token. The typical
+/// usage pattern is: build one group at boot, clone it into each place
+/// that needs to spawn or observe cancellation, call `shutdown` once
+/// from the SIGTERM handler.
+///
+/// See the module doc for the panic and cancellation contracts.
+#[derive(Clone)]
+pub(crate) struct TaskGroup {
+    inner: Arc<TaskGroupInner>,
+}
+
+struct TaskGroupInner {
+    tracker: TaskTracker,
+    token: CancellationToken,
+    /// Explicit closed-state gate. `Mutex<bool>` (not `AtomicBool`)
+    /// so `spawn` can hold the lock across the `tracker.spawn()` call
+    /// and block any concurrent `shutdown` from racing a silent-drop
+    /// into the tracker. The lock is held for microseconds and is
+    /// never held across `.await`, so contention is not a concern.
+    closed: Mutex<bool>,
+}
+
+impl TaskGroup {
+    pub(crate) fn new() -> Self {
+        Self {
+            inner: Arc::new(TaskGroupInner {
+                tracker: TaskTracker::new(),
+                token: CancellationToken::new(),
+                closed: Mutex::new(false),
+            }),
+        }
+    }
+
+    /// Spawn a task in the group.
+    ///
+    /// Returns `Err(TaskGroupError::Closed)` if the group has already
+    /// been shut down. This is an explicit rejection, not a silent
+    /// drop — the operator's hard requirement per the audit.
+    ///
+    /// The spawned future is wrapped so that panics are logged via
+    /// `tracing::error!` with the given name and then re-raised; the
+    /// `JoinHandle` surfaces the panic via `JoinError::is_panic()`.
+    /// See the module doc for the full panic contract.
+    pub(crate) fn spawn<F>(
+        &self,
+        name: &'static str,
+        fut: F,
+    ) -> Result<JoinHandle<()>, TaskGroupError>
+    where
+        F: Future<Output = ()> + Send + 'static,
+    {
+        // Hold the closed-state lock across the tracker.spawn() call.
+        // Without this, a concurrent `shutdown` could close the
+        // tracker between our check and the spawn, producing a
+        // silent-drop (TaskTracker returns a JoinHandle that never
+        // runs on a closed tracker). The lock is released as soon
+        // as `tracker.spawn` returns — before the future runs.
+        let closed = self
+            .inner
+            .closed
+            .lock()
+            .expect("TaskGroup closed mutex poisoned");
+        if *closed {
+            return Err(TaskGroupError::Closed);
+        }
+
+        let handle = self.inner.tracker.spawn(wrap_with_panic_log(name, fut));
+        Ok(handle)
+    }
+
+    /// Cancellation token shared by every task in the group. Tasks
+    /// are expected to co-operate by polling this token in their
+    /// event loops, typically via `tokio::select!`.
+    pub(crate) fn token(&self) -> CancellationToken {
+        self.inner.token.clone()
+    }
+
+    /// Signal cancel to every registered task and wait for them to
+    /// complete, up to `deadline`. After return the group is closed;
+    /// `spawn` will reject with `TaskGroupError::Closed`.
+    ///
+    /// Calling `shutdown` twice is safe: the second call observes
+    /// `closed == true` and the tracker already empty, so it returns
+    /// an all-zero `ShutdownReport` immediately without re-cancelling.
+    pub(crate) async fn shutdown(&self, deadline: Duration) -> ShutdownReport {
+        // Flip closed under the lock so in-flight spawns either beat
+        // us (they succeed; we include them in `total`) or see
+        // `closed == true` (they get Err).
+        {
+            let mut closed = self
+                .inner
+                .closed
+                .lock()
+                .expect("TaskGroup closed mutex poisoned");
+            *closed = true;
+        }
+
+        let total = self.inner.tracker.len();
+        self.inner.token.cancel();
+        self.inner.tracker.close();
+
+        // `tracker.wait()` returns when every tracked task has finished
+        // (regardless of success/panic). Wrap in timeout so we
+        // surface "tasks still running past deadline" rather than
+        // hanging indefinitely.
+        let deadline_result = tokio::time::timeout(deadline, self.inner.tracker.wait()).await;
+        let remaining = self.inner.tracker.len();
+
+        match deadline_result {
+            Ok(()) => ShutdownReport {
+                total,
+                joined: total,
+                timed_out: 0,
+            },
+            Err(_elapsed) => ShutdownReport {
+                total,
+                joined: total.saturating_sub(remaining),
+                timed_out: remaining,
+            },
+        }
+    }
+
+    /// Count of currently-alive tasks. Primarily for tests and
+    /// `tracing::debug!` instrumentation.
+    #[allow(dead_code)] // used by tests + future migration PRs
+    pub(crate) fn len(&self) -> usize {
+        self.inner.tracker.len()
+    }
+
+    #[allow(dead_code)] // used by tests + future migration PRs
+    pub(crate) fn is_empty(&self) -> bool {
+        self.inner.tracker.is_empty()
+    }
+}
+
+/// Wrap a future so that a panic during polling is logged via
+/// `tracing::error!` before being re-raised. The re-raise preserves
+/// `JoinError::is_panic()` semantics for callers that explicitly
+/// observe the JoinHandle.
+async fn wrap_with_panic_log<F>(name: &'static str, fut: F)
+where
+    F: Future<Output = ()> + Send + 'static,
+{
+    // `AssertUnwindSafe` tells the compiler to trust that a panic
+    // inside the future leaves observable state consistent. For
+    // our tasks (async fns without shared interior-mutable state
+    // across panic points), this holds. Callers that capture
+    // `RefCell<T>` mid-mutation into the future should handle
+    // panics themselves before reaching this wrapper.
+    let result = std::panic::AssertUnwindSafe(fut).catch_unwind().await;
+    if let Err(panic_payload) = result {
+        let msg = extract_panic_message(&panic_payload);
+        error!(
+            task = name,
+            panic = %msg,
+            "task panicked (isolated; siblings continue)"
+        );
+        // Re-raise so `JoinHandle::await` still returns
+        // `Err(JoinError)` with `is_panic() == true`. The panic
+        // is NEVER silently dropped — log above guarantees
+        // operator visibility; JoinHandle guarantees caller-side
+        // observability.
+        std::panic::resume_unwind(panic_payload);
+    }
+}
+
+/// Best-effort extraction of a human-readable message from a panic
+/// payload. Panic payloads are `Box<dyn Any + Send>`, typically a
+/// `&'static str` (from `panic!("literal")`) or a `String` (from
+/// `panic!("formatted {x}")`). Other types produce a generic message
+/// so the log line is never silent, just less informative.
+fn extract_panic_message(payload: &Box<dyn std::any::Any + Send>) -> String {
+    if let Some(s) = payload.downcast_ref::<&'static str>() {
+        (*s).to_string()
+    } else if let Some(s) = payload.downcast_ref::<String>() {
+        s.clone()
+    } else {
+        "<non-string panic payload>".to_string()
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    #[tokio::test]
+    async fn spawn_and_await_single_task_returns_ok() {
+        let tg = TaskGroup::new();
+        let handle = tg.spawn("noop", async { /* nothing */ }).expect("spawn");
+        handle.await.expect("task completes cleanly");
+        assert_eq!(tg.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn multiple_tasks_complete_independently() {
+        let tg = TaskGroup::new();
+        let counter = Arc::new(AtomicU32::new(0));
+
+        let mut handles = Vec::new();
+        for i in 0..5 {
+            let c = counter.clone();
+            let handle = tg
+                .spawn("counter", async move {
+                    tokio::time::sleep(Duration::from_millis(20 * (i + 1))).await;
+                    c.fetch_add(1, Ordering::SeqCst);
+                })
+                .expect("spawn");
+            handles.push(handle);
+        }
+
+        for h in handles {
+            h.await.expect("task completes");
+        }
+        assert_eq!(counter.load(Ordering::SeqCst), 5);
+        assert_eq!(tg.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn shutdown_waits_for_tasks_within_deadline() {
+        let tg = TaskGroup::new();
+
+        for _ in 0..3 {
+            tg.spawn("short-sleep", async {
+                tokio::time::sleep(Duration::from_millis(50)).await;
+            })
+            .expect("spawn");
+        }
+
+        let report = tg.shutdown(Duration::from_secs(1)).await;
+        assert_eq!(report.total, 3);
+        assert_eq!(report.joined, 3);
+        assert_eq!(report.timed_out, 0);
+    }
+
+    #[tokio::test]
+    async fn shutdown_reports_timeout_when_deadline_exceeded() {
+        let tg = TaskGroup::new();
+
+        // Task that deliberately ignores the cancellation token to
+        // force the timeout path. Real production tasks should poll
+        // the token; this fixture is the failure-mode anchor.
+        tg.spawn("uncooperative", async {
+            tokio::time::sleep(Duration::from_secs(10)).await;
+        })
+        .expect("spawn");
+
+        let report = tg.shutdown(Duration::from_millis(100)).await;
+        assert_eq!(report.total, 1);
+        assert_eq!(report.timed_out, 1);
+        assert_eq!(report.joined, 0);
+    }
+
+    #[tokio::test]
+    async fn cancellation_token_propagates_to_spawned_tasks() {
+        let tg = TaskGroup::new();
+        let token = tg.token();
+        let was_cancelled = Arc::new(AtomicU32::new(0));
+
+        let w = was_cancelled.clone();
+        tg.spawn("co-operative", async move {
+            tokio::select! {
+                _ = token.cancelled() => {
+                    w.store(1, Ordering::SeqCst);
+                }
+                _ = tokio::time::sleep(Duration::from_secs(10)) => {
+                    // should not reach — the test cancels well before
+                    // this sleep resolves.
+                    w.store(2, Ordering::SeqCst);
+                }
+            }
+        })
+        .expect("spawn");
+
+        // Let the task reach the select!.
+        tokio::time::sleep(Duration::from_millis(10)).await;
+
+        let report = tg.shutdown(Duration::from_secs(1)).await;
+        assert_eq!(report.total, 1);
+        assert_eq!(
+            report.joined, 1,
+            "cancel must drain the task within deadline"
+        );
+        assert_eq!(report.timed_out, 0);
+        assert_eq!(
+            was_cancelled.load(Ordering::SeqCst),
+            1,
+            "task must have exited via the cancelled() branch, not the sleep branch"
+        );
+    }
+
+    #[tokio::test]
+    async fn panic_in_one_task_does_not_affect_others() {
+        let tg = TaskGroup::new();
+        let survivors = Arc::new(AtomicU32::new(0));
+
+        // Panicker — runs first and loudly fails.
+        let panic_handle = tg
+            .spawn("deliberate-panicker", async {
+                panic!("this panic is part of the test — expected");
+            })
+            .expect("spawn panicker");
+
+        // Two survivors — should complete normally despite the
+        // sibling panic.
+        for _ in 0..2 {
+            let s = survivors.clone();
+            tg.spawn("survivor", async move {
+                tokio::time::sleep(Duration::from_millis(30)).await;
+                s.fetch_add(1, Ordering::SeqCst);
+            })
+            .expect("spawn survivor");
+        }
+
+        // Await each explicitly so we can observe the panic on the
+        // panicker without killing the test via the re-raise.
+        let panicker_result = panic_handle.await;
+        assert!(
+            panicker_result.is_err(),
+            "JoinHandle must surface the panic as Err"
+        );
+
+        // Drain survivors with a generous deadline.
+        let report = tg.shutdown(Duration::from_secs(1)).await;
+        assert_eq!(
+            survivors.load(Ordering::SeqCst),
+            2,
+            "both non-panicking tasks must have completed"
+        );
+        assert_eq!(
+            report.timed_out, 0,
+            "shutdown must have drained all survivors"
+        );
+    }
+
+    #[tokio::test]
+    async fn panic_surfaces_via_join_handle_not_silently_dropped() {
+        let tg = TaskGroup::new();
+        let handle = tg
+            .spawn("deliberate-panic", async {
+                panic!("boom from test body");
+            })
+            .expect("spawn");
+
+        let err = handle.await.expect_err(
+            "panicking task must surface an error — silent drop is the bug this guards against",
+        );
+        assert!(err.is_panic(), "JoinError must report is_panic() = true");
+
+        let payload = err.into_panic();
+        let msg = payload
+            .downcast_ref::<&'static str>()
+            .copied()
+            .map(str::to_string)
+            .or_else(|| payload.downcast_ref::<String>().cloned())
+            .expect("panic payload must be string-like for this fixture");
+        assert!(
+            msg.contains("boom"),
+            "panic payload must be recoverable for caller-side inspection: got {msg:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn spawn_after_shutdown_returns_closed_error() {
+        let tg = TaskGroup::new();
+        let _ = tg.shutdown(Duration::from_millis(50)).await;
+
+        let result = tg.spawn("post-shutdown", async {});
+        assert_eq!(
+            result.err(),
+            Some(TaskGroupError::Closed),
+            "spawn after shutdown MUST return Err, not silently drop the task"
+        );
+    }
+
+    #[tokio::test]
+    async fn shutdown_is_idempotent() {
+        // Belt-and-suspenders: calling shutdown twice must not panic
+        // and must report an empty group the second time.
+        let tg = TaskGroup::new();
+        let first = tg.shutdown(Duration::from_millis(50)).await;
+        let second = tg.shutdown(Duration::from_millis(50)).await;
+        assert_eq!(first.total, 0);
+        assert_eq!(second.total, 0);
+        assert_eq!(second.timed_out, 0);
+    }
+}


### PR DESCRIPTION
## Summary

**Spec 036 (audit I-04) PR-1 of N.** Ships the TaskGroup primitive ONLY. ZERO existing `tokio::spawn` call site is migrated. The first migration batch (decision_writer + telegram batcher + pcap_capture) lands in the follow-up PR under operator approval.

No production behavior change. The module is registered as `#[allow(dead_code)] mod task_group;` in main.rs; the allowance goes away with the first migration.

## API

```rust
let tg = TaskGroup::new();

let handle = tg.spawn(\"decision-writer\", async move {
    let token = tg.token();
    loop {
        tokio::select! {
            _ = token.cancelled() => break,
            work = next_work() => do_work(work).await,
        }
    }
})?;

let report = tg.shutdown(Duration::from_secs(5)).await;
if report.timed_out > 0 {
    tracing::warn!(timed_out = report.timed_out, \"shutdown abandoned tasks\");
}
```

- `spawn(name, fut) -> Result<JoinHandle<()>, TaskGroupError>` — explicit `Err(Closed)` after shutdown, never silent drop.
- `token() -> CancellationToken` — cooperative cancel, idiomatic via `tokio::select!`.
- `shutdown(deadline) -> ShutdownReport { total, joined, timed_out }` — cancel + close + wait with timeout.

Backed by `tokio_util::task::TaskTracker` + `CancellationToken`. Clone is cheap (Arc inc).

## Panic contract (the operator's hard requirement — tested)

Three guarantees, documented in module rustdoc:

1. **Panic does not kill sibling tasks.** Anchored by `panic_in_one_task_does_not_affect_others`.
2. **Panic is visible via JoinHandle.** Spawned future wrapped in `futures_util::FutureExt::catch_unwind`, panic is captured + logged + re-raised via `std::panic::resume_unwind`, `JoinHandle::await` returns `Err(JoinError)` with `is_panic() == true`. Anchored by `panic_surfaces_via_join_handle_not_silently_dropped`.
3. **Panic is logged via `tracing::error!`** with `task=<name>` and `panic=<message>` BEFORE the re-raise. Programmatic log-capture deferred (would add dev-dep or 50 LOC subscriber plumbing for one test); the essential non-silent-drop invariant is anchored by the JoinHandle test.

## Shutdown contract (tested)

- `spawn()` holds an internal closed-state lock across `tracker.spawn()` to prevent silent-drop race with concurrent `shutdown()`. Lock never held across `.await`.
- `spawn_after_shutdown_returns_closed_error` — explicit `Err`, not silent drop. Per operator's adjustment to the original plan.
- `shutdown_is_idempotent` — calling twice is safe and reports total=0 on the second call.

## Test summary (9 `#[tokio::test]`, all green, 0.11 s wall-clock)

- `spawn_and_await_single_task_returns_ok`
- `multiple_tasks_complete_independently`
- `shutdown_waits_for_tasks_within_deadline`
- `shutdown_reports_timeout_when_deadline_exceeded`
- `cancellation_token_propagates_to_spawned_tasks`
- `panic_in_one_task_does_not_affect_others`
- `panic_surfaces_via_join_handle_not_silently_dropped`
- `spawn_after_shutdown_returns_closed_error`
- `shutdown_is_idempotent`

## Deps

Two new production deps (both tiny, trusted companion crates):

- `tokio-util = \"0.7\"` with `rt` feature → `TaskTracker`.
- `futures-util = \"0.3\"` → `FutureExt::catch_unwind`.

Per plan, deliberately skipped `tracing-test` dev-dep (would be one-test convenience at the cost of a dev-dep). No `thiserror` either — manual `Display + Error` impl for the single-variant enum is ~10 LOC.

## Verification

| Gate | Result |
|---|---|
| `cargo build -p innerwarden-agent` | ✅ |
| `cargo test --workspace` | ✅ 4396 → **4405 pass**, 4 ignored, 0 fail |
| `cargo test -p innerwarden-agent --features dhat-heap -- --test-threads=1` | ✅ 1829 → **1838 pass**, 1 ignored, 0 fail |
| `make heap-budget` (spec 035 A2 gates) | ✅ 3/3 pass, budgets unchanged |
| `cargo fmt --all --check` | ✅ |
| `cargo clippy --workspace -- -D warnings` | ✅ |
| `cargo clippy -p innerwarden-agent --features dhat-heap -- -D warnings` | ✅ |

## Planned next PR

First migration batch:
- `decisions.rs` — decision_writer (highest value, hash chain integrity)
- `telegram.rs` — batcher (has existing 60 s window)
- `pcap_capture.rs` — already bounded 60 s lifetime; low-risk canary

Each: replace `tokio::spawn(async move {...})` with `tg.spawn(\"<name>\", async move {...})?` + add a `tokio::select!` watching `token.cancelled()` inside the event loop. Each gets a regression test that proves `shutdown()` drains pending work within deadline.

Deliberately NOT in scope: `ai/router.rs` (per standing operator memory), eBPF spawn sites, `bot_commands.rs` (12 sites, merits dedicated PR), slow_loop sub-tasks (blocked on audit I-05).

🤖 Generated with [Claude Code](https://claude.com/claude-code)