### PR TITLE
test(agent): add unit tests for decision_honeypot dispatch (#211)

### DIFF
--- a/crates/agent/src/decision_honeypot.rs
+++ b/crates/agent/src/decision_honeypot.rs
@@ -104,3 +104,142 @@ pub(crate) async fn execute_honeypot_decision(
         ("skipped: honeypot skill not available".to_string(), false)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use chrono::Local;
+    use innerwarden_core::{event::Severity, incident::Incident};
+
+    use super::execute_honeypot_decision;
+
+    fn make_test_incident() -> Incident {
+        Incident {
+            ts: chrono::Utc::now(),
+            host: "test-host".to_string(),
+            incident_id: "honeypot:test".to_string(),
+            severity: Severity::High,
+            title: "Test honeypot incident".to_string(),
+            summary: "fixture".to_string(),
+            evidence: serde_json::json!({}),
+            recommended_checks: vec![],
+            tags: vec!["honeypot".to_string()],
+            entities: vec![],
+        }
+    }
+
+    fn honeypot_events_path(data_dir: &std::path::Path) -> std::path::PathBuf {
+        let today = Local::now().date_naive().format("%Y-%m-%d");
+        data_dir.join(format!("events-{today}.jsonl"))
+    }
+
+    fn blank_skill_registry(state: &mut crate::AgentState) {
+        // Use the public `empty()` constructor so the test exercises the
+        // no-honeypot branch without reaching into `SkillRegistry`'s
+        // private fields.
+        state.skill_registry = crate::skills::SkillRegistry::empty();
+    }
+
+    #[tokio::test]
+    async fn execute_honeypot_decision_returns_skipped_when_no_honeypot_skill() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut state = crate::tests::triage_test_state(dir.path());
+        blank_skill_registry(&mut state);
+
+        let cfg = crate::config::AgentConfig::default();
+        let incident = make_test_incident();
+
+        let (msg, auto_executed) =
+            execute_honeypot_decision("192.0.2.1", &incident, dir.path(), &cfg, &mut state).await;
+
+        assert_eq!(msg, "skipped: honeypot skill not available");
+        assert!(!auto_executed, "auto_executed should stay false");
+    }
+
+    #[tokio::test]
+    async fn execute_honeypot_decision_skipped_message_is_stable() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut state = crate::tests::triage_test_state(dir.path());
+        blank_skill_registry(&mut state);
+
+        let cfg = crate::config::AgentConfig::default();
+        let incident = make_test_incident();
+
+        let (msg, _) =
+            execute_honeypot_decision("192.0.2.2", &incident, dir.path(), &cfg, &mut state).await;
+
+        assert!(
+            msg.contains("honeypot skill not available"),
+            "expected stable skip message text, got: {msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn execute_honeypot_decision_auto_executed_is_false_on_early_return() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut state = crate::tests::triage_test_state(dir.path());
+        blank_skill_registry(&mut state);
+
+        let cfg = crate::config::AgentConfig::default();
+        let incident = make_test_incident();
+
+        let (_, auto_executed) =
+            execute_honeypot_decision("192.0.2.3", &incident, dir.path(), &cfg, &mut state).await;
+
+        assert!(!auto_executed);
+    }
+
+    #[tokio::test]
+    async fn execute_honeypot_decision_writes_one_marker_for_listener_dry_run() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut state = crate::tests::triage_test_state(dir.path());
+
+        let mut cfg = crate::config::AgentConfig::default();
+        cfg.responder.dry_run = true;
+        cfg.honeypot.mode = "listener".to_string();
+        cfg.honeypot.duration_secs = 1;
+
+        let incident = make_test_incident();
+
+        let (msg, auto_executed) =
+            execute_honeypot_decision("192.0.2.4", &incident, dir.path(), &cfg, &mut state).await;
+
+        let events_path = honeypot_events_path(dir.path());
+        let contents = std::fs::read_to_string(&events_path).expect("read events file");
+
+        assert!(msg.contains("honeypot marker written to"));
+        assert!(!auto_executed);
+        assert_eq!(
+            contents.lines().count(),
+            1,
+            "marker event must be written exactly once per honeypot invocation"
+        );
+        assert!(contents.contains("\"kind\":\"honeypot.demo_decoy_hit\""));
+        assert!(contents.contains("\"incident_id\":\"honeypot:test\""));
+    }
+
+    #[tokio::test]
+    async fn execute_honeypot_decision_returns_clear_error_when_listener_guard_rejects_bind() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut state = crate::tests::triage_test_state(dir.path());
+
+        let mut cfg = crate::config::AgentConfig::default();
+        cfg.responder.dry_run = false;
+        cfg.honeypot.mode = "listener".to_string();
+        cfg.honeypot.bind_addr = "0.0.0.0".to_string();
+
+        let incident = make_test_incident();
+
+        let (msg, auto_executed) =
+            execute_honeypot_decision("192.0.2.5", &incident, dir.path(), &cfg, &mut state).await;
+
+        assert!(
+            msg.contains("rejected by isolation guard"),
+            "expected a clear guard rejection message, got: {msg}"
+        );
+        assert!(!auto_executed);
+        assert!(
+            !honeypot_events_path(dir.path()).exists(),
+            "marker event should not be written when listener startup is rejected"
+        );
+    }
+}

