### PR TITLE
feat(state_store): warm-cache xdp_block_times from SQLite on boot

### DIFF
--- a/crates/agent/src/decision_block_ip.rs
+++ b/crates/agent/src/decision_block_ip.rs
@@ -106,9 +106,19 @@ pub(crate) async fn execute_block_ip_decision(
             Ok(()) => {
                 layers_applied.push("XDP");
                 any_success = true;
+                // Spec 037 PR-1: runtime first (immediate protection),
+                // persist second (SQLite canonical for warm-cache on
+                // restart). `set_xdp_block_time` already swallows
+                // errors with a `warn!` — a persistence failure
+                // degrades to pre-I-02 behaviour (TTL accounting lost
+                // on restart) but never derruba the block itself.
+                let blocked_at = chrono::Utc::now();
                 state
                     .xdp_block_times
-                    .insert(ip.to_string(), (chrono::Utc::now(), block_ttl_secs));
+                    .insert(ip.to_string(), (blocked_at, block_ttl_secs));
+                state
+                    .store
+                    .set_xdp_block_time(ip, blocked_at, block_ttl_secs);
                 true
             }
             Err(e) => {
@@ -126,9 +136,15 @@ pub(crate) async fn execute_block_ip_decision(
             if xdp_result.success {
                 layers_applied.push("XDP");
                 any_success = true;
+                // Spec 037 PR-1: same ordering as the shield path —
+                // runtime first, persist second with swallowed errors.
+                let blocked_at = chrono::Utc::now();
                 state
                     .xdp_block_times
-                    .insert(ip.to_string(), (chrono::Utc::now(), block_ttl_secs));
+                    .insert(ip.to_string(), (blocked_at, block_ttl_secs));
+                state
+                    .store
+                    .set_xdp_block_time(ip, blocked_at, block_ttl_secs);
             }
         }
     }

--- a/crates/agent/src/loops/boot.rs
+++ b/crates/agent/src/loops/boot.rs
@@ -871,7 +871,15 @@ pub(crate) async fn run_agent(cli: crate::Cli) -> Result<()> {
             None
         },
         recent_blocks: std::collections::VecDeque::new(),
-        xdp_block_times: HashMap::new(),
+        // Spec 037 PR-1 (I-02 slice 1): warm-cache from the SQLite
+        // `xdp_block_times` namespace so TTL accounting survives a
+        // restart. Pre-PR the map was reset on every boot; adaptive
+        // TTL expiration for previously-blocked IPs was lost and
+        // the cleanup loop would sit idle until fresh blocks landed.
+        // `load_xdp_block_times` degrades to an empty map on a store
+        // read error (logged `warn!`), matching pre-PR behaviour in
+        // the degraded case.
+        xdp_block_times: store.load_xdp_block_times(),
         response_lifecycle: response_lifecycle::ResponseLifecycle::load_snapshot(
             &cli.data_dir,
             sqlite_store.as_deref(),
@@ -1423,6 +1431,10 @@ pub(crate) async fn run_agent(cli: crate::Cli) -> Result<()> {
                                 // poison entry; can't act on kernel anyway.
                                 warn!(ip, "XDP cleanup: unparseable IP in xdp_block_times, dropping local entry");
                                 state.xdp_block_times.remove(ip);
+                                // Spec 037 PR-1: mirror the remove in SQLite so
+                                // warm-cache on next boot does not resurrect the
+                                // poison entry.
+                                state.store.remove_xdp_block_time(ip);
                                 continue;
                             };
                             let b = addr.octets();
@@ -1436,6 +1448,10 @@ pub(crate) async fn run_agent(cli: crate::Cli) -> Result<()> {
                             match output {
                                 Ok(out) if out.status.success() => {
                                     state.xdp_block_times.remove(ip);
+                                    // Spec 037 PR-1: mirror remove in SQLite so
+                                    // the warm-cache does not resurrect an
+                                    // already-expired block on next boot.
+                                    state.store.remove_xdp_block_time(ip);
                                     info!(ip, ttl_secs, "XDP adaptive TTL expired - removed from blocklist");
                                 }
                                 Ok(out) => {
@@ -1448,6 +1464,8 @@ pub(crate) async fn run_agent(cli: crate::Cli) -> Result<()> {
                                         || lower.contains("does not exist");
                                     if already_absent {
                                         state.xdp_block_times.remove(ip);
+                                        // Spec 037 PR-1: same mirror reason.
+                                        state.store.remove_xdp_block_time(ip);
                                         info!(ip, ttl_secs, "XDP cleanup: entry already absent in kernel map, local state cleared");
                                     } else {
                                         warn!(

--- a/crates/agent/src/state_store.rs
+++ b/crates/agent/src/state_store.rs
@@ -266,6 +266,26 @@ impl StateStore {
         }
     }
 
+    /// Warm-cache loader for `AgentState::xdp_block_times`.
+    ///
+    /// Spec 037 PR-1 (I-02 slice 1): SQLite `xdp_block_times` namespace
+    /// becomes the canonical persisted store. The in-memory HashMap
+    /// reverts to a runtime view rebuilt at boot from this method. A
+    /// failed read (corrupted row, KV backend unavailable) is already
+    /// swallowed by `all_xdp_block_times` with a `warn!` — this method
+    /// inherits that behaviour and returns an empty map in the
+    /// degraded case. Same semantic as pre-I-02 boot: no TTL
+    /// accounting, cleanup loop is a no-op, kernel rules continue
+    /// blocking until reinserted.
+    pub fn load_xdp_block_times(
+        &self,
+    ) -> std::collections::HashMap<String, (chrono::DateTime<chrono::Utc>, i64)> {
+        self.all_xdp_block_times()
+            .into_iter()
+            .map(|(ip, ts, ttl)| (ip, (ts, ttl)))
+            .collect()
+    }
+
     // ── Trust Rules ─────────────────────────────────────────────────
 
     pub fn has_trust_rule(&self, key: &str) -> bool {
@@ -437,6 +457,111 @@ mod tests {
         let (dt, ttl) = store.get_xdp_block_time("5.6.7.8").unwrap();
         assert_eq!(ttl, 3600);
         assert!((dt - now).num_seconds().abs() < 1);
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // Spec 037 PR-1 — `load_xdp_block_times` warm-cache anchors
+    // ─────────────────────────────────────────────────────────────────
+    //
+    // PR-1 of I-02 promotes SQLite `xdp_block_times` to the canonical
+    // persisted store and rebuilds `AgentState::xdp_block_times` as a
+    // warm-cache at boot via `load_xdp_block_times`. These tests pin
+    // the behaviours the boot path depends on:
+    //
+    //   1. Empty store → empty map (safe fallback; pre-PR behaviour).
+    //   2. Round-trip: persisted entries load back with matching TTL +
+    //      timestamp (modulo sub-second drift from ms precision).
+    //   3. Remove mirror: after a remove, the load result no longer
+    //      contains that IP. Guards the "resurrect-expired-block"
+    //      regression the operator flagged explicitly.
+    //   4. Corrupt row: a malformed payload is skipped, valid siblings
+    //      still load. The store never panics on boot.
+
+    #[test]
+    fn load_xdp_block_times_is_empty_on_fresh_store() {
+        let (_dir, store) = make_store();
+        let loaded = store.load_xdp_block_times();
+        assert!(
+            loaded.is_empty(),
+            "fresh store MUST return an empty warm-cache — pre-PR boot behaviour"
+        );
+    }
+
+    #[test]
+    fn load_xdp_block_times_returns_inserted_entries() {
+        let (_dir, store) = make_store();
+        let now = chrono::Utc::now();
+        store.set_xdp_block_time("10.0.0.1", now, 3600);
+        store.set_xdp_block_time("10.0.0.2", now, 900);
+        store.set_xdp_block_time("10.0.0.3", now, 60);
+
+        let loaded = store.load_xdp_block_times();
+        assert_eq!(
+            loaded.len(),
+            3,
+            "all persisted entries must appear in the warm-cache"
+        );
+
+        let (ts1, ttl1) = loaded.get("10.0.0.1").expect("10.0.0.1 must be in the map");
+        assert_eq!(*ttl1, 3600);
+        assert!(
+            (*ts1 - now).num_seconds().abs() < 1,
+            "round-tripped timestamp must be within sub-second drift (ms precision)"
+        );
+        assert_eq!(loaded.get("10.0.0.2").map(|(_, ttl)| *ttl), Some(900));
+        assert_eq!(loaded.get("10.0.0.3").map(|(_, ttl)| *ttl), Some(60));
+    }
+
+    #[test]
+    fn load_xdp_block_times_reflects_remove_mirror() {
+        // Anchors the "resurrect-expired-block" regression the
+        // operator flagged: if `boot.rs` cleanup removes an entry
+        // from `state.xdp_block_times` but NOT from SQLite, the
+        // warm-cache on the next restart puts it back.
+        let (_dir, store) = make_store();
+        let now = chrono::Utc::now();
+        store.set_xdp_block_time("192.0.2.10", now, 3600);
+        store.set_xdp_block_time("192.0.2.11", now, 3600);
+
+        // Simulate the `boot.rs` cleanup mirror: the live runtime
+        // path calls both the HashMap remove and `remove_xdp_block_time`.
+        store.remove_xdp_block_time("192.0.2.10");
+
+        let loaded = store.load_xdp_block_times();
+        assert_eq!(loaded.len(), 1);
+        assert!(
+            !loaded.contains_key("192.0.2.10"),
+            "a removed entry MUST NOT resurface in the warm-cache"
+        );
+        assert!(
+            loaded.contains_key("192.0.2.11"),
+            "sibling entries must remain available"
+        );
+    }
+
+    #[test]
+    fn load_xdp_block_times_skips_corrupt_rows() {
+        // Guards against a panic-on-boot regression: if a previous
+        // agent version wrote a row with a missing/typed field, the
+        // reader must skip it with no log-spam-at-boot (`all_xdp_block_times`
+        // already does this) and return the remaining valid entries.
+        let (_dir, store) = make_store();
+        let now = chrono::Utc::now();
+        store.set_xdp_block_time("198.51.100.5", now, 3600);
+
+        // Write a corrupt row via the raw KV API.
+        store
+            .store
+            .kv_set(NS_XDP_BLOCK_TIMES, "198.51.100.6", b"not-json")
+            .expect("raw kv_set");
+
+        let loaded = store.load_xdp_block_times();
+        assert_eq!(
+            loaded.len(),
+            1,
+            "corrupt row must be skipped, valid sibling must still load"
+        );
+        assert!(loaded.contains_key("198.51.100.5"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

**Spec 037 (audit I-02 slice 1) PR-1 of N.** First slice of the Single-Source-of-Truth arc. XDP block times — the lowest-risk of the five duplicated-state vectors — are now persisted in SQLite and reloaded on boot, closing the \"restart loses TTL accounting\" regression documented in the audit.

3 files modified, +162 LOC.

## What the audit missed

The audit flagged XDP as \"in-memory only; SQLite NOT loaded back into memory\". On investigation, the situation was sharper: `set_xdp_block_time` / `remove_xdp_block_time` existed in `state_store.rs` but had **ZERO production call sites** — the SQLite namespace was orphaned API, never written, never read. The in-memory `AgentState::xdp_block_times` HashMap was the sole storage, reset on every boot, causing adaptive-TTL accounting to reset until fresh blocks landed.

This PR closes the loop end-to-end: write + remove mirrors + warm-cache on boot, per the operator's \"combined PR\" scope decision.

## What ships

### `state_store.rs`
New `load_xdp_block_times(&self) -> HashMap<String, (DateTime<Utc>, i64)>` — warm-cache loader. Wraps existing `all_xdp_block_times` iterator. Inherits swallow-with-warn semantic so corrupt rows / unavailable backend degrade to an empty map — matches pre-PR behaviour in the degraded case (no panic).

### `decision_block_ip.rs`
Two XDP insert sites (shield path + standalone-skill fallback). After the runtime `state.xdp_block_times.insert(...)`, mirror the write to SQLite. Ordering per operator constraint: **runtime first (immediate protection never breaks), persist second** (errors `warn!`-swallowed).

### `loops/boot.rs`
- Constructor: `HashMap::new()` → `store.load_xdp_block_times()`.
- Cleanup loop: all three `state.xdp_block_times.remove(ip)` sites mirror the remove via `state.store.remove_xdp_block_time(ip)`. Required for warm-cache correctness — without the mirror, expired-IP cleanup would resurrect removed entries on next boot (the specific regression the operator flagged during planning).

## Regression anchors (4 new, all in `state_store::tests`)

| Test | Guards |
|---|---|
| `load_xdp_block_times_is_empty_on_fresh_store` | Pre-PR boot behaviour preserved on empty Store |
| `load_xdp_block_times_returns_inserted_entries` | Round-trip via `set_xdp_block_time` + `load_xdp_block_times` |
| `load_xdp_block_times_reflects_remove_mirror` | \"Resurrect-expired-block\" regression — operator-flagged during plan |
| `load_xdp_block_times_skips_corrupt_rows` | Panic-on-boot guard with malformed payload + valid sibling |

## Verification

| Gate | Result |
|---|---|
| `cargo build -p innerwarden-agent` | ✅ |
| `cargo test --workspace` | ✅ 4420 → **4424 pass**, 4 ignored, 0 fail |
| `cargo test -p innerwarden-agent state_store::` | ✅ 9 → **13 pass** (+4 new) |
| `make heap-budget` (spec 035 A2) | ✅ 3/3 |
| `cargo fmt --all --check` | ✅ |
| `cargo clippy --workspace -- -D warnings` | ✅ |

## Rollback posture

Revert-safe: kernel XDP rules continue blocking (unchanged), in-memory map reverts to `HashMap::new()` on boot (pre-PR behaviour). No data loss. The SQLite namespace keeps receiving writes from any partially-reverted commit path without corrupting the schema (opaque JSON blobs).

## What slice 2 brings (attacker profiles)

Attacker profiles already load from SQLite (`attacker_intel::load_from_store`) and dual-write to JSON + SQLite blob. Slice 2 audits `attacker-profiles.json` readers — if orphan, the write path loses the JSON branch; if dashboard reads it, the JSON stays as a projection. <100 LOC PR either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)