### PR TITLE
feat(ip_reputation): warm-cache ip_reputations from SQLite on boot (spec 037 PR-3)

### DIFF
--- a/crates/agent/src/ip_reputation.rs
+++ b/crates/agent/src/ip_reputation.rs
@@ -82,11 +82,14 @@ pub(crate) fn append_blocked_ip(data_dir: &Path, ip: &str) {
     }
 }
 
-/// Write the in-memory reputation map to `ip-reputation.json` so the dashboard
-/// (which runs in a separate task) can read it without shared state.
+/// Persist the in-memory reputation map. SQLite is canonical (warm-cache
+/// source on boot); the JSON file is a projection the dashboard reads
+/// directly. `store` is `Option` because the prune self-call in
+/// `load_ip_reputations` runs before a store handle exists.
 pub(crate) fn persist_ip_reputations(
     data_dir: &Path,
     reputations: &HashMap<String, LocalIpReputation>,
+    store: Option<&crate::state_store::StateStore>,
 ) {
     let path = data_dir.join("ip-reputation.json");
     match serde_json::to_string(reputations) {
@@ -97,6 +100,26 @@ pub(crate) fn persist_ip_reputations(
         }
         Err(e) => warn!("failed to serialize ip reputations: {e}"),
     }
+    if let Some(sq) = store {
+        for (ip, rep) in reputations {
+            if let Ok(val) = serde_json::to_value(rep) {
+                sq.set_ip_reputation(ip, &val);
+            }
+        }
+    }
+}
+
+/// Warm-cache loader from the SQLite canonical namespace. Returns an empty
+/// map on store-unavailable errors (already logged upstream); the caller
+/// falls back to the JSON loader when empty.
+pub(crate) fn load_ip_reputations_from_store(
+    store: &crate::state_store::StateStore,
+) -> HashMap<String, LocalIpReputation> {
+    store
+        .all_ip_reputations()
+        .into_iter()
+        .filter_map(|(ip, val)| serde_json::from_value(val).ok().map(|r| (ip, r)))
+        .collect()
 }
 
 /// Load the reputation map from `ip-reputation.json` at startup.
@@ -118,7 +141,9 @@ pub(crate) fn load_ip_reputations(data_dir: &Path) -> HashMap<String, LocalIpRep
             removed,
             "pruned invalid IP/CIDR entries from ip-reputation.json at startup"
         );
-        persist_ip_reputations(data_dir, &reputations);
+        // No store handle available yet at boot-prune time; the next
+        // slow-loop persist tick re-mirrors to SQLite.
+        persist_ip_reputations(data_dir, &reputations, None);
     }
     reputations
 }
