### PR TITLE
fix(boot): wrap nightly autoencoder training in block_in_place

### DIFF
--- a/crates/agent/src/loops/boot.rs
+++ b/crates/agent/src/loops/boot.rs
@@ -1379,15 +1379,51 @@ pub(crate) async fn run_agent(cli: crate::Cli) -> Result<()> {
                     }
 
                     // Autoencoder nightly training — at 3 AM UTC.
+                    //
+                    // The training routine is synchronous and CPU-heavy: it
+                    // reads tens of thousands of events from SQLite, builds
+                    // feature windows, runs N epochs of gradient descent on
+                    // the autoencoder, then writes the model. Production hang
+                    // observed on 2026-04-25 03:00 UTC: running this inline
+                    // in the async tick blocked the tokio main thread for
+                    // the entire training duration; meanwhile other tasks
+                    // (dashboard handlers holding `state.knowledge_graph`'s
+                    // `std::sync::RwLock`, mesh ticker holding its own
+                    // locks, the v2 src_ip backfill mid-transaction) all
+                    // ended up in `futex_wait` cycles — classic AB-BA
+                    // deadlock with no progress, 19 threads stuck.
+                    //
+                    // `block_in_place` tells the multi-thread tokio runtime
+                    // "I'm about to do CPU/blocking work; transfer my
+                    // workers." Other tokio tasks keep making progress on
+                    // sibling worker threads. The training future is
+                    // unchanged from the caller's view; only the runtime
+                    // scheduling property differs. Requires a multi-thread
+                    // runtime (we have one via `#[tokio::main]` default —
+                    // single-thread would panic).
                     {
                         let hour = chrono::Utc::now().hour();
-                        if hour == 3 {
+                        // Operator override for validation runs (tested 2026-04-25
+                        // after the AB-BA deadlock at 03:00 UTC). Default 3 keeps
+                        // production behavior unchanged. Setting to the current
+                        // hour, restarting the agent, and observing one cycle
+                        // proves the `block_in_place` wrapper above prevents the
+                        // hang without waiting 24h for the natural trigger.
+                        let trigger_hour: u32 = std::env::var("INNERWARDEN_AUTOENCODER_TRAIN_HOUR")
+                            .ok()
+                            .and_then(|s| s.parse::<u32>().ok())
+                            .filter(|h| *h <= 23)
+                            .unwrap_or(3);
+                        if hour == trigger_hour {
                             let today_key = format!("anomaly_train:{}", chrono::Utc::now().format("%Y-%m-%d"));
                             if !state.store.has_cooldown(state_store::CooldownTable::Decision, &today_key) {
-                                info!("autoencoder: triggering nightly training");
-                                match state.anomaly_engine.train_nightly_with_store(
-                                    state.sqlite_store.as_deref(),
-                                ) {
+                                info!(trigger_hour, "autoencoder: triggering nightly training");
+                                let result = tokio::task::block_in_place(|| {
+                                    state.anomaly_engine.train_nightly_with_store(
+                                        state.sqlite_store.as_deref(),
+                                    )
+                                });
+                                match result {
                                     Ok(()) => {
                                         info!(
                                             maturity = format!("{:.2}", state.anomaly_engine.maturity),


### PR DESCRIPTION
## What broke

Production agent hung on **2026-04-25 03:00 UTC**. Last log at 02:59:23 (\"mesh ticker fired\"); zero logs for 5+ hours after. Forensic state captured via \`/proc\` before manual restart:

- 19 threads, **ALL in \`futex_wait_queue\`** — deadlock, not idle.
- CPU 9.6% (worker threads spinning on wake / re-block cycle).
- 2 fds open to \`innerwarden.db-wal\` simultaneously (anomalous).
- WAL mtime 03:02 — transaction in flight when the hang began.

Classic AB-BA deadlock. Process alive but tokio runtime fully blocked.

## Root cause

\`AnomalyEngine::train_nightly_with_store\` is **synchronous and CPU-heavy** — reads tens of thousands of events, builds feature windows, runs N epochs of gradient descent, writes the model. The 03:00 UTC trigger at \`boot.rs:1382\` calls it **inline** inside the async slow_loop tick, so for the entire training duration:

- The tokio main thread is blocked.
- Workers cannot progress on sibling tasks.
- Tasks holding \`state.knowledge_graph\`'s \`std::sync::RwLock\` (dashboard handlers — see \`RECURRING_BUGS.md\` *Dashboard handlers block tokio worker threads*) cannot release.
- Mesh ticker / src_ip backfill mid-transaction cannot complete.

**PR #288 didn't introduce this** — the synchronous-on-tokio bug is pre-existing. But PR #288 removed the JSON dual-write release valve, making the lock-cycle harder to escape.

## Fix

Wrap the synchronous training call in \`tokio::task::block_in_place\`. This tells the multi-thread tokio runtime \"I'm about to do CPU/blocking work; transfer my workers.\" Sibling tasks keep making progress on other worker threads. **No semantic change to training** — only the runtime scheduling property differs.

\`#[tokio::main]\` defaults to multi-thread runtime → \`block_in_place\` is safe.

## Validation lever

Production validation needs the 03:00 UTC code path to fire. Waiting 24h for the natural trigger is too slow when verifying the fix.

New env var \`INNERWARDEN_AUTOENCODER_TRAIN_HOUR\` (0-23, default 3) overrides the trigger hour. Operator workflow:

\`\`\`bash
# 1. Set env var to current hour (e.g., 04 if running at 04:30 UTC)
sudo systemctl edit innerwarden-agent
# Add: Environment=\"INNERWARDEN_AUTOENCODER_TRAIN_HOUR=4\"
sudo systemctl restart innerwarden-agent

# 2. Watch logs for one tick cycle (~30s)
sudo journalctl -u innerwarden-agent -f | grep autoencoder

# 3. Expected: \"autoencoder: triggering nightly training\" → \"training complete\"
#    With other tasks still ticking concurrently (no hang).

# 4. Revert
sudo systemctl edit innerwarden-agent  # remove the override
sudo systemctl restart innerwarden-agent
\`\`\`

## Why no unit test

The deadlock requires concurrent state pressure that's hard to simulate without a brittle test that doesn't actually exercise the failure mode. **The validation IS the production rollout.** If the agent ticks normally during training, fix holds.

## Out of scope (flagged)

The underlying \`state.knowledge_graph: Arc<std::sync::RwLock<...>>\` contention pattern is still present — it was the lock the synchronous training caused to deadlock against. Long-term fix: migrate to \`tokio::sync::RwLock\` so dashboard handlers cannot block tokio workers. This PR only addresses the immediate trigger.

## Test plan

- [x] \`cargo build -p innerwarden-agent\` clean
- [x] \`cargo test\` — 4463 passed, 4 ignored
- [x] \`cargo fmt --check\` clean
- [x] \`cargo clippy -p innerwarden-agent --all-targets\` clean on touched lines
- [x] \`make heap-budget\` — 3 anchors pass
- [ ] codecov/patch
- [ ] **Production validation:** deploy, set \`INNERWARDEN_AUTOENCODER_TRAIN_HOUR\` to current hour, restart, observe one cycle ticks normally during training.

🤖 Generated with [Claude Code](https://claude.com/claude-code)