### PR TITLE
feat(honeypot): swap watch::Receiver<bool> for CancellationToken on always-on listener

### DIFF
--- a/crates/agent/src/honeypot_always_on.rs
+++ b/crates/agent/src/honeypot_always_on.rs
@@ -314,6 +314,15 @@ async fn handle_always_on_connection(
 ///
 /// `filter_blocklist` is a shared set of already-blocked IPs populated at startup
 /// from recent decisions and updated in-place when new IPs are blocked via the gate.
+///
+/// Spec 036 PR-4: `token` replaces the pre-existing
+/// `tokio::sync::watch::Receiver<bool>` parameter. Cancellation is
+/// now driven by the agent's unified `state.task_group` — when
+/// SIGTERM/SIGINT fires, `run_agent`'s shutdown path cancels the
+/// token and waits for every registered task (including this
+/// listener) to drain within the graceful deadline. Per-connection
+/// handlers spawned inside the loop remain raw `tokio::spawn` on
+/// purpose (bounded lifetime; out of scope for this PR).
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn run_always_on_honeypot(
     port: u16,
@@ -331,7 +340,7 @@ pub(crate) async fn run_always_on_honeypot(
     block_backend: String,
     allowed_skills: Vec<String>,
     interaction: String,
-    mut shutdown_rx: tokio::sync::watch::Receiver<bool>,
+    token: tokio_util::sync::CancellationToken,
 ) {
     use skills::builtin::honeypot::ssh_interact::build_ssh_config;
 
@@ -452,11 +461,9 @@ pub(crate) async fn run_always_on_honeypot(
                     }
                 });
             }
-            _ = shutdown_rx.changed() => {
-                if *shutdown_rx.borrow() {
-                    info!("always-on honeypot listener shutting down");
-                    break;
-                }
+            _ = token.cancelled() => {
+                info!("always-on honeypot listener shutting down");
+                break;
             }
         }
     }
@@ -599,5 +606,86 @@ mod tests {
         // Precision path: whole-second durations must pass through unchanged.
         let started = std::time::Instant::now() - std::time::Duration::from_secs(3);
         assert!(elapsed_secs_for_report(started) >= 3);
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // Spec 036 PR-4 — CancellationToken shutdown contract
+    // ─────────────────────────────────────────────────────────────────
+    //
+    // PR-4 replaced `tokio::sync::watch::Receiver<bool>` with
+    // `tokio_util::sync::CancellationToken` as the shutdown signal
+    // for the always-on listener. The swap is a contract change —
+    // the listener used to observe a boolean-watch channel and only
+    // exit when the payload was `true`; it now exits unconditionally
+    // on `token.cancelled()`.
+    //
+    // These tests pin the NEW contract at two ends:
+    //   1. A fresh, uncancelled token keeps the listener RUNNING
+    //      (not spuriously-exiting the moment the loop starts).
+    //   2. Cancelling the token drains the listener within a
+    //      bounded deadline — the property the agent's
+    //      `state.task_group.shutdown()` relies on.
+
+    #[tokio::test]
+    async fn listener_exits_promptly_when_token_cancelled() {
+        use std::time::Duration;
+        use tokio_util::sync::CancellationToken;
+
+        let token = CancellationToken::new();
+        let token_for_task = token.clone();
+        let tmpdir = tempfile::tempdir().expect("tempdir");
+        let data_dir = tmpdir.path().to_path_buf();
+
+        // Bind to port 0 → kernel-assigned ephemeral port. No real
+        // SSH client connects in this test; we only care that the
+        // accept loop observes `token.cancelled()` and exits.
+        let listener_task = tokio::spawn(async move {
+            run_always_on_honeypot(
+                0,                                    // port (OS-assigned)
+                "127.0.0.1".to_string(),              // bind_addr
+                3,                                    // ssh_max_auth_attempts
+                Arc::new(Mutex::new(HashSet::new())), // filter_blocklist
+                None,                                 // ai_provider
+                None,                                 // telegram_client
+                Arc::new(AtomicU64::new(0)),          // gate_suppressed_counter
+                None,                                 // abuseipdb_client
+                0,                                    // abuseipdb_threshold
+                data_dir,
+                false,                // responder_enabled
+                true,                 // dry_run
+                "ufw".to_string(),    // block_backend
+                vec![],               // allowed_skills
+                "reject".to_string(), // interaction
+                token_for_task,
+            )
+            .await;
+        });
+
+        // Let the listener reach its accept loop. 100 ms is ample
+        // for binding + starting the select! on a dev laptop and CI.
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        assert!(
+            !listener_task.is_finished(),
+            "listener must NOT exit on its own with an uncancelled token — \
+             a spurious-exit regression here would mean SIGTERM drain does \
+             nothing because the listener is already gone"
+        );
+
+        // Trigger the shutdown contract.
+        token.cancel();
+
+        // Listener must observe `cancelled()` and exit within a
+        // bounded window. 1 s is generous — the real select! arm
+        // fires on the very next poll.
+        let join_result = tokio::time::timeout(Duration::from_secs(1), listener_task).await;
+        assert!(
+            join_result.is_ok(),
+            "listener must exit within 1 s of token.cancel() — a timeout here \
+             means the shutdown contract regressed (the cancelled() arm is \
+             gone from the select!, or the loop swallowed the signal)"
+        );
+        join_result
+            .unwrap()
+            .expect("listener task completed without panic");
     }
 }