@@ -372,13 +397,104 @@ mod tests {
         r2.record_block();
         reputations.insert("2.2.2.2".to_string(), r2);
 
-        persist_ip_reputations(tmp.path(), &reputations);
+        persist_ip_reputations(tmp.path(), &reputations, None);
 
         let loaded = load_ip_reputations(tmp.path());
         assert_eq!(loaded.len(), 2);
         assert_eq!(loaded["1.1.1.1"].total_incidents, 1);
         assert_eq!(loaded["2.2.2.2"].total_blocks, 1);
         assert_eq!(loaded["2.2.2.2"].reputation_score, 2.0);
+    }
+
+    #[test]
+    fn load_ip_reputations_from_store_is_empty_on_fresh_store() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = crate::state_store::StateStore::open(tmp.path()).unwrap();
+
+        let loaded = load_ip_reputations_from_store(&store);
+        assert!(
+            loaded.is_empty(),
+            "fresh store MUST return an empty warm-cache — boot falls back to JSON"
+        );
+    }
+
+    #[test]
+    fn persist_ip_reputations_mirrors_to_store_and_round_trips() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = crate::state_store::StateStore::open(tmp.path()).unwrap();
+
+        let mut reputations = HashMap::new();
+        let mut r1 = rep();
+        r1.record_incident();
+        r1.record_block();
+        reputations.insert("198.51.100.5".to_string(), r1);
+        let mut r2 = rep();
+        r2.record_incident();
+        reputations.insert("198.51.100.6".to_string(), r2);
+
+        persist_ip_reputations(tmp.path(), &reputations, Some(&store));
+
+        // SQLite canonical round-trip.
+        let loaded = load_ip_reputations_from_store(&store);
+        assert_eq!(
+            loaded.len(),
+            2,
+            "both persisted entries must appear in the SQLite warm-cache"
+        );
+        assert_eq!(loaded["198.51.100.5"].total_incidents, 1);
+        assert_eq!(loaded["198.51.100.5"].total_blocks, 1);
+        assert_eq!(loaded["198.51.100.6"].total_incidents, 1);
+
+        // JSON projection still written (dashboard consumes it).
+        let json_loaded = load_ip_reputations(tmp.path());
+        assert_eq!(
+            json_loaded.len(),
+            2,
+            "JSON projection must stay in sync with SQLite for dashboard reads"
+        );
+    }
+
+    #[test]
+    fn persist_ip_reputations_skips_sqlite_when_store_is_none() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = crate::state_store::StateStore::open(tmp.path()).unwrap();
+
+        let mut reputations = HashMap::new();
+        reputations.insert("203.0.113.7".to_string(), rep());
+
+        // Call with None — SQLite should remain empty.
+        persist_ip_reputations(tmp.path(), &reputations, None);
+
+        let sqlite_loaded = load_ip_reputations_from_store(&store);
+        assert!(
+            sqlite_loaded.is_empty(),
+            "persist_ip_reputations with store=None MUST NOT write to SQLite"
+        );
+
+        // JSON was still written.
+        let json_loaded = load_ip_reputations(tmp.path());
+        assert_eq!(json_loaded.len(), 1);
+    }
+
+    #[test]
+    fn load_ip_reputations_from_store_skips_corrupt_rows() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = crate::state_store::StateStore::open(tmp.path()).unwrap();
+
+        let mut reputations = HashMap::new();
+        reputations.insert("198.51.100.9".to_string(), rep());
+        persist_ip_reputations(tmp.path(), &reputations, Some(&store));
+
+        // Corrupt: an integer, not the expected object.
+        store.set_ip_reputation("198.51.100.10", &serde_json::json!(42));
+
+        let loaded = load_ip_reputations_from_store(&store);
+        assert_eq!(
+            loaded.len(),
+            1,
+            "corrupt row must be skipped, valid sibling must still load"
+        );
+        assert!(loaded.contains_key("198.51.100.9"));
     }
 
     #[test]

--- a/crates/agent/src/loops/boot.rs
+++ b/crates/agent/src/loops/boot.rs
@@ -854,7 +854,28 @@ pub(crate) async fn run_agent(cli: crate::Cli) -> Result<()> {
         },
         circuit_breaker_until: None,
         pending_honeypot_choices: HashMap::new(),
