### PR TITLE
feat(decisions): mirror append_chained writes to SQLite (spec 037 slice 4 PR-1)

### DIFF
--- a/crates/agent/src/dashboard/actions.rs
+++ b/crates/agent/src/dashboard/actions.rs
@@ -196,6 +196,7 @@ pub(super) async fn api_action_block_ip(
 
     let result = execute_block_ip(
         &state.data_dir,
+        state.sqlite_store.as_ref(),
         &state.action_cfg,
         &ip,
         &body.reason,
@@ -273,6 +274,7 @@ pub(super) async fn api_action_suspend_user(
 
     let result = execute_suspend_user(
         &state.data_dir,
+        state.sqlite_store.as_ref(),
         &state.action_cfg,
         &user,
         &body.reason,
@@ -370,7 +372,9 @@ pub(super) async fn api_action_honeypot(
                 },
                 prev_hash: None,
             };
-            if let Err(e) = append_decision_entry(&state.data_dir, &entry) {
+            if let Err(e) =
+                append_decision_entry(&state.data_dir, &entry, state.sqlite_store.as_ref())
+            {
                 warn!("failed to write honeypot test decision entry: {e}");
             }
 
@@ -450,6 +454,7 @@ pub(super) fn validate_action_params(target: &str, reason: &str) -> Result<(), &
 /// Execute a block-ip skill and write the decision to the audit trail.
 pub(super) async fn execute_block_ip(
     data_dir: &Path,
+    store: Option<&std::sync::Arc<innerwarden_store::Store>>,
     cfg: &DashboardActionConfig,
     ip: &str,
     reason: &str,
@@ -512,7 +517,7 @@ pub(super) async fn execute_block_ip(
         prev_hash: None,
     };
 
-    append_decision_entry(data_dir, &entry)?;
+    append_decision_entry(data_dir, &entry, store)?;
 
     // Admin action audit trail
     let mut audit = AdminActionEntry {
@@ -550,6 +555,7 @@ pub(super) async fn execute_block_ip(
 /// Execute a suspend-user skill and write the decision to the audit trail.
 pub(super) async fn execute_suspend_user(
     data_dir: &Path,
+    store: Option<&std::sync::Arc<innerwarden_store::Store>>,
     cfg: &DashboardActionConfig,
     user: &str,
     reason: &str,
@@ -621,7 +627,7 @@ pub(super) async fn execute_suspend_user(
         prev_hash: None,
     };
 
-    append_decision_entry(data_dir, &entry)?;
+    append_decision_entry(data_dir, &entry, store)?;
 
     // Admin action audit trail
     let mut audit = AdminActionEntry {
@@ -678,9 +684,14 @@ pub(super) fn make_synthetic_incident(
     }
 }
 
-/// Append a single `DecisionEntry` to today's decisions JSONL file.
-pub(super) fn append_decision_entry(data_dir: &Path, entry: &DecisionEntry) -> anyhow::Result<()> {
-    crate::decisions::append_chained(data_dir, entry)
+/// Append a single `DecisionEntry` to today's decisions JSONL file and mirror
+/// to the SQLite `decisions` table when `store` is `Some`.
+pub(super) fn append_decision_entry(
+    data_dir: &Path,
+    entry: &DecisionEntry,
+    store: Option<&std::sync::Arc<innerwarden_store::Store>>,
+) -> anyhow::Result<()> {
+    crate::decisions::append_chained(data_dir, entry, store)
 }
 
 /// Inject a synthetic high-severity SSH brute-force incident so the agent's main

--- a/crates/agent/src/dashboard/mod.rs
+++ b/crates/agent/src/dashboard/mod.rs
@@ -1564,7 +1564,7 @@ mod tests {
             prev_hash: None,
         };
 
-        append_decision_entry(dir.path(), &entry).unwrap();
+        append_decision_entry(dir.path(), &entry, None).unwrap();
 
         // File must exist and contain exactly one valid JSON line.
         let date = chrono::Local::now()
@@ -1582,7 +1582,7 @@ mod tests {
         assert_eq!(parsed.target_ip.as_deref(), Some("1.2.3.4"));
 
         // Appending a second entry should produce two lines.
-        append_decision_entry(dir.path(), &entry).unwrap();
+        append_decision_entry(dir.path(), &entry, None).unwrap();
         let contents2 = std::fs::read_to_string(&path).unwrap();
         assert_eq!(contents2.lines().count(), 2);
     }

--- a/crates/agent/src/decision_honeypot.rs
+++ b/crates/agent/src/decision_honeypot.rs
@@ -41,6 +41,7 @@ pub(crate) async fn execute_honeypot_decision(
             let post_ip = ip.to_string();
             let post_session_id = session_id.clone();
             let post_data_dir = data_dir.to_path_buf();
+            let post_store = state.sqlite_store.clone();
             let post_ai = state.ai_router.any_llm();
             let post_tg = state.telegram_client.clone();
             let post_gate_counter = state.telemetry.gate_suppressed_counter();
@@ -54,6 +55,7 @@ pub(crate) async fn execute_honeypot_decision(
                     &post_ip,
                     &post_session_id,
                     &post_data_dir,
+                    post_store,
                     post_ai,
                     post_tg,
                     post_gate_counter,

--- a/crates/agent/src/decisions.rs
+++ b/crates/agent/src/decisions.rs
@@ -154,29 +154,8 @@ impl DecisionWriter {
             .flush()
             .context("failed to flush decision entry")?;
 
-        // Dual-write to sqlite. Failure to persist the row mirrors up as a
-        // warning rather than an error: the JSONL write already succeeded
-        // (that is the audit trail of record), and a sqlite hiccup must not
-        // silently discard the whole decision.
         if let Some(ref store) = self.store {
-            let row = innerwarden_store::decisions::DecisionRow {
-                ts: entry.ts.to_rfc3339(),
-                incident_id: entry.incident_id.clone(),
-                action_type: entry.action_type.clone(),
-                target_ip: entry.target_ip.clone(),
-                target_user: entry.target_user.clone(),
-                confidence: entry.confidence as f64,
-                auto_executed: entry.auto_executed,
-                reason: Some(entry.reason.clone()),
-                data: line.clone(),
-            };
-            if let Err(e) = store.insert_decision(&row) {
-                warn!(
-                    incident_id = %entry.incident_id,
-                    error = %e,
-                    "decision written to JSONL but sqlite mirror failed"
-                );
-            }
+            mirror_to_sqlite(store, entry, &line);
         }
         Ok(())
     }
@@ -242,8 +221,15 @@ fn open_or_create(data_dir: &Path, date: &str) -> Result<File> {
 
 /// Standalone hash-chained append for code paths that don't own a `DecisionWriter`
 /// (e.g. the always-on honeypot task). Reads the last hash from the file, sets
-/// `prev_hash`, writes the entry, and flushes.
-pub fn append_chained(data_dir: &Path, entry: &DecisionEntry) -> Result<()> {
+/// `prev_hash`, writes the entry, flushes, and — when `store` is `Some` —
+/// mirrors the same canonical JSON line into the SQLite `decisions` table
+/// using the shared [`mirror_to_sqlite`] helper. Callers that pass `None`
+/// (tests) stay JSONL-only.
+pub fn append_chained(
+    data_dir: &Path,
+    entry: &DecisionEntry,
+    store: Option<&Arc<innerwarden_store::Store>>,
+) -> Result<()> {
     let today = chrono::Local::now()
         .date_naive()
         .format("%Y-%m-%d")
@@ -275,7 +261,38 @@ pub fn append_chained(data_dir: &Path, entry: &DecisionEntry) -> Result<()> {
         .with_context(|| format!("failed to open {}", path.display()))?;
     use std::io::Write;
     writeln!(f, "{line}").context("failed to write decision entry")?;
-    f.flush().context("failed to flush decision entry")
+    f.flush().context("failed to flush decision entry")?;
+
+    if let Some(store) = store {
+        mirror_to_sqlite(store, entry, &line);
+    }
+    Ok(())
+}
+
+/// Write a decision row to the SQLite `decisions` table. Shared by
+/// `DecisionWriter::write` and `append_chained` so the two writers can
+/// never drift in what they mirror. A mirror failure degrades to a `warn!`:
+/// the JSONL audit trail has already succeeded, and a transient SQLite
+/// error must not discard the whole decision.
+fn mirror_to_sqlite(store: &innerwarden_store::Store, entry: &DecisionEntry, line: &str) {
+    let row = innerwarden_store::decisions::DecisionRow {
+        ts: entry.ts.to_rfc3339(),
+        incident_id: entry.incident_id.clone(),
+        action_type: entry.action_type.clone(),
+        target_ip: entry.target_ip.clone(),
+        target_user: entry.target_user.clone(),
+        confidence: entry.confidence as f64,
+        auto_executed: entry.auto_executed,
+        reason: Some(entry.reason.clone()),
+        data: line.to_owned(),
+    };
+    if let Err(e) = store.insert_decision(&row) {
+        warn!(
+            incident_id = %entry.incident_id,
+            error = %e,
+            "decision written to JSONL but sqlite mirror failed"
+        );
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -472,6 +489,156 @@ mod tests {
         assert_eq!(entry.target_user, Some("alice".to_string()));
         assert_eq!(entry.target_ip, None);
         assert_eq!(entry.dry_run, true);
+    }
+
+    fn burst_entry(incident: &str) -> DecisionEntry {
+        DecisionEntry {
+            ts: chrono::Utc::now(),
+            incident_id: incident.into(),
+            host: "h".into(),
+            ai_provider: "test".into(),
+            action_type: "block_ip".into(),
+            target_ip: Some("203.0.113.99".into()),
+            target_user: None,
+            skill_id: Some("block-ip-ufw".into()),
+            confidence: 0.9,
+            auto_executed: true,
+            dry_run: false,
+            reason: "synthetic".into(),
+            estimated_threat: "high".into(),
+            execution_result: "ok".into(),
+            prev_hash: None,
+        }
+    }
+
+    fn read_jsonl_lines(dir: &std::path::Path) -> Vec<String> {
+        let today = chrono::Local::now().date_naive().format("%Y-%m-%d");
+        let path = dir.join(format!("decisions-{today}.jsonl"));
+        std::fs::read_to_string(path)
+            .unwrap_or_default()
+            .lines()
+            .filter(|l| !l.trim().is_empty())
+            .map(String::from)
+            .collect()
+    }
+
+    #[test]
+    fn append_chained_mirrors_to_sqlite() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = Arc::new(innerwarden_store::Store::open(dir.path()).expect("store"));
+        let entry = burst_entry("inc-append-1");
+
+        append_chained(dir.path(), &entry, Some(&store)).expect("append_chained");
+
+        let jsonl = read_jsonl_lines(dir.path());
+        assert_eq!(jsonl.len(), 1, "JSONL must contain exactly the one entry");
+        assert!(jsonl[0].contains("inc-append-1"));
+
+        let count = store.decisions_count().expect("count");
+        assert_eq!(
+            count, 1,
+            "SQLite decisions table must receive the mirrored row"
+        );
+    }
+
+    #[test]
+    fn append_chained_with_none_skips_sqlite() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = Arc::new(innerwarden_store::Store::open(dir.path()).expect("store"));
+        let entry = burst_entry("inc-append-none");
+
+        append_chained(dir.path(), &entry, None).expect("append_chained None");
+
+        let jsonl = read_jsonl_lines(dir.path());
+        assert_eq!(jsonl.len(), 1, "JSONL still writes when store is None");
+
+        let count = store.decisions_count().expect("count");
+        assert_eq!(count, 0, "SQLite must stay untouched when store is None");
+    }
+
+    #[test]
+    fn jsonl_and_sqlite_counts_match_under_mixed_writer_burst() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = Arc::new(innerwarden_store::Store::open(dir.path()).expect("store"));
+        let mut writer =
+            DecisionWriter::with_store(dir.path(), Some(store.clone())).expect("writer");
+
+        for i in 0..5 {
+            writer
+                .write(&burst_entry(&format!("inc-writer-{i}")))
+                .expect("writer.write");
+            append_chained(
+                dir.path(),
+                &burst_entry(&format!("inc-append-{i}")),
+                Some(&store),
+            )
+            .expect("append_chained");
+        }
+
+        let jsonl = read_jsonl_lines(dir.path());
+        let sqlite = store.decisions_count().expect("count") as usize;
+        assert_eq!(
+            jsonl.len(),
+            sqlite,
+            "JSONL and SQLite counts must match after mixed-writer burst"
+        );
+        assert_eq!(jsonl.len(), 10, "10 total entries (5 + 5) expected");
+    }
+
+    #[test]
+    fn hash_chain_stays_intact_across_mixed_writers() {
+        // Two invariants matter when DecisionWriter and append_chained interleave:
+        //   1. The SQLite hash chain remains self-consistent (its own scheme:
+        //      SHA-256(prev_hash || data)).
+        //   2. For each sequence position, the JSONL line and the SQLite
+        //      `data` column hold the same canonical JSON. Divergence here
+        //      means the two stores disagree on what actually happened.
+        // The two hash schemes differ by design (JSONL hashes the whole line
+        // including prev_hash; SQLite hashes prev_hash concatenated with
+        // data), so byte-equal chain comparison is not the right check —
+        // content correspondence plus self-consistency is.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = Arc::new(innerwarden_store::Store::open(dir.path()).expect("store"));
+        let mut writer =
+            DecisionWriter::with_store(dir.path(), Some(store.clone())).expect("writer");
+
+        writer
+            .write(&burst_entry("inc-mix-1"))
+            .expect("writer.write 1");
+        append_chained(dir.path(), &burst_entry("inc-mix-2"), Some(&store))
+            .expect("append_chained 2");
+        writer
+            .write(&burst_entry("inc-mix-3"))
+            .expect("writer.write 3");
+        append_chained(dir.path(), &burst_entry("inc-mix-4"), Some(&store))
+            .expect("append_chained 4");
+
+        let chain = store.verify_hash_chain().expect("verify");
+        assert!(
+            chain.intact,
+            "SQLite hash chain must remain intact, broken_at = {:?}",
+            chain.broken_at
+        );
+        assert_eq!(chain.verified, 4);
+
+        let jsonl = read_jsonl_lines(dir.path());
+        let sqlite_rows = store
+            .decisions_since(0, 100)
+            .expect("decisions_since")
+            .into_iter()
+            .map(|(_, data)| data)
+            .collect::<Vec<_>>();
+        assert_eq!(
+            jsonl.len(),
+            sqlite_rows.len(),
+            "mixed-writer burst must keep JSONL and SQLite row counts aligned"
+        );
+        for (i, (j, s)) in jsonl.iter().zip(sqlite_rows.iter()).enumerate() {
+            assert_eq!(
+                j, s,
+                "row {i} diverges between JSONL line and SQLite data column"
+            );
+        }
     }
 
     #[test]

--- a/crates/agent/src/honeypot_always_on.rs
+++ b/crates/agent/src/honeypot_always_on.rs
@@ -50,6 +50,7 @@ async fn handle_always_on_connection(
     telegram_client: Option<Arc<telegram::TelegramClient>>,
     gate_suppressed_counter: Arc<AtomicU64>,
     data_dir: PathBuf,
+    sqlite_store: Option<Arc<innerwarden_store::Store>>,
     interaction: String,
     blocklist_already_has_ip: bool,
     responder_enabled: bool,
@@ -227,7 +228,8 @@ async fn handle_always_on_connection(
                     },
                     prev_hash: None,
                 };
-                if let Err(e) = decisions::append_chained(&data_dir, &entry) {
+                if let Err(e) = decisions::append_chained(&data_dir, &entry, sqlite_store.as_ref())
+                {
                     warn!("honeypot: failed to write decision: {e:#}");
                 }
                 true
@@ -335,6 +337,7 @@ pub(crate) async fn run_always_on_honeypot(
     abuseipdb_client: Option<Arc<abuseipdb::AbuseIpDbClient>>,
     abuseipdb_threshold: u8,
     data_dir: PathBuf,
+    sqlite_store: Option<Arc<innerwarden_store::Store>>,
     responder_enabled: bool,
     dry_run: bool,
     block_backend: String,
@@ -403,9 +406,11 @@ pub(crate) async fn run_always_on_honeypot(
                                 let threshold = abuseipdb_threshold;
                                 let re = responder_enabled;
                                 let dr = dry_run;
+                                let store_c = sqlite_store.clone();
                                 tokio::spawn(async move {
                                     always_on_abuseipdb_block(
-                                        &ip_c, score, threshold, &dd, re, dr, &bb, &sk,
+                                        &ip_c, score, threshold, &dd, store_c.as_ref(), re, dr,
+                                        &bb, &sk,
                                     )
                                     .await;
                                 });
@@ -426,6 +431,7 @@ pub(crate) async fn run_always_on_honeypot(
                 let tg_clone = telegram_client.clone();
                 let gate_counter = gate_suppressed_counter.clone();
                 let dd = data_dir.clone();
+                let store_c = sqlite_store.clone();
                 let ip_clone = ip.clone();
                 let intr = interaction.clone();
                 let bb = block_backend.clone();
@@ -443,6 +449,7 @@ pub(crate) async fn run_always_on_honeypot(
                         tg_clone,
                         gate_counter,
                         dd,
+                        store_c,
                         intr,
                         bl_has_ip,
                         re,
@@ -476,6 +483,7 @@ async fn always_on_abuseipdb_block(
     score: u8,
     threshold: u8,
     data_dir: &Path,
+    sqlite_store: Option<&Arc<innerwarden_store::Store>>,
     responder_enabled: bool,
     dry_run: bool,
     block_backend: &str,
@@ -507,7 +515,7 @@ async fn always_on_abuseipdb_block(
         prev_hash: None,
     };
 
-    if let Err(e) = decisions::append_chained(data_dir, &entry) {
+    if let Err(e) = decisions::append_chained(data_dir, &entry, sqlite_store) {
         warn!("honeypot abuseipdb gate: failed to write decision: {e:#}");
     }
 
@@ -651,6 +659,7 @@ mod tests {
                 None,                                 // abuseipdb_client
                 0,                                    // abuseipdb_threshold
                 data_dir,
+                None,                 // sqlite_store
                 false,                // responder_enabled
                 true,                 // dry_run
                 "ufw".to_string(),    // block_backend

--- a/crates/agent/src/honeypot_post_session.rs
+++ b/crates/agent/src/honeypot_post_session.rs
@@ -111,6 +111,7 @@ pub(crate) async fn spawn_post_session_tasks(
     ip: &str,
     session_id: &str,
     data_dir: &Path,
+    sqlite_store: Option<Arc<innerwarden_store::Store>>,
     ai_provider: Option<Arc<dyn ai::AiProvider>>,
     telegram_client: Option<Arc<telegram::TelegramClient>>,
     gate_suppressed_counter: Arc<AtomicU64>,
@@ -249,7 +250,9 @@ pub(crate) async fn spawn_post_session_tasks(
                         },
                         prev_hash: None,
                     };
-                    if let Err(e) = decisions::append_chained(data_dir, &entry) {
+                    if let Err(e) =
+                        decisions::append_chained(data_dir, &entry, sqlite_store.as_ref())
+                    {
                         tracing::warn!("honeypot post-session: failed to write decision: {e:#}");
                     }
                     true

--- a/crates/agent/src/loops/boot.rs
+++ b/crates/agent/src/loops/boot.rs
@@ -1178,6 +1178,7 @@ pub(crate) async fn run_agent(cli: crate::Cli) -> Result<()> {
             let tg_clone = state.telegram_client.clone();
             let gate_counter = state.telemetry.gate_suppressed_counter();
             let data_dir_clone = cli.data_dir.clone();
+            let store_clone = state.sqlite_store.clone();
             let responder_enabled = cfg.responder.enabled;
             let dry_run = cfg.responder.dry_run;
             let block_backend = cfg.responder.block_backend.clone();
@@ -1199,6 +1200,7 @@ pub(crate) async fn run_agent(cli: crate::Cli) -> Result<()> {
                         abuseipdb_client,
                         abuseipdb_threshold,
                         data_dir_clone,
+                        store_clone,
                         responder_enabled,
                         dry_run,
                         block_backend,


### PR DESCRIPTION
## Summary

Spec 037 I-02 slice 4 (decisions, highest-risk slice), **PR-1 of ~3**.

Closes a real gap between the JSONL audit trail and the SQLite `decisions` table:

- `DecisionWriter::write` has dual-written since spec 016.
- `append_chained` — used by 4 code paths (always-on honeypot listener, AbuseIPDB gate, post-session handler, dashboard manual actions) — wrote only to JSONL.
- Result: SQLite was silently missing every decision from those paths. Dashboards and `/metrics` that query SQLite (compliance tab, drift harness) saw a strict subset of reality.

## What changes

- `append_chained` takes `Option<&Arc<Store>>`; when `Some`, mirrors the canonical JSON line to SQLite using a new shared helper `mirror_to_sqlite`.
- `DecisionWriter::write` now calls the same helper. One source of truth for the mirror — the two writers cannot drift in what they persist.
- 4 callsites updated to thread `state.sqlite_store` through:
  - `honeypot_always_on::handle_always_on_connection` (post-session honeypot block)
  - `honeypot_always_on::always_on_abuseipdb_block` (AbuseIPDB gate)
  - `honeypot_post_session::spawn_post_session_tasks`
  - `dashboard::actions::append_decision_entry` + `execute_block_ip` + `execute_suspend_user`
- Spawn points (`loops/boot.rs` always-on task, `decision_honeypot.rs` post-session) pass `state.sqlite_store.clone()`.

## Out of scope (per slice-4 plan)

- `verify_hash_chain` cross-check (JSONL vs SQLite) → PR-2.
- `response_lifecycle` warm-cache restart consistency → PR-3.
- Reconciliation path untouched. JSONL remains canonical append-only audit.

## Regression anchors

All in `crates/agent/src/decisions.rs` tests:

- `append_chained_mirrors_to_sqlite` — `Some(store)` ⇒ both JSONL and SQLite contain the row.
- `append_chained_with_none_skips_sqlite` — `None` ⇒ JSONL only; SQLite empty.
- `jsonl_and_sqlite_counts_match_under_mixed_writer_burst` — 5 `DecisionWriter::write` + 5 `append_chained` interleaved ⇒ JSONL lines == SQLite rows == 10.
- `hash_chain_stays_intact_across_mixed_writers` — after mixed writes: (a) `store.verify_hash_chain().intact` is true, (b) each JSONL line equals the corresponding SQLite `data` column.

## Note on hash chain consistency

The JSONL chain (`SHA-256(line)`) and the SQLite chain (`SHA-256(prev_hash || data)`) use different formulas by design. They cannot be byte-equal. What is verifiable and what the anchor checks:

1. SQLite chain is self-consistent (`verify_hash_chain` passes).
2. Row-for-row content correspondence between JSONL line N and SQLite `data` field of row N.

Unifying the two hash schemes is out of scope for this PR — that is an on-disk format change and belongs in its own spec if ever worth doing.

## Test plan

- [x] `cargo build -p innerwarden-agent` clean
- [x] `cargo test` — 4435 passed, 4 ignored
- [x] `cargo fmt --check` clean
- [x] `cargo clippy -p innerwarden-agent --all-targets` clean on touched files
- [x] `make heap-budget` — 3 anchors pass
- [ ] codecov/patch

🤖 Generated with [Claude Code](https://claude.com/claude-code)