### PR TITLE
feat(knowledge_graph): migrate dated-snapshot readers to SQLite-first (spec 037 slice 5 PR-2)

### DIFF
--- a/crates/agent/src/knowledge_graph/persistence.rs
+++ b/crates/agent/src/knowledge_graph/persistence.rs
@@ -442,6 +442,23 @@ impl KnowledgeGraph {
         Some(graph)
     }
 
+    /// SQLite-first loader with JSON fallback. Opens a short-lived `Store`
+    /// against `data_dir/innerwarden.db`, tries the SQLite blob first, falls
+    /// back to the dated JSON snapshot on miss. Callers that already hold a
+    /// live store should call `load_dated_from_store` directly.
+    ///
+    /// Priority matches the rule "if both sinks hold a snapshot for `date`,
+    /// SQLite wins and the JSON file is never consulted" — the fallback
+    /// cannot mask drift between the two.
+    pub fn load_dated_sqlite_first(data_dir: &Path, date: &str) -> Option<Self> {
+        if let Ok(store) = innerwarden_store::Store::open(data_dir) {
+            if let Some(g) = Self::load_dated_from_store(&store, date) {
+                return Some(g);
+            }
+        }
+        Self::load_dated(data_dir, date)
+    }
+
     /// Delete SQLite graph snapshots older than `keep_days` days.
     pub fn cleanup_store_snapshots(store: &innerwarden_store::Store, keep_days: u32) {
         let cutoff = (chrono::Local::now().date_naive() - chrono::Duration::days(keep_days as i64))
@@ -1095,6 +1112,114 @@ mod tests {
         assert!(
             check.agrees(),
             "both sinks hold the same bytes for the same date; cross-check must agree: {check:?}"
+        );
+    }
+
+    // ── spec 037 slice 5 PR-2: load_dated_sqlite_first anchors ──────
+    //
+    // The helper is the idiom the 6 migrated callsites now use
+    // (neural_lifecycle × 3, report.rs × 2, threat_report.rs × 1).
+    // Four invariants matter:
+    //   1. SQLite populated, JSON missing → loads from SQLite.
+    //   2. JSON populated, SQLite empty → loads from JSON fallback.
+    //   3. Both present and identical → loads something; either
+    //      source is fine because they agree (PR-1 equivalence anchor
+    //      already proves structural equality for the same bytes).
+    //   4. Divergence: SQLite wins, JSON fallback does NOT run. This
+    //      is the load-bearing property — consumers that migrated
+    //      must see the canonical source, not stale JSON.
+
+    #[test]
+    fn load_dated_sqlite_first_reads_sqlite_when_json_missing() {
+        let dir = tempdir().unwrap();
+        let store = innerwarden_store::Store::open(dir.path()).expect("store");
+        let date = "2026-04-20";
+
+        let g = seed_graph_with_mixed_nodes();
+        let snap = g.serialize_snapshot_bytes().expect("serialize");
+        store
+            .save_graph_snapshot(date, &snap.bytes, snap.nodes_count, snap.edges_count)
+            .expect("save to store");
+        // No JSON file written.
+
+        let loaded = KnowledgeGraph::load_dated_sqlite_first(dir.path(), date)
+            .expect("sqlite-only must load");
+        assert_eq!(graph_summary(&loaded), graph_summary(&g));
+    }
+
+    #[test]
+    fn load_dated_sqlite_first_falls_back_to_json_when_sqlite_missing() {
+        let dir = tempdir().unwrap();
+        // Open+close a store so the innerwarden.db file exists but has no row.
+        {
+            let _ = innerwarden_store::Store::open(dir.path()).expect("store open");
+        }
+        let date = "2026-04-20";
+
+        let g = seed_graph_with_mixed_nodes();
+        let snap = g.serialize_snapshot_bytes().expect("serialize");
+        let safe_name = safe_snapshot_filename(date).unwrap();
+        KnowledgeGraph::write_snapshot_bytes(&dir.path().join(safe_name), &snap)
+            .expect("write json");
+        // No SQLite row for this date.
+
+        let loaded = KnowledgeGraph::load_dated_sqlite_first(dir.path(), date)
+            .expect("json fallback must load");
+        assert_eq!(graph_summary(&loaded), graph_summary(&g));
+    }
+
+    #[test]
+    fn load_dated_sqlite_first_prefers_sqlite_when_both_present_and_diverge() {
+        // Plant deliberately different graphs in the two sinks. The
+        // helper must return the SQLite graph — if the JSON fallback
+        // ever runs when SQLite had an answer, migrated consumers
+        // would silently read the wrong source.
+        let dir = tempdir().unwrap();
+        let store = innerwarden_store::Store::open(dir.path()).expect("store");
+        let date = "2026-04-20";
+
+        let mut sqlite_graph = KnowledgeGraph::new();
+        sqlite_graph.ensure_ip("203.0.113.77", Utc::now()); // unique to SQLite
+
+        let mut json_graph = KnowledgeGraph::new();
+        json_graph.ensure_ip("198.51.100.88", Utc::now()); // unique to JSON
+
+        let sq_snap = sqlite_graph.serialize_snapshot_bytes().unwrap();
+        store
+            .save_graph_snapshot(
+                date,
+                &sq_snap.bytes,
+                sq_snap.nodes_count,
+                sq_snap.edges_count,
+            )
+            .expect("save sqlite");
+
+        let json_snap = json_graph.serialize_snapshot_bytes().unwrap();
+        let safe_name = safe_snapshot_filename(date).unwrap();
+        KnowledgeGraph::write_snapshot_bytes(&dir.path().join(safe_name), &json_snap)
+            .expect("write json");
+
+        let loaded = KnowledgeGraph::load_dated_sqlite_first(dir.path(), date)
+            .expect("one of the two must load");
+        assert!(
+            loaded.find_by_ip("203.0.113.77").is_some(),
+            "SQLite IP must be present — SQLite wins"
+        );
+        assert!(
+            loaded.find_by_ip("198.51.100.88").is_none(),
+            "JSON IP must NOT be present — fallback was masked by SQLite hit"
+        );
+    }
+
+    #[test]
+    fn load_dated_sqlite_first_returns_none_when_neither_sink_has_date() {
+        let dir = tempdir().unwrap();
+        let _store = innerwarden_store::Store::open(dir.path()).expect("store");
+        // Empty store, no JSON file.
+
+        assert!(
+            KnowledgeGraph::load_dated_sqlite_first(dir.path(), "2026-04-20").is_none(),
+            "no data in either sink must return None, not panic"
         );
     }
 

--- a/crates/agent/src/neural_lifecycle.rs
+++ b/crates/agent/src/neural_lifecycle.rs
@@ -1317,7 +1317,8 @@ pub fn read_fp_report_detectors(data_dir: &Path, days: i64) -> HashSet<String> {
     for d in 0..days {
         let date = today - chrono::Duration::days(d);
         let date_str = date.format("%Y-%m-%d").to_string();
-        if let Some(graph) = crate::knowledge_graph::KnowledgeGraph::load_dated(data_dir, &date_str)
+        if let Some(graph) =
+            crate::knowledge_graph::KnowledgeGraph::load_dated_sqlite_first(data_dir, &date_str)
         {
             use crate::knowledge_graph::types::{Node, NodeType};
             for id in graph.nodes_of_type(NodeType::Incident) {
@@ -1397,7 +1398,8 @@ pub fn read_fp_report_counts(data_dir: &Path, days: i64) -> Vec<(String, String,
     for d in 0..days {
         let date = today - chrono::Duration::days(d);
         let date_str = date.format("%Y-%m-%d").to_string();
-        if let Some(graph) = crate::knowledge_graph::KnowledgeGraph::load_dated(data_dir, &date_str)
+        if let Some(graph) =
+            crate::knowledge_graph::KnowledgeGraph::load_dated_sqlite_first(data_dir, &date_str)
         {
             use crate::knowledge_graph::types::{Node, NodeType};
             for id in graph.nodes_of_type(NodeType::Incident) {
@@ -2328,7 +2330,8 @@ fn load_blocked_ips(data_dir: &Path) -> HashSet<String> {
     for days_ago in 0..7i64 {
         let date = today - chrono::Duration::days(days_ago);
         let date_str = date.format("%Y-%m-%d").to_string();
-        if let Some(graph) = crate::knowledge_graph::KnowledgeGraph::load_dated(data_dir, &date_str)
+        if let Some(graph) =
+            crate::knowledge_graph::KnowledgeGraph::load_dated_sqlite_first(data_dir, &date_str)
         {
             use crate::knowledge_graph::types::{Node, NodeType};
             for id in graph.nodes_of_type(NodeType::Incident) {

--- a/crates/agent/src/report.rs
+++ b/crates/agent/src/report.rs
@@ -915,7 +915,7 @@ fn compute_recent_window_at(
     // so the comparison is `chrono::DateTime`-typed, not string.
     let mut snapshots: Vec<(NaiveDate, crate::knowledge_graph::KnowledgeGraph)> = Vec::new();
     if let Some(today_g) =
-        crate::knowledge_graph::KnowledgeGraph::load_dated(data_dir, analyzed_date)
+        crate::knowledge_graph::KnowledgeGraph::load_dated_sqlite_first(data_dir, analyzed_date)
     {
         if let Ok(d) = NaiveDate::parse_from_str(analyzed_date, "%Y-%m-%d") {
             snapshots.push((d, today_g));
@@ -929,7 +929,7 @@ fn compute_recent_window_at(
         let (prev_d, prev_str) = prev_date_str;
         if cutoff.date_naive() <= prev_d {
             if let Some(prev_g) =
-                crate::knowledge_graph::KnowledgeGraph::load_dated(data_dir, &prev_str)
+                crate::knowledge_graph::KnowledgeGraph::load_dated_sqlite_first(data_dir, &prev_str)
             {
                 snapshots.push((prev_d, prev_g));
             }

--- a/crates/agent/src/threat_report.rs
+++ b/crates/agent/src/threat_report.rs
@@ -272,8 +272,9 @@ pub fn generate_monthly(
         let date_str = date.format("%Y-%m-%d").to_string();
         let week_idx = (day_offset / 7).min(3) as usize;
 
-        // Try graph snapshot first
-        if let Some(graph) = crate::knowledge_graph::KnowledgeGraph::load_dated(data_dir, &date_str)
+        // Try graph snapshot first (SQLite canonical, JSON fallback).
+        if let Some(graph) =
+            crate::knowledge_graph::KnowledgeGraph::load_dated_sqlite_first(data_dir, &date_str)
         {
             use crate::knowledge_graph::types::{Node, NodeType, Relation};
             let event_count = graph.edge_count() as u64; // approximate: edges ≈ events


### PR DESCRIPTION
## Summary

Spec 037 I-02 slice 5, **PR-2 of ~3**. Migrates the 6 real JSON-only consumers of dated KG snapshots to a SQLite-first pattern with JSON fallback.

Builds on PR-1 (#284) which anchored structural equivalence between \`load_dated_from_store\` and \`load_dated\` for the same date.

## New helper

\`KnowledgeGraph::load_dated_sqlite_first(data_dir, date)\`:
- Opens a short-lived \`Store\` against \`data_dir/innerwarden.db\`.
- Tries the SQLite blob first via \`load_dated_from_store\`.
- Falls back to \`load_dated\` (dated JSON file) on miss.
- Priority matches the rule **SQLite wins on divergence** — when both sinks hold a snapshot for the same date, the fallback is never consulted.

## 6 callsites migrated (one-line swap each)

| File | Line | Context |
|---|---|---|
| \`neural_lifecycle.rs\` | 1320 | \`read_fp_report_detectors\` |
| \`neural_lifecycle.rs\` | 1400 | \`read_fp_report_counts\` |
| \`neural_lifecycle.rs\` | 2331 | \`load_blocked_ips\` |
| \`report.rs\` | 918 | \`compute_recent_window_at\` — cross-midnight path |
| \`report.rs\` | 932 | \`compute_recent_window_at\` — previous-day load |
| \`threat_report.rs\` | 276 | \`generate_monthly\` per-day scan |

The cross-midnight fix for \`compute_recent_window\` (\`RECURRING_BUGS.md\`) stays intact — only the backing source changes.

## Legitimately untouched

- \`decision_cooldown.rs:179\` — **explicit out-of-scope** per user instruction.
- \`report.rs:1221\` — already the JSON fallback of the SQLite-first pair at line 1215.
- \`persistence.rs:920-921, 995, 1080\` — path-traversal and equivalence anchors testing the low-level \`load_dated\` primitive directly.

## Per-call SQLite connection overhead

\`Store::open\` runs pragmas and migration checks. Concrete impact:
- ~7 extra opens per nightly training (\`neural_lifecycle\`, weekly cadence).
- ~28-31 opens per monthly report (\`threat_report\`).
- ~2 opens per daily report (\`report\`).

Acceptable for a correctness-oriented slice. Plumbing the live \`state.sqlite_store\` through these call chains is a perf optimization deferred to a later pass if it matters in prod.

## Regression anchors (4 new, all in \`knowledge_graph::persistence::tests\`)

- \`load_dated_sqlite_first_reads_sqlite_when_json_missing\` — SQLite populated, JSON missing → loads from SQLite.
- \`load_dated_sqlite_first_falls_back_to_json_when_sqlite_missing\` — JSON populated, SQLite empty → loads from JSON.
- \`load_dated_sqlite_first_prefers_sqlite_when_both_present_and_diverge\` — **the load-bearing property**: divergent sinks → SQLite content wins, JSON fallback does NOT mask. Pinned with different IP per sink so the assertion is concrete.
- \`load_dated_sqlite_first_returns_none_when_neither_sink_has_date\` — returns None (not panic).

## Test plan

- [x] \`cargo build -p innerwarden-agent\` clean
- [x] \`cargo test\` — 4455 passed, 4 ignored
- [x] \`cargo fmt --check\` clean
- [x] \`cargo clippy -p innerwarden-agent --all-targets\` clean on touched files
- [x] \`make heap-budget\` — 3 anchors pass
- [ ] codecov/patch

## Not in scope

- \`decision_cooldown\` — not a KG consumer.
- Boot path — untouched.
- Snapshot format — untouched.
- Removing JSON write — PR-3 after PR-2 settles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)