-        ip_reputations: load_ip_reputations(&cli.data_dir),
+        // SQLite is canonical; JSON fallback covers data dirs that predate
+        // the migration. The next persist tick syncs SQLite, so the fallback
+        // path is self-healing on subsequent boots.
+        ip_reputations: {
+            let from_store = ip_reputation::load_ip_reputations_from_store(&store);
+            if from_store.is_empty() {
+                let from_json = load_ip_reputations(&cli.data_dir);
+                if !from_json.is_empty() {
+                    info!(
+                        count = from_json.len(),
+                        "warm-cache: SQLite ip_reputations empty, loaded from legacy JSON (will sync to SQLite on next slow-loop tick)"
+                    );
+                }
+                from_json
+            } else {
+                info!(
+                    count = from_store.len(),
+                    "warm-cache: loaded ip_reputations from SQLite canonical"
+                );
+                from_store
+            }
+        },
         lsm_enabled: false,
         mesh: if cfg.mesh.enabled {
             match mesh::MeshIntegration::new(&cfg.mesh, &cli.data_dir) {
@@ -1406,7 +1427,11 @@ pub(crate) async fn run_agent(cli: crate::Cli) -> Result<()> {
                         entries.truncate(5000);
                         state.ip_reputations = entries.into_iter().collect();
                     }
-                    persist_ip_reputations(&cli.data_dir, &state.ip_reputations);
+                    persist_ip_reputations(
+                        &cli.data_dir,
+                        &state.ip_reputations,
+                        Some(&state.store),
+                    );
 
                     // ── Safeguard: XDP TTL - expire old blocklist entries ──
                     //
@@ -2103,7 +2128,11 @@ pub(crate) async fn run_agent(cli: crate::Cli) -> Result<()> {
                         entries.truncate(5000);
                         state.ip_reputations = entries.into_iter().collect();
                     }
-                    persist_ip_reputations(&cli.data_dir, &state.ip_reputations);
+                    persist_ip_reputations(
+                        &cli.data_dir,
+                        &state.ip_reputations,
+                        Some(&state.store),
+                    );
                     let removed = data_retention::cleanup(&cli.data_dir, &cfg.data);
                     if removed > 0 {
                         info!(removed, "data_retention: cleaned up old files");


### PR DESCRIPTION
## Summary

Spec 037 (audit I-02 Single Source of Truth) — **slice 3 of 5**: IP reputation.

Same pattern as the previous two slices:

- Slice 1 (XDP blocks, #278): warm-cache `xdp_block_times` from SQLite on boot.
- Slice 2 (attacker profiles, #279): SQLite blob canonical, retired `attacker-profiles.json` write.
- **Slice 3 (this PR, IP reputation)**: SQLite `ip_reputations` namespace becomes canonical, JSON becomes a projection for the dashboard live-feed widget.

## What changes

- `persist_ip_reputations` takes `store: Option<&StateStore>` and mirrors the in-memory map to SQLite alongside the existing JSON write.
- New `load_ip_reputations_from_store` builds the warm-cache at boot. If SQLite is empty (data dir predates the migration), boot falls back to the legacy JSON loader and logs a one-liner so the fallback is observable. The next slow-loop persist tick re-syncs SQLite — the migration is self-healing.
- Both slow-loop persist call sites in `boot.rs` now pass `Some(&state.store)`.
- `load_ip_reputations`'s internal re-write after a prune keeps passing `None` (no store handle is in scope there; next persist tick mirrors the cleaned state).

## Regression anchors

All four live in `crates/agent/src/ip_reputation.rs` tests:

- `load_ip_reputations_from_store_is_empty_on_fresh_store` — fresh store ⇒ empty warm-cache ⇒ boot falls back to JSON.
- `persist_ip_reputations_mirrors_to_store_and_round_trips` — SQLite round-trip + JSON projection stays in sync.
- `persist_ip_reputations_skips_sqlite_when_store_is_none` — the boot-prune path never touches SQLite.
- `load_ip_reputations_from_store_skips_corrupt_rows` — a malformed row does not block siblings (matches slice 1's corrupt-row guard).

## Why keep the JSON projection

`dashboard/live_feed.rs:62::load_ip_reputation_map` reads `ip-reputation.json` directly without sharing `AgentState`. Retiring the file would require a second SQLite reader inside the dashboard task — defer that to a later slice if it becomes worth it; for now the JSON write is cheap and the dashboard stays decoupled.

## Test plan

- [x] `cargo build -p innerwarden-agent` clean
- [x] `cargo test` — 4431 passed, 4 ignored
- [x] `cargo fmt --check` clean
- [x] `cargo clippy -p innerwarden-agent --all-targets` clean on touched files
- [x] `make heap-budget` — 3 anchors pass
- [ ] codecov/patch

🤖 Generated with [Claude Code](https://claude.com/claude-code)