--- a/crates/agent/src/skills/mod.rs
+++ b/crates/agent/src/skills/mod.rs
@@ -295,6 +295,14 @@ pub struct SkillRegistry {
 }
 
 impl SkillRegistry {
+    /// Build an empty registry with no skills. Useful in tests that need
+    /// to exercise "no skill registered" code paths without relying on
+    /// `remove`-style mutation of `default_builtin()`.
+    #[cfg(test)]
+    pub fn empty() -> Self {
+        Self { skills: Vec::new() }
+    }
+
     /// Build the registry with all built-in skills.
     pub fn default_builtin() -> Self {
         use builtin::*;


### PR DESCRIPTION
## Summary

Adds the unit tests requested by issue #211 for `crates/agent/src/decision_honeypot.rs`'s `execute_honeypot_decision` function.

Closes #211

## Type

- [x] Tests only (with one small supporting API addition -- see below)

## Coverage

`#[cfg(test)] mod tests` block at the bottom of `crates/agent/src/decision_honeypot.rs`, 5 tokio tests:

| Test | What it covers (mapping to the issue's bullets) |
|---|---|
| `execute_honeypot_decision_returns_skipped_when_no_honeypot_skill` | "When honeypot config is disabled / skill registry has no honeypot: dispatch returns early without panic". Strict equality against the public skip message string. |
| `execute_honeypot_decision_skipped_message_is_stable` | Pins the substring `"honeypot skill not available"` so callers that grep for it (e.g. log analysis, decision recording) don't silently break. |
| `execute_honeypot_decision_auto_executed_is_false_on_early_return` | Pins the second return value (`auto_executed: bool`) on the no-skill path so the decision-recording call sites stay correct. |
| `execute_honeypot_decision_writes_one_marker_for_listener_dry_run` | "Marker event is written exactly once per honeypot invocation (not per retry)". Asserts `events-{date}.jsonl` has exactly one line, contains `kind: honeypot.demo_decoy_hit`, and references the test incident id. |
| `execute_honeypot_decision_returns_clear_error_when_listener_guard_rejects_bind` | "Session spawn failure: decision still recorded as `auto_executed=false` with error in execution_result". When `bind_addr=0.0.0.0` triggers the isolation guard rejection, the function returns a clear error message, `auto_executed=false`, and does NOT write a marker event.

All five tests use `triage_test_state(tmpdir)` per the issue's acceptance criterion.

```
$ cargo test -p innerwarden-agent --bin innerwarden-agent decision_honeypot
running 6 tests
test dashboard::investigation::tests::detector_journey_outcome_reflects_decision_honeypot ... ok
test decision_honeypot::tests::execute_honeypot_decision_returns_skipped_when_no_honeypot_skill ... ok
test decision_honeypot::tests::execute_honeypot_decision_returns_clear_error_when_listener_guard_rejects_bind ... ok
test decision_honeypot::tests::execute_honeypot_decision_auto_executed_is_false_on_early_return ... ok
test decision_honeypot::tests::execute_honeypot_decision_skipped_message_is_stable ... ok
test decision_honeypot::tests::execute_honeypot_decision_writes_one_marker_for_listener_dry_run ... ok

test result: ok. 6 passed; 0 failed; 0 ignored
```

(The 6th test is the existing `detector_journey_outcome_reflects_decision_honeypot`; not modified.)

## Supporting change: `SkillRegistry::empty()`

The "no honeypot skill" tests need an `AgentState` whose `skill_registry` doesn't contain a honeypot skill. `SkillRegistry` previously exposed only `default_builtin()` (which always includes `Honeypot`) and no removal API, so the natural test setup wasn't possible without reaching into private fields.

Adding a 3-line `pub fn empty() -> Self { Self { skills: Vec::new() } }` to `SkillRegistry` makes the tests trivial and is a minimal, focused public-API extension that costs nothing in production paths.

```rust
impl SkillRegistry {
    /// Build an empty registry with no skills. Useful in tests that need
    /// to exercise "no skill registered" code paths without relying on
    /// `remove`-style mutation of `default_builtin()`.
    pub fn empty() -> Self {
        Self { skills: Vec::new() }
    }
    // ... existing default_builtin() ...
}
```

Happy to drop this and use a different approach if you'd prefer (e.g. add a `remove(id: &str)` method, or scope the new ctor to `#[cfg(test)]`).

## Verification

- `cargo build -p innerwarden-agent` -> pass (one pre-existing warning unrelated to this diff)
- `cargo test -p innerwarden-agent --bin innerwarden-agent decision_honeypot` -> 6 passed
- `cargo fmt --check` -> clean
- All five new tests pass; broader `decision_*` tests unaffected

This contribution was developed with AI assistance (Codex), with manual review of the test scenarios and a follow-up edit to replace an unsafe-transmute approach in the original draft with the public `SkillRegistry::empty()` constructor described above.