--- a/crates/agent/src/loops/boot.rs
+++ b/crates/agent/src/loops/boot.rs
@@ -1109,10 +1109,13 @@ pub(crate) async fn run_agent(cli: crate::Cli) -> Result<()> {
         crate::loops::slow_loop::backfill_graph_decisions(&cli.data_dir, &mut state);
 
         // Always-on honeypot: permanent SSH listener from startup.
-        // A watch channel is used to signal shutdown on SIGTERM/SIGINT.
-        let always_on_shutdown_tx = if cfg.honeypot.mode == "always_on" {
-            let (tx, rx) = tokio::sync::watch::channel(false);
-
+        // Spec 036 PR-4: cancellation flows through the agent's unified
+        // `state.task_group` — the listener observes
+        // `token.cancelled()` in its accept loop and exits cleanly
+        // when SIGTERM/SIGINT triggers `task_group.shutdown()`. The
+        // pre-PR-4 `tokio::sync::watch::Receiver<bool>` mechanism is
+        // gone; we no longer hold a sender at the caller level.
+        if cfg.honeypot.mode == "always_on" {
             // Build a filter blocklist pre-populated from today's + yesterday's decisions.
             let initial_blocked: std::collections::HashSet<String> = {
                 let (bl, _) = load_startup_decision_state(&cli.data_dir, false);
@@ -1151,33 +1154,33 @@ pub(crate) async fn run_agent(cli: crate::Cli) -> Result<()> {
             let block_backend = cfg.responder.block_backend.clone();
             let allowed_skills = cfg.responder.allowed_skills.clone();
             let interaction = cfg.honeypot.interaction.clone();
+            let token = state.task_group.token();
 
-            tokio::spawn(async move {
-                honeypot_always_on::run_always_on_honeypot(
-                    port,
-                    bind_addr,
-                    max_auth,
-                    filter_bl,
-                    ai_clone,
-                    tg_clone,
-                    gate_counter,
-                    abuseipdb_client,
-                    abuseipdb_threshold,
-                    data_dir_clone,
-                    responder_enabled,
-                    dry_run,
-                    block_backend,
-                    allowed_skills,
-                    interaction,
-                    rx,
-                )
-                .await;
-            });
-
-            Some(tx)
-        } else {
-            None
-        };
+            state.task_group.spawn_or_log(
+                "honeypot-always-on",
+                Box::pin(async move {
+                    honeypot_always_on::run_always_on_honeypot(
+                        port,
+                        bind_addr,
+                        max_auth,
+                        filter_bl,
+                        ai_clone,
+                        tg_clone,
+                        gate_counter,
+                        abuseipdb_client,
+                        abuseipdb_threshold,
+                        data_dir_clone,
+                        responder_enabled,
+                        dry_run,
+                        block_backend,
+                        allowed_skills,
+                        interaction,
+                        token,
+                    )
+                    .await;
+                }),
+            );
+        }
 
         let ai_poll = cfg.ai.incident_poll_secs;
         info!(
@@ -2155,10 +2158,12 @@ pub(crate) async fn run_agent(cli: crate::Cli) -> Result<()> {
             };
 
             if shutdown {
-                // Signal always-on honeypot listener to stop (if running).
-                if let Some(ref tx) = always_on_shutdown_tx {
-                    let _ = tx.send(true);
-                }
+                // Spec 036 PR-4: the honeypot listener is registered
+                // in `state.task_group`, so the `shutdown()` below
+                // cancels its token alongside every other migrated
+                // task. No separate watch-channel send is needed —
+                // the pre-PR-4 `always_on_shutdown_tx.send(true)`
+                // that used to live here is gone.
                 if let Some(w) = &mut state.decision_writer {
                     w.flush();
                 }


### PR DESCRIPTION
## Summary

**Spec 036 (audit I-04) PR-4 of N.** Shutdown contract change for the always-on honeypot listener. Pre-existing ad-hoc `tokio::sync::watch::Receiver<bool>` replaced by `CancellationToken` sourced from the agent's unified `state.task_group`. Two shutdown systems unified into one.

Scope stays narrow per earlier operator decision: only the LISTENER migrates. Per-connection handler spawns inside the accept loop stay raw `tokio::spawn` — bounded lifetime, explicit out-of-scope.

## What changes

### `crates/agent/src/honeypot_always_on.rs`

- `run_always_on_honeypot` signature: final parameter `mut shutdown_rx: tokio::sync::watch::Receiver<bool>` → `token: tokio_util::sync::CancellationToken`.
- `select!` arm tightens from
    ```rust
    _ = shutdown_rx.changed() => {
        if *shutdown_rx.borrow() { info!(\"...\"); break; }
    }
    ```
  to the unconditional
    ```rust
    _ = token.cancelled() => { info!(\"...\"); break; }
    ```
  `CancellationToken` fires once and only once, so the outer if-check goes away — semantically tighter.

### `crates/agent/src/loops/boot.rs`

- Delete the `tokio::sync::watch::channel(false)` setup and the `always_on_shutdown_tx` binding that leaked to outer scope.
- Spawn the listener via `state.task_group.spawn_or_log(\"honeypot-always-on\", Box::pin(...))` passing `state.task_group.token()`. Listener is now a TRACKED member of the group — SIGTERM drain (PR-3) waits for it within the deadline alongside telegram-polling.
- Remove the `always_on_shutdown_tx.send(true)` in the shutdown branch. PR-3's `state.task_group.shutdown()` a few lines below now handles it uniformly for EVERY migrated task.

## Net result

SIGTERM → `state.task_group.shutdown(GRACEFUL_SHUTDOWN_DEADLINE)` cancels the shared token → telegram-polling AND honeypot listener AND any future-migrated spawn observe `token.cancelled()` in the same instant → each exits its select! arm → tracker drains within the deadline → `log_shutdown_report` reports the verdict.

## Regression test (1 new)

`listener_exits_promptly_when_token_cancelled` in `honeypot_always_on::tests`:

- Binds to `127.0.0.1:0` (kernel-assigned ephemeral port).
- Spawns `run_always_on_honeypot` with all stub deps (no AI, no Telegram, no AbuseIPDB).
- 100 ms sanity delay; asserts listener is NOT finished — guards against a regression where an uncancelled token spuriously fires `cancelled()`.
- Cancels the token.
- Asserts the listener exits within 1 s via `tokio::time::timeout` around the JoinHandle.

Positive-path tests (accept real SSH connection, write evidence) are operator-run canary territory — the unit-test harness to short-circuit that would be substantially larger than this PR's surface.

## Verification

| Gate | Result |
|---|---|
| `cargo build -p innerwarden-agent` | ✅ |
| `cargo test --workspace` | ✅ 4413 → **4414 pass**, 4 ignored, 0 fail |
| `cargo test -p innerwarden-agent honeypot_always_on::` | ✅ 6 → **7 pass** (+1 new) |
| `make heap-budget` (spec 035 A2) | ✅ 3/3 |
| `cargo fmt --all --check` | ✅ |
| `cargo clippy --workspace -- -D warnings` | ✅ |

## Coverage expectation

boot.rs is orchestration-exempt. honeypot_always_on.rs changes are narrow:
- Signature: one parameter type swapped (exercised by existing callers on the changed signature + the new test).
- Select arm: replaced 2 uncovered lines (`if *shutdown_rx.borrow()` branch needed a sender to fire) with 1 covered line (`token.cancelled()` fires deterministically in the new test).
- Module doc: ~10 lines of comments, not instrumented.

Net: fewer uncovered patch lines than before, plus 1 new test that exercises the critical arm. Codecov patch should pass.

## What PR-5 brings (last in arc)

Firmware + hypervisor alert migrations with the `process_firmware_tick → SendNow` integration fixture that PR-2 deferred. That fixture unlocks coverage on the remaining per-tick alert migrations and closes the spec 036 migration arc.

After PR-5, the operator inherits: one canonical shutdown path, one cancel token, unified drain visibility via ShutdownReport logs. The \"59 raw tokio::spawn\" state called out in the audit is down to the per-connection handlers (out of scope) and the handful inside bot_commands/honeypot-session, which are bounded-lifetime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)